### PR TITLE
オートモードの速度が0の時も再起動して保持されるように修正

### DIFF
--- a/tyrano/plugins/kag/kag.js
+++ b/tyrano/plugins/kag/kag.js
@@ -556,7 +556,7 @@ tyrano.plugin.kag ={
         //if(that.variable.sf._system_config_bgm_volume) that.config["defaultBgmVolume"] = that.variable.sf._system_config_bgm_volume;
         //if(that.variable.sf._system_config_se_volume) that.config["defaultSeVolume"] = that.variable.sf._system_config_se_volume;
         if(that.variable.sf._config_ch_speed) that.config["chSpeed"] = that.variable.sf._config_ch_speed;
-        if(that.variable.sf._system_config_auto_speed) that.config["autoSpeed"] = that.variable.sf._system_config_auto_speed;
+        if(typeof that.variable.sf._system_config_auto_speed !== "undefined") that.config["autoSpeed"] = that.variable.sf._system_config_auto_speed;
         if(that.variable.sf._system_config_auto_click) that.config["autoClickStop"] = that.variable.sf._system_config_auto_click_stop;
         if(that.variable.sf._system_config_already_read_text_color) that.config["alreadyReadTextColor"] = that.variable.sf._system_config_already_read_text_color;
         if(typeof that.variable.sf._system_config_unread_text_skip != "undefined"){


### PR DESCRIPTION
* `[autoconfig speed=0]` をしたのち、再起動するとspeedが0以外になってしまっていた。
  if文を修正して0の設定が保持されるようにする。

* ちなみに、この値は `setTimeout` の第二引数として使われるようだが、

https://github.com/ShikemokuMK/tyranoscript/blob/96156d4988211caf0651f5ce0bcb6518e86edcbd/tyrano/plugins/kag/kag.tag.js#L1165

 `setTimeout` の第二引数は0にしても問題ない（そもそもデフォルトが0である）

>この引数を省略すると値 0 を使用しますので "直ちに" 実行する、より正確に言えばできるだけ早く実行することを意味します。
>
>https://developer.mozilla.org/ja/docs/Web/API/WindowTimers/setTimeout