### PR TITLE
fix freeimage time=0

### DIFF
--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -1604,6 +1604,7 @@ tyrano.plugin.kag.tag.freeimage = {
             //前景レイヤの場合、全部削除だよ
             
             //非表示にした後、削除する
+            if (pm.time == 0) pm.time = ""; // integer 0 and string "0" are equal to ""
             if(pm.time !=""){
                 
                 var j_obj = this.kag.layer.getLayer(pm.layer, pm.page).children();


### PR DESCRIPTION
When tyranobuilder write

    [tb_image_hide  time="0"  ]

with macro

    [macro name="tb_image_hide"]
        [freeimage layer=1 page=fore time=%time]	
    [endmacro]

from standard bulder.ks,
there is time="0" typeof String
and String "0" is not equal to String "".