### PR TITLE
ScreenRatio=fix の場合の余白の均等割り当て

### DIFF
--- a/tyrano/tyrano.base.js
+++ b/tyrano/tyrano.base.js
@@ -40,8 +40,16 @@ tyrano.base ={
         	
         	if(width_f > height_f){
                scale_f = height_f;
+                // viewport の幅から設定サイズの縮小後を引いた幅が全体の余白
+                // これを縮小前のスケールに戻し、さらに 2 分割する
+                padding = (view_width-(width*scale_f))/scale_f/2;
+                if (padding>0) $(".tyrano_base").css("padding-right", padding+"px");
              }else{
                 scale_f = width_f;
+
+                // 上に同じ
+                padding = (view_height-(height*scale_f))/scale_f/2;
+                if (padding>0) $(".tyrano_base").css("padding-bottom", padding+"px");
         	}
         	//alert(scale_f);
         	$(".tyrano_base").css("transform","scale("+scale_f+") ");	


### PR DESCRIPTION
実験的なものです。https://github.com/ShikemokuMK/tyranoscript/pull/45 関連

ScreenRatio=fix の場合上下または左右の片側に余白が出来ますが、これを 2 分割したものを計算してスクロール前に padding に割り当て、その後スクロールされることで均等割り当てを図ろうというものです。

transform、margin で取った余白にはスクロール出来ない環境がありますが padding だとスクロール出来るようなのでこのような実装を取ってみています。

Phonegap での Android ビルド (with Crosswalk) で確認しました。
