### PR TITLE
細かい不具合の修正

### DIFF
--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -3236,9 +3236,9 @@ tyrano.plugin.kag.tag.configdelay = {
             this.kag.stat.ch_speed = "";
             this.kag.config.chSpeed = pm.speed;
             this.kag.ftag.startTag("eval", {"exp":"sf._config_ch_speed = "+pm.speed});
+        }else{
+            this.kag.ftag.nextOrder();
         }
-
-        this.kag.ftag.nextOrder();
 
     }
 };

--- a/tyrano/plugins/kag/kag.tag_system.js
+++ b/tyrano/plugins/kag/kag.tag_system.js
@@ -967,6 +967,7 @@ tyrano.plugin.kag.tag.erasemacro = {
 
     start : function(pm) {
         delete this.kag.stat.map_macro[pm.name];
+        this.kag.ftag.nextOrder();
     }
 };
 


### PR DESCRIPTION
次の2点を修正しました。
・[configdelay]タグにspeedパラメータを指定したとき、nextOrderが二重に実行される。
・[erasemacro]タグを使用したとき、nextOrderが実行されない。