### PR TITLE
「タイトルに戻る」がAndroid端末でも正常動作するように改修

### DIFF
--- a/tyrano/plugins/kag/kag.menu.js
+++ b/tyrano/plugins/kag/kag.menu.js
@@ -118,16 +118,20 @@ tyrano.plugin.kag.menu = {
 
             //タイトルに戻る
             layer_menu.find(".menu_back_title").click(function() {
-                
-                $.confirm($.lang("go_title"), 
-                    
-                    function() {
-                        location.href="./index.html";
-                    }, 
-                    function() {
-                    
-                    }
-                );
+                if ("appJsInterface" in window) {
+                    appJsInterface.finishGame();
+                }
+                else{
+                    $.confirm($.lang("go_title"),
+
+                        function() {
+                            location.href="./index.html";
+                        },
+                        function() {
+
+                        }
+                    );
+                }
 
                 /*
                 if (!confirm($.lang("go_title"))) {


### PR DESCRIPTION
`kag.manu.js` に対して、`tyrano_player.js`にて実装されていたAndroid端末用の「タイトルに戻る」機能を移植しました。

現状のコードでは、Android端末においてMainActivityの初期化が行われず、その結果セーブデータや変数などが消えてしまいゲームを継続プレイすることができなくなってしまうためです。

Confirm画面が2度表示されるのは印象が悪かったのでAndroidの場合とそうでない場合での条件分岐を実装しています。なお、iOSは未確認のため本プルリクの動作保証対象外としています。


**確認環境:**
 **Devices:** arrows Be F-05J (docomo)  
 **OS:**        Android 7.1.1

 **Devices:** Xperia Z5 Compact   (SIM Free)
 **OS:**        Android 5.1.1
