### PR TITLE
default [ptext] text - blank

### DIFF
--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -1688,7 +1688,7 @@ tyrano.plugin.kag.tag.ptext = {
         "x" : 0,
         "y" : 0,
         "vertical" : "false",
-        "text" : "　　　　　　　　　　　　　　", //テキスト領域のデフォルト値を指定するためですが、、、
+        "text" : "", //テキスト領域のデフォルト値を指定するためですが、、、
         "size" : "",
         "face" : "",
         "color" : "",


### PR DESCRIPTION
For example, to make character name underlined.
If there will be string with spases - those spaces will be underlined.