### PR TITLE
一部の環境で ScreenRatio=fix の場合に画面からはみ出す

### DIFF
--- a/tyrano/tyrano.base.js
+++ b/tyrano/tyrano.base.js
@@ -46,6 +46,8 @@ tyrano.base ={
         	//alert(scale_f);
         	$(".tyrano_base").css("transform","scale("+scale_f+") ");	
         
+            // 画面を右下に寄せる為に過剰スクロールする
+            window.scrollTo(width, height);
         }else if(screen_ratio =="fit"){
             
             //スクリーンサイズに合わせて自動的に調整される


### PR DESCRIPTION
HTML/CSS レイアウトに疎いのでデバッガでの動作に基づく憶測で記載する部分がありますがご容赦下さい。

アプリで設定されているサイズが画面サイズを大きく超える場合（scWidth=1350、画面幅 viewport 値 750 程度で確認）、transform で縮小したあとの [左余白]+[サイズ] が画面幅を超えることではみ出し、表示出来ないことがあります。

transform 後にスクロールすることで表示領域が画面に収まるような対応を行いました。transform 後の右/下の余白部分へはスクロール出来ないようなので、大きめの値を取ってスクロールしても問題無いようです。

nw.js での PC アプリでは画面サイズ = ウィンドウサイズとなるはずなので、主にモバイルに向けた対応になるかと思います。Android 向けに Crosswalk を利用しビルドして確認したので、Crosswalk さえ用いれば 4.0 系以降では同じ動作が保証出来るはずです。