### PR TITLE
fix showmenu

### DIFF
--- a/tyrano/plugins/kag/kag.tag_ext.js
+++ b/tyrano/plugins/kag/kag.tag_ext.js
@@ -223,7 +223,7 @@ tyrano.plugin.kag.tag.showmenu ={
     start:function(pm){
         
         this.kag.menu.showMenu();
-        this.kag.ftag.nextOrder();
+//        this.kag.ftag.nextOrder();
         
     }
 };


### PR DESCRIPTION
key_mouseプラグインや、[button role="menu"]タグで不具合が起こる為
showmenuで、nextOrderしないように修正。
