### PR TITLE
アニメーション中のchara_hide_all でanimateのコンプリートが呼ばれない

### DIFF
--- a/tyrano/plugins/kag/kag.tag_ext.js
+++ b/tyrano/plugins/kag/kag.tag_ext.js
@@ -2328,7 +2328,6 @@ tyrano.plugin.kag.tag.chara_hide_all = {
 
         var chara_num = 0;
         that.kag.layer.hideEventLayer();
-        var flag_complete = false;
         //アニメーションでj表示させます
         
         //キャラがいない場合、次へ
@@ -2336,19 +2335,17 @@ tyrano.plugin.kag.tag.chara_hide_all = {
             that.kag.ftag.nextOrder();
             return;
         }
-        
+        var removeCount = 0;
         img_obj.animate({
             opacity : "hide"
         }, {
             duration : parseInt(that.kag.cutTimeWithSkip(pm.time)),
             easing : "linear",
             complete : function() {
-
-                img_obj.remove();
+                $(this).remove();
+                removeCount++;
                 if (pm.wait == "true") {
-
-                    if (flag_complete == false) {
-                        flag_complete = true;
+                    if (removeCount === img_obj.length) {
                         that.kag.layer.showEventLayer();
                         that.kag.ftag.nextOrder();
                     }


### PR DESCRIPTION
```
[chara_show  name="akane" ]
[chara_show  name="yamato" ]
[anim name=akane left="-=30" time=1000 effect=jswing]
[anim name=akane left="+=30" time=1000 effect=jswing]
[chara_hide_all time="0"]
[wa]
```

上記のような複数キャラがいる状態で片方がアニメーションしているときに、chara_hide_all をするとアニメーション中のキャラが途中でremoveされてしまい、アニメーション完了が呼ばれず、[wa]タグのアニメーション待ちが終わらない。

すべてのキャラのhideのanimateがコンプリートし次第、nextOrderを呼ぶように修正