### PR TITLE
iscirpt - endscript 内ではエンティティを置き換えない

### DIFF
--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -161,7 +161,10 @@ tyrano.plugin.kag.ftag = {
             if (this.master_tag[tag.name]) {
 
                 //この時点で、変数の中にエンティティがあれば、置き換える必要あり
-                tag.pm = this.convertEntity(tag.pm);
+                // iscript - endscript 内ではエンティティは置き換えない
+                if (!this.kag.stat.is_script) {
+                    tag.pm = this.convertEntity(tag.pm);
+                }
 
                 //必須項目チェック
                 var err_str = this.checkVital(tag);


### PR DESCRIPTION
エンティティ機能はシナリオ内で変数を参照するために & や % を使用し、シナリオをパースした後 & や % で始まるパラメータを変数に置き換えます。

iscirpt - endscript 内では各行の内容がそのままパラメータとなるため、以下のような複数行の条件文で & を行の最初で使用した場合にエラーとなります。

```
[iscript]
if(1 == 1
  && 2 == 2)alert("iscript disable entity OK")
[endscript]
```

そのため iscirpt - endscript 内ではエンティティ機能を無効化するように修正しました。

※本コードは株式会社ビットグルーヴ（ https://www.bitgroove.jp/ ）から寄贈されました