### PR TITLE
[chara_part]がフリーズするバグを修正

### DIFF
--- a/tyrano/plugins/kag/kag.tag_ext.js
+++ b/tyrano/plugins/kag/kag.tag_ext.js
@@ -3075,41 +3075,43 @@ tyrano.plugin.kag.tag.chara_part = {
                 console.log(map_part);
                 
                 for(key in map_part){
-                    
-                    cnt++;
-                    var part = map_part[key];
-                    var j_img = target_obj.find(".part"+"." + key + "");
-                    var j_new_img = j_img.clone();
-                    j_new_img.css("opacity", 0);
-                    
-                    if(part.storage!="none"){
-                        j_new_img.attr("src","./data/fgimage/" + part.storage);
-                    }else{
-                        j_new_img.attr("src", "./tyrano/images/system/transparent.png");
-                    }
-                    
-                    //zindexの指定があった場合は、変更を行う
-                    if(pm[key+"_zindex"]){
-                        j_new_img.css("z-index", pm[key+"_zindex"]);
-                    }else{
-                        j_new_img.css("z-index", chara_part[key]["zindex"]);
-                    }
-                    
-                    //イメージを追加
-                    j_img.after(j_new_img);
-                    
-                    j_img.fadeTo(parseInt(pm.time), 0, function(){
-                        j_img.remove();
-                    }); 
-                    
-                    j_new_img.fadeTo(parseInt(pm.time), 1, function(){
-                        n++;
-                        if(pm.wait=="true"){
-                            if(cnt==n){ 
-                                that.kag.ftag.nextOrder();
-                            }
+
+                    (function() {
+                        cnt++;
+                        var part = map_part[key];
+                        var j_img = target_obj.find(".part"+"." + key + "");
+                        var j_new_img = j_img.clone();
+                        j_new_img.css("opacity", 0);
+                        
+                        if(part.storage!="none"){
+                            j_new_img.attr("src","./data/fgimage/" + part.storage);
+                        }else{
+                            j_new_img.attr("src", "./tyrano/images/system/transparent.png");
                         }
-                    });
+                        
+                        //zindexの指定があった場合は、変更を行う
+                        if(pm[key+"_zindex"]){
+                            j_new_img.css("z-index", pm[key+"_zindex"]);
+                        }else{
+                            j_new_img.css("z-index", chara_part[key]["zindex"]);
+                        }
+                        
+                        //イメージを追加
+                        j_img.after(j_new_img);
+                        
+                        j_img.fadeTo(parseInt(pm.time), 0, function(){
+                            j_img.remove();
+                        }); 
+                        
+                        j_new_img.fadeTo(parseInt(pm.time), 1, function(){
+                            n++;
+                            if(pm.wait=="true"){
+                                if(cnt==n){ 
+                                    that.kag.ftag.nextOrder();
+                                }
+                            }
+                        });
+                    })();
                     
                 }
                 


### PR DESCRIPTION
[chara_part name="chara1" partA="1" partB="1" time=1000]
待ち[p]
[chara_part name="chara1" partA="2" partB="2" time=1000]
待ち[p]

などのように、chara_partで複数部位を指定し、かつtimeを指定してアニメーションさせた場合、この操作を数回繰り返すとティラノスクリプトがフリーズするようです。（当方で自前で画像を用意して試したところでは、5回目でフリーズしました。）

原因はtyrano.plugin.kag.tag.chara_part.start中の
```
    j_img.fadeTo(parseInt(pm.time), 0, function(){
        j_img.remove();
    }); 
```
において、変数j_imgのスコープが（for文の中のブロックスコープではなく）関数スコープになっていたため、複数部位を指定してループした際に、ループの最後に代入されたj_imgがコールバック中で参照され、画像の削除漏れが起こるためだと思われます。（chromeのデベロッパーツールなどでDOMを見ていますと、chara_partを繰り返すたびに要素が増えていくのが確認できると思います。）

該当個所を匿名関数で囲んで強制的にfor文内にブロックスコープを作ることで対処しましたが、この修正は、
`    var j_img = target_obj.find(".part"+"." + key + "");`
を
`    let j_img = target_obj.find(".part"+"." + key + "");`
と変更するだけでも直ることを確認しました。（ティラノスクリプトが想定しているjavascriptのバージョンが分からなかったので、今回はletを使わずに直しました。）

ソースコードを網羅的にレビューはしていないので、同件の不具合は他にもあるかもしれません。また発見しましたらお知らせいたします。（ループ中で書き変わる変数をコールバックから参照する場合に同件の問題は発生しえます。）

pull requestを送るのは初めてなので、至らない点がありましたら申し訳ありません。

以上です。
