### PR TITLE
ロード時のバックログの挙動に関する修正

### DIFF
--- a/tyrano/plugins/kag/kag.menu.js
+++ b/tyrano/plugins/kag/kag.menu.js
@@ -576,6 +576,9 @@ tyrano.plugin.kag.menu = {
         //layerの復元
         this.kag.layer.setLayerHtml(data.layer);
         
+        //バックログの初期化
+        this.kag.variable.tf.system.backlog = [];
+        
         //ステータスの設定、ディープに設定する
         this.kag.stat = data.stat;
         


### PR DESCRIPTION
以下の問題を修正しました。

・ゲーム進行中にロードした際に、ロード前のバックログを引き継いでしまう。