### PR TITLE
表情画像をhttp指定したときに、./data/配下を探しにいく問題を修正

### DIFF
--- a/tyrano/plugins/kag/kag.tag_ext.js
+++ b/tyrano/plugins/kag/kag.tag_ext.js
@@ -1903,7 +1903,9 @@ tyrano.plugin.kag.tag.chara_show = {
                 return;
             }
             storage_url = "./data/fgimage/" + cpm["map_face"][pm.face];
-        
+            if ($.isHTTP(cpm["map_face"][pm.face])) {
+              storage_url = cpm["map_face"][pm.face];
+            }
         }else if(pm.storage != "") {
 
             if ($.isHTTP(pm.storage)) {
@@ -2546,6 +2548,9 @@ tyrano.plugin.kag.tag.chara_mod = {
                 return;
             }
             storage_url = this.kag.stat.charas[pm.name]["map_face"][pm.face];
+            if ($.isHTTP(storage_url)) {
+                folder="";
+            }
         } else {
 
             if ($.isHTTP(pm.storage)) {


### PR DESCRIPTION
以下のように、表情のstorageにhttp経由での画像を設定したところ、./data/配下を探しにいってエラーとなってしまいました。

```
[chara_face name="akane" face="angry" storage="https://create-now.now.sh/data/fgimage/chara/akane/angry.png"]
```

原因は、表情画像についてはisHttp関数を通していないことのようです。
こちらを通すようにしたところ、エラーが消えることを確認しました。

よろしくお願いします。
