### PR TITLE
fix double callback when html is cached

### DIFF
--- a/tyrano/plugins/kag/kag.js
+++ b/tyrano/plugins/kag/kag.js
@@ -714,10 +714,9 @@ tyrano.plugin.kag ={
                 var html = tmpl.render(data);
                 callback($(html));
             }
-        }
-        
-        $.loadText("./tyrano/html/"+html_file_name+".html",function(text_str){
-                
+        } else {
+            $.loadText("./tyrano/html/"+html_file_name+".html",function(text_str){
+            
                 var tmpl = $.templates(text_str);
                 var html = tmpl.render(data);
                 
@@ -727,8 +726,9 @@ tyrano.plugin.kag ={
                 if(callback){
                     callback($(html));
                 }
-                
-        });
+            
+            });
+        }
         
     },
     


### PR DESCRIPTION
Second part
"$.loadText ..."
must execute only if html is not cached.

Moved to else statement.
