### PR TITLE
禁則処理対時の文字表示を改善

### DIFF
--- a/tyrano/tyrano.css
+++ b/tyrano/tyrano.css
@@ -45,7 +45,7 @@ abbr,acronym{
     writing-mode:vertical-rl ;
     -webkit-writing-mode:vertical-rl ;
     float:right;
-    /*height : 960px ;*/
+    height:100%;
 
 }
 


### PR DESCRIPTION
## 概要

* 以下のプラグインを作成しましたが、
[TyranoScriptの禁則処理時の文字表示を改善する - Qiita](https://qiita.com/noymer/items/0bdd1c54e2b78d4ac71f)
  これはtyranoscriptの基本機能の改善であり、tyranoscript本体に取り込んでいいのでは？と思ったので、プルリクを書いてみました。

* もちろん「いやこういうのはtyranoscript本体には入れないです」というお考えでも全然構いません、それを確認する為にもプルリク書きました。

## コード変更点

*特に言及しておきたいところ*

* `showMessage` と `showMessageVertical` の処理をひとまとめにした。
  差分を見ると、これにより縦書き表示の動作がちょっとだけ変化したはず。
    * 縦書き表示の動作変更として例えば、文字表示速度 `ch_speed` が 3ミリsec未満の時は、横書き表示と同様に文章がいっぺんに表示されるようになった。

## 動作確認

* 環境
  * mac
  * tyranorider Version 41.0.2272.76 (2272.76)
  * 利用シナリオ：本プルリク同梱の「基本機能デモゲーム」


* [x] 横書き表示時に特に問題がない
* [x] 縦書き表示時に特に問題がない

ただし本修正による影響範囲は私には完全把握仕切れないと思うので、シケモクMKさんに確認してもらうべきだとは思います。