### PR TITLE
[chara_show] タグでwait=falseを指定したときの不具合の修正

### DIFF
--- a/tyrano/plugins/kag/kag.tag_ext.js
+++ b/tyrano/plugins/kag/kag.tag_ext.js
@@ -1909,7 +1909,9 @@ tyrano.plugin.kag.tag.chara_show = {
                                 chara_num--;
                                 if (chara_num == 0) {
                                     that.kag.layer.showEventLayer();
-                                    that.kag.ftag.nextOrder();
+                                    if (pm.wait == "true") {
+                                        that.kag.ftag.nextOrder();
+                                    }
                                 }
                             });
 
@@ -1923,7 +1925,9 @@ tyrano.plugin.kag.tag.chara_show = {
                             chara_num--;
                             if (chara_num == 0) {
                                 that.kag.layer.showEventLayer();
-                                that.kag.ftag.nextOrder();
+                                if (pm.wait == "true") {
+                                    that.kag.ftag.nextOrder();
+                                }
                             }
                         });
 


### PR DESCRIPTION
[chara_show] タグについて、以下の問題を修正しました。

・自動配置が有効になっているキャラクターをwait=falseで表示したとき、nextOrderが「自動配置が完了したとき」「タグを実行した直後」の2回実行される。