### PR TITLE
アニメーション中のfreeimageでanimateのコンプリートが呼ばれない

### DIFF
--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -2000,11 +2000,11 @@ tyrano.plugin.kag.tag.freeimage = {
                 );
                 
             }else{
-              var layer = that.kag.layer.getLayer(pm.layer, pm.page)
-              layer.find(":animated").finish();
-              layer.empty();
-                 //次へ移動ですがな
-                 that.kag.ftag.nextOrder();
+                var layer = that.kag.layer.getLayer(pm.layer, pm.page)
+                layer.find(":animated").finish();
+                layer.empty();
+                //次へ移動ですがな
+                that.kag.ftag.nextOrder();
             }
 
         } else {

--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -1986,11 +1986,11 @@ tyrano.plugin.kag.tag.freeimage = {
                     {"opacity":0},
                     parseInt(pm.time), 
                     function(){
-                        that.kag.layer.getLayer(pm.layer, pm.page).empty();
+                        $(this).remove();
                         //次へ移動ですがな
                         cnt++;
                         if(s_cnt == cnt){
-                            
+                            that.kag.layer.getLayer(pm.layer, pm.page).empty();
                             if(pm.wait=="true"){
                                 that.kag.ftag.nextOrder();            
                             }
@@ -2000,7 +2000,9 @@ tyrano.plugin.kag.tag.freeimage = {
                 );
                 
             }else{
-                 that.kag.layer.getLayer(pm.layer, pm.page).empty();
+              var layer = that.kag.layer.getLayer(pm.layer, pm.page)
+              layer.find(":animated").finish();
+              layer.empty();
                  //次へ移動ですがな
                  that.kag.ftag.nextOrder();
             }


### PR DESCRIPTION
```
[chara_show  name="akane" ]
[chara_show  name="yamato" ]
[anim name=akane left="-=30" time=1000 effect=jswing]
[anim name=akane left="+=30" time=1000 effect=jswing]
[freeimage layer=0]
[wa]
```

上記スクリプトでアニメーション中にfreeimageを呼ぶと、animateのcompleteが呼ばれないため、[wa]タグでのアニメーション待ちがずっと続いてしまう。

time指定の場合は、アニメーション完了を待ち、time指定がない場合、アニメーションをfinishしてからempty()を呼ぶように修正