### PR TITLE
Prettier + GitHub Actionsの設定ファイル追加

### DIFF
--- a/.github/workflows/prettier-push.yml
+++ b/.github/workflows/prettier-push.yml
@@ -1,0 +1,22 @@
+name: Prettier
+
+on:
+  push:
+    branches:
+      - master
+      - ogihara/dev
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Run Prettier
+        run: |
+          npx prettier --write "tyrano/**/*.js"
+      - uses: stefanzweifel/git-auto-commit-action@v3.0.0
+        with:
+          commit_message: 'style: Prettierによる整形 [GitHub Actions]'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
+# Windows
 Thumbs.db
+
+# Mac
 .DS_Store
 
+# リリース用
 release/
+
+# テスト用
+test/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+#lib
+tyrano/libs/

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,10 +1,29 @@
 module.exports = {
+    // タブ幅：半角スペース4個分
     tabWidth: 4,
+
+    // 半角スペースではなくタブ記号を使うか：No
     useTabs: false,
-    singleQuote: true,
-    quoteProps: "preserve",
-    trailingComma: "none",
+
+    // 文末にセミコロンを付けるか：Yes
     semi: true,
+
+    // シングルクォートを使うか：No（ダブルクォートを使う）
+    singleQuote: false,
+
+    // オブジェクトのプロパティ名に引用符を使うか：
+    // 少なくとも1つのプロパティに引用符が必要ならすべてのプロパティに引用符を使う
+    quoteProps: "consistent",
+
+    // オブジェクトや配列内の末尾のコンマを付けるか：可能な限り付ける
+    trailingComma: "all",
+
+    // アロー関数のパラメータをカッコで囲むか：常に囲む
+    arrowParens: "always",
+
+    // オブジェクトリテラルのカッコ内にスペースを入れるか：Yes（たとえば {x:1} ではなく { x: 1 } となる）
     bracketSpacing: true,
-    endOfLine: "crlf"
+
+    // 改行記号：CRLF
+    endOfLine: "crlf",
 };

--- a/doc.html
+++ b/doc.html
@@ -1,95 +1,104 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-  <title>タグリファレンス生成</title>
+	<title>タグリファレンス生成</title>
 
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />  
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
 
-<script type="text/javascript" src="./tyrano/libs/jquery-3.4.1.min.js"></script>
+	<script type="text/javascript" src="./tyrano/libs/jquery-3.6.0.min.js"></script>
 
-<script>
-try{
-    window.jQuery = window.$ = require('./tyrano/libs/jquery-3.4.1.min.js');
-}catch(e){
-    
-}
-</script>
+	<script>
+		try {
+			window.jQuery = window.$ = require('./tyrano/libs/jquery-3.6.0.min.js');
+		} catch (e) {
 
-
-<script type="text/javascript" src="./tyrano/libs/jquery-ui-1.8.20.custom.min.js"></script>
-  
-<script type="text/javascript" src="./tyrano/libs.js" ></script>
-<script type="text/javascript" src="./tyrano/doc.js" ></script>
+		}
+	</script>
 
 
-<script type="text/javascript"  >
-    
-    tyrano.plugin.kag.tag ={};
-    
-</script>
-<script type="text/javascript" src="./tyrano/plugins/kag/kag.tag.js" ></script>
-<script type="text/javascript" src="./tyrano/plugins/kag/kag.tag_audio.js" ></script>
-<script type="text/javascript" src="./tyrano/plugins/kag/kag.tag_system.js" ></script>
-<script type="text/javascript" src="./tyrano/plugins/kag/kag.tag_ext.js" ></script>
-<script type="text/javascript" src="./tyrano/plugins/kag/kag.tag_camera.js" ></script>
-<script type="text/javascript" src="./tyrano/plugins/kag/kag.tag_ar.js" ></script>
-<script type="text/javascript" src="./tyrano/plugins/kag/kag.tag_three.js" ></script>
+	<script type="text/javascript" src="./tyrano/libs/jquery-ui/jquery-ui.min.js"></script>
 
-<link href="http://tyrano.jp/css/style.css" rel="stylesheet" type="text/css"/>
+	<script type="text/javascript" src="./tyrano/libs.js"></script>
+	<script type="text/javascript" src="./tyrano/doc.js"></script>
+
+
+	<script type="text/javascript">
+
+		tyrano.plugin.kag.tag = {};
+
+	</script>
+	<script type="text/javascript" src="./tyrano/plugins/kag/kag.tag.js"></script>
+	<script type="text/javascript" src="./tyrano/plugins/kag/kag.tag_audio.js"></script>
+	<script type="text/javascript" src="./tyrano/plugins/kag/kag.tag_system.js"></script>
+	<script type="text/javascript" src="./tyrano/plugins/kag/kag.tag_ext.js"></script>
+	<script type="text/javascript" src="./tyrano/plugins/kag/kag.tag_camera.js"></script>
+	<script type="text/javascript" src="./tyrano/plugins/kag/kag.tag_ar.js"></script>
+	<script type="text/javascript" src="./tyrano/plugins/kag/kag.tag_three.js"></script>
+
+	<link href="https://tyrano.jp/assets/plugins/bootstrap/css/bootstrap.css" rel="stylesheet" type="text/css" />
+	<link href="https://tyrano.jp/assets/plugins/bootstrap/css/non-responsive.css" rel="stylesheet" type="text/css" />
+	<!-- CORSエラーが出るのでコメントアウト
+	<link href="https://tyrano.jp/assets/plugins/font-awesome/css/font-awesome.min.css" rel="stylesheet"
+		type="text/css" />
+	-->
+	<link href="https://tyrano.jp/assets/css/style.css" rel="stylesheet" type="text/css" />
+	<link href="https://tyrano.jp/assets/css/custom.css" rel="stylesheet" type="text/css" />
+	<script type="text/javascript" src="https://tyrano.jp/assets/plugins/bootstrap/js/bootstrap.js"></script>
 
 </head>
 
 <body>
 
-<input id="button_gen" type="button" value="タグリファレンス生成" />
 
-<textarea id="src_html" style="height:300px">
-</textarea>
 
-オートコンプリート用のJS文字列
-<textarea id="auto_complete_tag" style="height:300px"></textarea>
-
-スタジオ用jsonファイル
-<textarea id="studio_json" style="height:300px"></textarea>
-
- 
-<div class="container content-md">
-	<div class="row area_main">
-		<div class="col-xs-4" style="background-color:white;border:0">
-			<ul class="area_group list-group sidebar-nav-v1" id="sidebar-nav-1">
-				<!-- ここにグループHTMLが格納される -->
-			</ul>
-
+	<div class="container">
+		<div class="row">
+			<div class="col-xs-3">
+				<button id="button_gen" style="margin-top:100px" class="btn btn-default">タグリファレンス生成</button>
+			</div>
+			<div class="col-xs-3">タグリファレンスHTML<br><textarea id="src_html" style="height:200px"></textarea></div>
+			<div class="col-xs-3">
+				オートコンプリート用のJS文字列<br>
+				<textarea id="auto_complete_tag" style="height:200px"></textarea>
+			</div>
+			<div class="col-xs-3">
+				スタジオ用jsonファイル<br>
+				<textarea id="studio_json" style="height:200px"></textarea>
+			</div>
 		</div>
-
-		<div class="area_ref col-xs-8">
-			<!-- ここにタグの解説がはいる -->
-		</div>
-
 	</div>
-</div>
+	<hr style="border-width:5px;">
+
+
+	<div class="container content-md">
+		<div class="row area_main">
+			<div class="col-xs-4"
+				style="background-color: white; border: 0;">
+				<ul class="area_group list-group sidebar-nav-v1" id="sidebar-nav-1">
+					<!-- ここにグループHTMLが格納される -->
+				</ul>
+			</div>
+			<div class="area_ref col-xs-8">
+				<!-- ここにタグの解説がはいる -->
+			</div>
+		</div>
+	</div>
 
 
 
-<script type="text/javascript">
-   
-   $(function(){
-    
-        //masterタグの作成
-        $("#button_gen").click(function(){
-        	$.generateHtml();
-        });
-        
-    
-   }); 
-   
-
-
-
-</script>
+	<script type="text/javascript">
+		$(function() {
+			$("#button_gen").click(function() {
+				$.setHtmlToTextarea();
+			});
+			$.generateHtml();
+		});
+	</script>
 
 
 
 </body>
+
 </html>

--- a/tyrano/doc.js
+++ b/tyrano/doc.js
@@ -1,24 +1,24 @@
 function object(o) {
-    var f = object.f, i, len, n, prop;
+    var f = object.f,
+        i,
+        len,
+        n,
+        prop;
     f.prototype = o;
-    n = new f;
+    n = new f();
     for (i = 1, len = arguments.length; i < len; ++i)
-        for (prop in arguments[i])
-            n[prop] = arguments[i][prop];
+        for (prop in arguments[i]) n[prop] = arguments[i][prop];
     return n;
 }
 
-object.f = function() { };
+object.f = function () {};
 
 var tyrano = {};
 tyrano.plugin = {};
 tyrano.plugin.kag = {};
 
-
-(function($) {
-
-    $.generateHtml = function() {
-
+(function ($) {
+    $.generateHtml = function () {
         var html = "";
 
         var master_tag = {};
@@ -26,9 +26,7 @@ tyrano.plugin.kag = {};
 
         // タグの種類を確定させる
         for (var order_type in tyrano.plugin.kag.tag) {
-
             master_tag[order_type] = object(tyrano.plugin.kag.tag[order_type]);
-
         }
 
         console.log(master_tag);
@@ -36,169 +34,166 @@ tyrano.plugin.kag = {};
         //テキストを読み込み。スクリプトから、オブジェクト構造解析
         //同じディレクトリにある、KAG関連のデータを読み込み
 
-        var array_script = ["kag.tag.js", "kag.tag_audio.js", "kag.tag_ext.js", "kag.tag_system.js", "kag.tag_camera.js", "kag.tag_ar.js", "kag.tag_three.js"];
+        var array_script = [
+            "kag.tag.js",
+            "kag.tag_audio.js",
+            "kag.tag_ext.js",
+            "kag.tag_system.js",
+            "kag.tag_camera.js",
+            "kag.tag_ar.js",
+            "kag.tag_three.js",
+        ];
 
         var script_num = array_script.length;
         var loading_num = 0;
 
         for (var i = 0; i < array_script.length; i++) {
+            $.loadText(
+                "./tyrano/plugins/kag/" + array_script[i],
+                function (text_str) {
+                    var flag_tag = ""; //タグ解析中の場合
+                    var flag_param = ""; //パラメータ名
 
-            $.loadText("./tyrano/plugins/kag/" + array_script[i], function(text_str) {
+                    var tmp_str = "";
 
-                var flag_tag = ""; //タグ解析中の場合
-                var flag_param = ""; //パラメータ名
+                    var array_str = text_str.split("\n");
 
-                var tmp_str = "";
+                    for (var i = 0; i < array_str.length; i++) {
+                        var line_str = $.trim(array_str[i]);
 
-                var array_str = text_str.split("\n");
+                        //タグ解析中は改行もつかう
+                        if (line_str != "" || flag_tag != "") {
+                            if (line_str === "#[end]") {
+                                //終了時点で登録すべきデータが残っていた場合は入れておく
+                                map_doc[flag_tag][flag_param] = tmp_str;
 
-                for (var i = 0; i < array_str.length; i++) {
-
-                    var line_str = $.trim(array_str[i]);
-
-                    //タグ解析中は改行もつかう
-                    if (line_str != "" || flag_tag != "") {
-
-                        if (line_str === "#[end]") {
-
-                            //終了時点で登録すべきデータが残っていた場合は入れておく
-                            map_doc[flag_tag][flag_param] = tmp_str;
-
-                            flag_tag = "";
-                            flag_param = "";
-
-                        }
-                        else if (flag_tag != "") {
-
-                            if (line_str.substr(0, 1) == ":") {
-
-                                if (tmp_str != "") {
-
-                                    if (flag_param != "") {
-                                        map_doc[flag_tag][flag_param] = tmp_str;
+                                flag_tag = "";
+                                flag_param = "";
+                            } else if (flag_tag != "") {
+                                if (line_str.substr(0, 1) == ":") {
+                                    if (tmp_str != "") {
+                                        if (flag_param != "") {
+                                            map_doc[flag_tag][flag_param] =
+                                                tmp_str;
+                                        }
                                     }
 
-                                }
+                                    flag_param = "";
+                                    flag_param = line_str.substr(
+                                        1,
+                                        line_str.length,
+                                    );
 
-                                flag_param = "";
-                                flag_param = line_str.substr(1, line_str.length);
+                                    //すでに登録済みのデータがあれば、それを格納する
+                                    map_doc[flag_tag][flag_param] = "";
 
-                                //すでに登録済みのデータがあれば、それを格納する
-                                map_doc[flag_tag][flag_param] = "";
-
-                                tmp_str = "";
-
-                            } else {
-
-                                if (flag_param != "param" && flag_param != "title") {
-                                    tmp_str += line_str + "\n";
+                                    tmp_str = "";
                                 } else {
-                                    tmp_str += line_str;
+                                    if (
+                                        flag_param != "param" &&
+                                        flag_param != "title"
+                                    ) {
+                                        tmp_str += line_str + "\n";
+                                    } else {
+                                        tmp_str += line_str;
+                                    }
                                 }
 
+                                //タグ読み込み開始
+                            } else if (line_str.substr(0, 2) === "#[") {
+                                var tag_name = line_str.replace("#[", "");
+                                tag_name = tag_name.replace("]", "");
+                                tag_name = $.trim(tag_name);
+
+                                flag_tag = tag_name;
+                                flag_param = "";
+
+                                map_doc[flag_tag] = {};
                             }
-
-
-                            //タグ読み込み開始
-                        } else if (line_str.substr(0, 2) === "#[") {
-
-                            var tag_name = line_str.replace("#[", "");
-                            tag_name = tag_name.replace("]", "");
-                            tag_name = $.trim(tag_name);
-
-                            flag_tag = tag_name;
-                            flag_param = "";
-
-
-                            map_doc[flag_tag] = {};
-
                         }
-
                     }
 
-                }
+                    //macdoc を　解析して、HTMLを作成
 
-                //macdoc を　解析して、HTMLを作成
+                    loading_num++;
 
-                loading_num++;
+                    if (loading_num == script_num) {
+                        //HTML作成
+                        $.putHtml(map_doc, master_tag);
 
-                if (loading_num == script_num) {
+                        ////////スタジオ用データ作成
+                        for (var key in map_doc) {
+                            var tag = map_doc[key];
+                            tag.array_param = [];
 
-                    //HTML作成
-                    $.putHtml(map_doc, master_tag);
+                            var array_param = tag.param.split(",");
 
-                    ////////スタジオ用データ作成
-                    for (var key in map_doc) {
+                            for (var k = 0; k < array_param.length; k++) {
+                                var tmp_array = array_param[k].split("=");
+                                var param_name = $.trim(tmp_array[0]);
+                                var param_value = $.trim(tmp_array[1]);
 
-                        var tag = map_doc[key];
-                        tag.array_param = [];
-
-                        var array_param = tag.param.split(",");
-
-                        for (var k = 0; k < array_param.length; k++) {
-
-                            var tmp_array = array_param[k].split("=");
-                            var param_name = $.trim(tmp_array[0]);
-                            var param_value = $.trim(tmp_array[1]);
-
-                            if (param_name == "") {
-                                continue;
-                            }
-
-                            var pm_obj = {
-                                "name": param_name,
-                                "value": param_value,
-                                "vital": "×",
-                                "default": "",
-                            };
-
-                            if (master_tag[key].pm && master_tag[key].pm[param_name]) {
-                                pm_obj["default"] = master_tag[key].pm[param_name];
-                            }
-
-                            if (master_tag[key] != null && master_tag[key]["vital"] != null) {
-
-                                var array_vital = master_tag[key]["vital"];
-
-                                for (var j = 0; j < array_vital.length; j++) {
-
-                                    if (master_tag[key].vital[j] == param_name) {
-
-                                        pm_obj["vital"] = "◯";
-                                        break;
-                                    }
-
+                                if (param_name == "") {
+                                    continue;
                                 }
 
+                                var pm_obj = {
+                                    name: param_name,
+                                    value: param_value,
+                                    vital: "×",
+                                    default: "",
+                                };
+
+                                if (
+                                    master_tag[key].pm &&
+                                    master_tag[key].pm[param_name]
+                                ) {
+                                    pm_obj["default"] =
+                                        master_tag[key].pm[param_name];
+                                }
+
+                                if (
+                                    master_tag[key] != null &&
+                                    master_tag[key]["vital"] != null
+                                ) {
+                                    var array_vital = master_tag[key]["vital"];
+
+                                    for (
+                                        var j = 0;
+                                        j < array_vital.length;
+                                        j++
+                                    ) {
+                                        if (
+                                            master_tag[key].vital[j] ==
+                                            param_name
+                                        ) {
+                                            pm_obj["vital"] = "◯";
+                                            break;
+                                        }
+                                    }
+                                }
+
+                                tag.array_param.push(pm_obj);
+
+                                delete tag["param"];
                             }
+                        } //end for loop
 
-                            tag.array_param.push(pm_obj);
+                        console.log("ww  map_doc  wwwwwwww");
+                        console.log(map_doc);
 
-                            delete tag["param"];
-
-                        }
-
-                    }//end for loop
-
-                    console.log("ww  map_doc  wwwwwwww");
-                    console.log(map_doc);
-
-                    $("#studio_json").val(JSON.stringify(map_doc, undefined, 4));
-
-                }
-
-
-            });//　ローディング
-
+                        $("#studio_json").val(
+                            JSON.stringify(map_doc, undefined, 4),
+                        );
+                    }
+                },
+            ); //　ローディング
         }
 
         return html;
-
     };
 
-
-    $.putHtml = function(map_doc, master_tag) {
-
+    $.putHtml = function (map_doc, master_tag) {
         //タグのグルーピングで左部分作成
 
         var group_map = {};
@@ -206,70 +201,95 @@ tyrano.plugin.kag = {};
         var ghtml = "";
 
         for (key in map_doc) {
-
             var obj = map_doc[key];
             if (group_map[obj.group]) {
             } else {
                 group_map[obj.group] = {};
             }
             group_map[obj.group][key] = obj;
-
         }
 
         var num_index = 0;
 
         //グループをつくる
         for (key in group_map) {
-
-
             ghtml += '<li class="list-group-item list-toggle">';
-            ghtml += '<a data-toggle="collapse" data-parent="#sidebar-nav-1" href="#nav_' + num_index + '" class="collapsed" aria-expanded="false">' + key + '</a>';
+            ghtml +=
+                '<a data-toggle="collapse" data-parent="#sidebar-nav-1" href="#nav_' +
+                num_index +
+                '" class="collapsed" aria-expanded="false">' +
+                key +
+                "</a>";
 
             var tmp = group_map[key];
 
-            ghtml += '<ul id="nav_' + num_index + '" class="collapse" aria-expanded="false" style="height: 0px;">';
+            ghtml +=
+                '<ul id="nav_' +
+                num_index +
+                '" class="collapse" aria-expanded="false" style="height: 0px;">';
 
             for (key2 in tmp) {
                 var obj = tmp[key2];
                 //ghtml +='<div style="padding:2px"><a  href="#'+key2+'">['+key2+']　<span style="font-style:italic;color:gray">('+obj.title+')</span></a></div>';
-                ghtml += '<li><a href="#' + key2 + '"> [' + key2 + ']　' + obj.title + '</a></li>';
+                ghtml +=
+                    '<li><a href="#' +
+                    key2 +
+                    '"> [' +
+                    key2 +
+                    "]　" +
+                    obj.title +
+                    "</a></li>";
             }
 
             ghtml += "</ul>";
             ghtml += "</li>";
 
             num_index++;
-
         }
 
         $(".area_group").html(ghtml);
 
-
         var j_root = $("<div></div>");
 
-
         for (key in map_doc) {
-
             var obj = map_doc[key];
 
-            var html = ''
-                + '<div  class="news-v3 bg-color-white margin-bottom-20">'
-                + '<div class="news-v3-in"><a name="' + key + '"></a>'
-                + '<h3 style="color:#a10f2b">[' + key + ']　' + obj.title + '</h3>'
-                + '<ul class="list-inline posted-info"><li>' + obj.group + '</li></ul>'
-                + '<p>' + $.br($.escapeHTML(obj.exp)) + '</p>';
+            var html =
+                "" +
+                '<div  class="news-v3 bg-color-white margin-bottom-20">' +
+                '<div class="news-v3-in"><a name="' +
+                key +
+                '"></a>' +
+                '<h3 style="color:#a10f2b">[' +
+                key +
+                "]　" +
+                obj.title +
+                "</h3>" +
+                '<ul class="list-inline posted-info"><li>' +
+                obj.group +
+                "</li></ul>" +
+                "<p>" +
+                $.br($.escapeHTML(obj.exp)) +
+                "</p>";
 
             //デモ用のURLがあるなら差し込む
             if (typeof obj.demo != "undefined") {
                 var array_demo = obj.demo.split(",");
-                var demo_url = "/demogame/tech_samples_" + $.trim(array_demo[0]) + "_v5/index.html?storage=" + $.trim(array_demo[1]);
-                html += '<p><a href="' + demo_url + '" target="_blank"">解説チュートリアル</a></p>';
+                var demo_url =
+                    "/demogame/tech_samples_" +
+                    $.trim(array_demo[0]) +
+                    "_v5/index.html?storage=" +
+                    $.trim(array_demo[1]);
+                html +=
+                    '<p><a href="' +
+                    demo_url +
+                    '" target="_blank"">解説チュートリアル</a></p>';
             }
 
-            html += '<table class="table table-bordered">'
-                + '<thead style="background-color:pink"><tr><th>パラメータ</th><th>必須</th><th>解説</th></tr></thead>'
-                + '<tbody>';
-
+            html +=
+                '<table class="table table-bordered">' +
+                '<thead style="background-color:pink"><tr><th>パラメータ</th><th>必須</th><th>解説</th></tr></thead>' +
+                "<tbody>";
 
             //繰り返し
 
@@ -281,9 +301,9 @@ tyrano.plugin.kag = {};
             console.log(array_param);
 
             for (var k = 0; k < array_param.length; k++) {
-
                 if (array_param[k] == "") {
-                    html += '<tr ><td colspan="3">指定できるパラメータはありません</td></tr>';
+                    html +=
+                        '<tr ><td colspan="3">指定できるパラメータはありません</td></tr>';
                 } else {
                     var tmp_array = array_param[k].split("=");
 
@@ -292,47 +312,45 @@ tyrano.plugin.kag = {};
 
                     var vital = "×";
 
-                    if (master_tag[key] != null && master_tag[key]["vital"] != null) {
-
+                    if (
+                        master_tag[key] != null &&
+                        master_tag[key]["vital"] != null
+                    ) {
                         var array_vital = master_tag[key]["vital"];
 
                         for (var j = 0; j < array_vital.length; j++) {
-
                             if (master_tag[key].vital[j] == param_name) {
-
                                 vital = "◯";
                                 break;
                             }
-
                         }
-
                     }
 
-                    html += '                 <tr>'
-                        + '                  <td>' + param_name + '</td>'
-                        + '                  <td>' + vital + '</td>'
-                        + '                  <td>' + param_value + '</td>'
-
-                        + '              </tr>';
-
+                    html +=
+                        "                 <tr>" +
+                        "                  <td>" +
+                        param_name +
+                        "</td>" +
+                        "                  <td>" +
+                        vital +
+                        "</td>" +
+                        "                  <td>" +
+                        param_value +
+                        "</td>" +
+                        "              </tr>";
                 }
+            } //end for loop
 
-            }//end for loop
-
-            html += '</tbody></table>';
-
+            html += "</tbody></table>";
 
             if (obj.sample != "") {
-
-                html += ''
-                    + '<ul class="list-inline posted-info"><li>サンプルコード</li></ul>'
-                    + '<code><br />'
-
-                    + $.br($.escapeHTML(obj.sample))
-
-                    + '<br /></code>'
-                    + '';
-
+                html +=
+                    "" +
+                    '<ul class="list-inline posted-info"><li>サンプルコード</li></ul>' +
+                    "<code><br />" +
+                    $.br($.escapeHTML(obj.sample)) +
+                    "<br /></code>" +
+                    "";
             }
 
             html += "</div></div>";
@@ -341,29 +359,27 @@ tyrano.plugin.kag = {};
             //htmlをぶち込みます
 
             j_root.append($(html));
-
-        }// end map_doc loop
-
-
+        } // end map_doc loop
 
         $(".area_ref").empty();
 
         //基本説明部分ｎ
 
-        var basic_exp = ''
-            + ' <div class="alert alert-success fade in margin-bottom-20">'
-            + '<h4>基本</h4>'
-            + '<p>'
-            + '                       [ ] で囲まれた部分がタグになります。 <br/ >'
-            + '                        @で始まる行も、タグとして認識しますが、１行で記述しなければなりません<br/ >'
-            + '                        ;(セミコロン)で始まる行はコメントとして扱われます。<br/ >'
-            + '                        複数行にわたってコメントにする場合は、/* からはじめて */ で 閉じることでコメントになります。　<br/ >'
-            + '                        すべてのタグにcond属性があります。JS式を記述して、その結果が真の場合のみタグが実行されます<br/ >'
-            + '                        _（半角アンダーバー）で始まる行は、文章の前に空白を挿入することができます。<br />'
-            + '                        '
-            + '                    </p>     '
-            + ''
-            + '</div>';
+        var basic_exp =
+            "" +
+            ' <div class="alert alert-success fade in margin-bottom-20">' +
+            "<h4>基本</h4>" +
+            "<p>" +
+            "                       [ ] で囲まれた部分がタグになります。 <br/ >" +
+            "                        @で始まる行も、タグとして認識しますが、１行で記述しなければなりません<br/ >" +
+            "                        ;(セミコロン)で始まる行はコメントとして扱われます。<br/ >" +
+            "                        複数行にわたってコメントにする場合は、/* からはじめて */ で 閉じることでコメントになります。　<br/ >" +
+            "                        すべてのタグにcond属性があります。JS式を記述して、その結果が真の場合のみタグが実行されます<br/ >" +
+            "                        _（半角アンダーバー）で始まる行は、文章の前に空白を挿入することができます。<br />" +
+            "                        " +
+            "                    </p>     " +
+            "" +
+            "</div>";
         $(".area_ref").append(basic_exp);
         $(".area_ref").append(j_root);
         $("#src_html").val($(".area_main").html());
@@ -376,9 +392,5 @@ tyrano.plugin.kag = {};
         console.log(master_tag);
 
         $("#auto_complete_tag").val(js_auto_complete);
-
-
     };
-
-
 })(jQuery);

--- a/tyrano/lang.js
+++ b/tyrano/lang.js
@@ -1,36 +1,34 @@
 window.tyrano_lang = {
-
     word: {
-
-        "go_title": "タイトルに戻ります。よろしいですね？",
-        "exit_game": "ウィンドウを閉じて終了します。よろしいですね？",
-        "not_saved": "まだ、保存されているデータがありません",
-        "tag": "タグ",
-        "not_exists": "は存在しません",
-        "error": "エラーが発生しました。スクリプトを確認して下さい",
-        "label": "ラベル",
-        "label_double": "は同一シナリオファイル内に重複しています",
-        "error_occurred": "エラーが発生しました",
-        "save_file_violation_1": "セーブデータの移動を検知しました。信頼できるセーブデータでない場合、絶対に読み込まないでください。",
-        "save_file_violation_2": "セーブデータを読み込んでゲームを起動してもよろしいですか？",
-        "save_file_violation_3": "起動を中止しました。セーブデータを削除してもう一度、起動してください",
-        "reload": "リロード",
+        go_title: "タイトルに戻ります。よろしいですね？",
+        exit_game: "ウィンドウを閉じて終了します。よろしいですね？",
+        not_saved: "まだ、保存されているデータがありません",
+        tag: "タグ",
+        not_exists: "は存在しません",
+        error: "エラーが発生しました。スクリプトを確認して下さい",
+        label: "ラベル",
+        label_double: "は同一シナリオファイル内に重複しています",
+        error_occurred: "エラーが発生しました",
+        save_file_violation_1:
+            "セーブデータの移動を検知しました。信頼できるセーブデータでない場合、絶対に読み込まないでください。",
+        save_file_violation_2:
+            "セーブデータを読み込んでゲームを起動してもよろしいですか？",
+        save_file_violation_3:
+            "起動を中止しました。セーブデータを削除してもう一度、起動してください",
+        reload: "リロード",
     },
 
     novel: {
-        "file_menu_button_save": "menu_button_save.gif",
-        "file_menu_button_load": "menu_button_load.gif",
-        "file_menu_button_message_close": "menu_message_close.gif",
-        "file_menu_button_skip": "menu_button_skip.gif",
-        "file_menu_button_title": "menu_button_title.gif",
-        "file_menu_button_close": "menu_button_close.png",
-        "file_menu_bg": "menu_bg.jpg",
-        "file_save_bg": "menu_save_bg.jpg",
-        "file_load_bg": "menu_load_bg.jpg",
-        "file_button_menu": "button_menu.png",
-        "error_occurred": "error occurred"
-
-
-    }
-
+        file_menu_button_save: "menu_button_save.gif",
+        file_menu_button_load: "menu_button_load.gif",
+        file_menu_button_message_close: "menu_message_close.gif",
+        file_menu_button_skip: "menu_button_skip.gif",
+        file_menu_button_title: "menu_button_title.gif",
+        file_menu_button_close: "menu_button_close.png",
+        file_menu_bg: "menu_bg.jpg",
+        file_save_bg: "menu_save_bg.jpg",
+        file_load_bg: "menu_load_bg.jpg",
+        file_button_menu: "button_menu.png",
+        error_occurred: "error occurred",
+    },
 };

--- a/tyrano/libs.js
+++ b/tyrano/libs.js
@@ -1,34 +1,25 @@
-(function($) {
-
+(function ($) {
     //jquery 拡張
 
     //アニメーション開始。未実装　キーフレアニメは投入したい
-    $.fn.a2d = function() {
-
-        return this.each(function(i) {
-
+    $.fn.a2d = function () {
+        return this.each(function (i) {
             $(this).css("-webkit-animation-play-state", str);
-
         });
     };
 
-    $.getBaseURL = function() {
-
+    $.getBaseURL = function () {
         var str = location.pathname;
-        var i = str.lastIndexOf('/');
+        var i = str.lastIndexOf("/");
         return str.substring(0, i + 1);
-
     };
 
-    $.getDirPath = function(str) {
-
-        var i = str.lastIndexOf('/');
+    $.getDirPath = function (str) {
+        var i = str.lastIndexOf("/");
         return str.substring(0, i + 1);
-
     };
 
-
-    $.isHTTP = function(str) {
+    $.isHTTP = function (str) {
         if (str.substring(0, 4) === "http") {
             return true;
         } else {
@@ -36,36 +27,29 @@
         }
     };
 
-    $.play_audio = function(audio_obj) {
-
+    $.play_audio = function (audio_obj) {
         audio_obj.play();
-
     };
 
-    $.toBoolean = function(str) {
-
+    $.toBoolean = function (str) {
         if (str == "true") {
             return true;
         } else {
             return false;
         }
-
     };
 
-    $.getAngle = function() {
-
+    $.getAngle = function () {
         let angle = screen && screen.orientation && screen.orientation.angle;
         if (angle === undefined) {
-            angle = window.orientation;    // iOS用
+            angle = window.orientation; // iOS用
         }
 
         return angle;
-
     };
 
     //横幅の方が大きければtrue;
-    $.getLargeScreenWidth = function() {
-
+    $.getLargeScreenWidth = function () {
         let w = parseInt(window.innerWidth);
         let h = parseInt(window.innerHeight);
 
@@ -74,11 +58,9 @@
         } else {
             return false;
         }
-
     };
 
-    $.localFilePath = function() {
-
+    $.localFilePath = function () {
         var path = "";
         //Mac os Sierra 対応
         if (process.execPath.indexOf("var/folders") != -1) {
@@ -88,17 +70,19 @@
         }
 
         return path;
-
     };
 
-    $.getViewPort = function() {
+    $.getViewPort = function () {
         var width, heiht;
 
         if (self.innerHeight) {
             // all except Explorer
             width = self.innerWidth;
             height = self.innerHeight;
-        } else if (document.documentElement && document.documentElement.clientHeight) {
+        } else if (
+            document.documentElement &&
+            document.documentElement.clientHeight
+        ) {
             // Explorer 6 Strict Mode
             width = document.documentElement.clientWidth;
             height = document.documentElement.clientHeight;
@@ -110,11 +94,11 @@
 
         return {
             width: width,
-            height: height
+            height: height,
         };
     };
 
-    $.escapeHTML = function(val, replace_str) {
+    $.escapeHTML = function (val, replace_str) {
         val = val || "";
         var t = $("<div />").text(val).html();
 
@@ -126,18 +110,15 @@
         return t;
     };
 
-    $.br = function(txtVal) {
-
+    $.br = function (txtVal) {
         txtVal = txtVal.replace(/\r\n/g, "<br />");
         txtVal = txtVal.replace(/(\n|\r)/g, "<br />");
         return txtVal;
-
     };
 
     //現在時刻を取得
     //現在の日
-    $.getNowDate = function() {
-
+    $.getNowDate = function () {
         var nowdate = new Date();
         var year = nowdate.getFullYear();
         // 年
@@ -147,12 +128,10 @@
         // 日
 
         return year + "/" + mon + "/" + date;
-
     };
 
     //現在の時刻
-    $.getNowTime = function() {
-
+    $.getNowTime = function () {
         var nowdate = new Date();
 
         var h = nowdate.getHours();
@@ -160,29 +139,25 @@
         var s = nowdate.getSeconds();
 
         return h + "：" + m + "：" + s;
-
     };
 
-    $.convertRem = function(px_val) {
-
+    $.convertRem = function (px_val) {
         function getRootElementFontSize() {
             // Returns a number
             return parseFloat(
                 // of the computed font-size, so in px
                 getComputedStyle(
                     // for the root <html> element
-                    document.documentElement
-                ).fontSize
+                    document.documentElement,
+                ).fontSize,
             );
         }
 
         return px_val * getRootElementFontSize();
-
     };
 
     //複数のスクリプトを一括して読み込み
-    $.getMultiScripts = function(arr, cb) {
-
+    $.getMultiScripts = function (arr, cb) {
         var cnt_script = arr.length;
         var load_cnt = 0;
 
@@ -192,40 +167,30 @@
         }
 
         function getScript(src) {
-
-            $.getScript(arr[load_cnt], function(e) {
-
+            $.getScript(arr[load_cnt], function (e) {
                 load_cnt++;
 
                 if (cnt_script == load_cnt) {
-
                     if (typeof cb == "function") {
                         cb();
                     }
-
                 } else {
                     getScript(arr[load_cnt]);
                 }
-
             });
-
-
         }
 
         getScript(arr[0]);
-
-
-
     };
 
-    $.convertSecToString = function(val) {
+    $.convertSecToString = function (val) {
         if (val == 0) {
-            return '-';
+            return "-";
         }
         var day = Math.floor(val / (24 * 60 * 60));
-        var hour = Math.floor((val % (24 * 60 * 60) / (60 * 60)));
-        var minute = Math.floor(val % (24 * 60 * 60) % (60 * 60) / 60);
-        var second = Math.floor(val % (24 * 60 * 60) % (60 * 60) % 60);
+        var hour = Math.floor((val % (24 * 60 * 60)) / (60 * 60));
+        var minute = Math.floor(((val % (24 * 60 * 60)) % (60 * 60)) / 60);
+        var second = Math.floor(((val % (24 * 60 * 60)) % (60 * 60)) % 60);
 
         var str = "";
         if (day !== 0) {
@@ -244,7 +209,7 @@
         return str;
     };
 
-    $.secToMinute = function(val) {
+    $.secToMinute = function (val) {
         if (val === 0) {
             return "-";
         }
@@ -261,9 +226,8 @@
         return str;
     };
 
-    $.trim = function(str) {
+    $.trim = function (str) {
         if (str) {
-
         } else {
             return "";
         }
@@ -271,124 +235,104 @@
         return str.replace(/^\s+|\s+$/g, "");
     };
 
-    $.rmspace = function(str) {
-
+    $.rmspace = function (str) {
         str = str.replace(/ /g, "");
         str = str.replace(/　/g, "");
         str = str.replace(/\r\n?/g, "");
 
         return str;
-
     };
 
-    $.replaceAll = function(text, searchString, replacement) {
-
+    $.replaceAll = function (text, searchString, replacement) {
         if (typeof text != "string") {
             return text;
         }
-
 
         //置換のコード変えてみた
         var result = text.split(searchString).join(replacement);
 
         return result;
-
-
     };
 
     //確証しを取得
-    $.getExt = function(str) {
+    $.getExt = function (str) {
         return str.split(".").pop();
     };
 
     //指定した拡張子を付ける。拡張子がなければ
-    $.setExt = function(name, ext_str) {
-
+    $.setExt = function (name, ext_str) {
         var tmp = name.split(".");
         if (tmp.length == 1) {
             name = name + "." + ext_str;
         }
 
         return name;
-
     };
 
     //要素をクローンします
-    $.cloneObject = function(source) {
-
+    $.cloneObject = function (source) {
         return $.extend(true, {}, source);
-
     };
 
     //透明度を適切な値に変更
-    $.convertOpacity = function(val) {
+    $.convertOpacity = function (val) {
         //255をマックスとして計算する
 
         var p = val / 255;
 
         return p;
-
     };
 
     //パスにfgimage bgimage image が含まれていた場合、それを適応する
-    $.convertStorage = function(path) {
+    $.convertStorage = function (path) {};
 
-    };
-
-    $.convertColor = function(val) {
-
+    $.convertColor = function (val) {
         if (val.indexOf("0x") != -1) {
             return val.replace("0x", "#");
         }
 
         return val;
-
     };
 
-    $.convertBold = function(flag) {
-
+    $.convertBold = function (flag) {
         if (flag == "true") {
             return "bold";
         }
 
         return "";
-
     };
 
-    $.convertItalic = function(flag) {
-
+    $.convertItalic = function (flag) {
         if (flag == "true") {
             return "italic";
         }
 
         return "";
-
     };
 
-    $.send = function(url, obj, call_back) {
+    $.send = function (url, obj, call_back) {
         //game.current_story_file = story_file;
         $.ajax({
             type: "POST",
             url: url,
             data: obj,
-            dataType: 'json',
-            complete: function() {
+            dataType: "json",
+            complete: function () {
                 //通信終了時の処理
                 $.hideLoading();
             },
-            success: function(data, status) {
+            success: function (data, status) {
                 $.hideLoading();
 
                 var data_obj = data;
                 if (call_back) {
                     call_back(data_obj);
                 }
-            }
+            },
         });
     };
 
-    $.loadText = function(file_path, callback) {
-
+    $.loadText = function (file_path, callback) {
         /*
         var httpObj = jQuery.get(file_path + "?" + Math.floor(Math.random() * 1000000), null, function(obj) {
 
@@ -417,22 +361,19 @@
         $.ajax({
             url: file_path + "?" + Math.floor(Math.random() * 1000000),
             cache: false,
-            success: function(text) {
+            success: function (text) {
                 order_str = text;
                 callback(order_str);
             },
-            error: function() {
+            error: function () {
                 alert("file not found:" + file_path);
                 callback("");
-            }
+            },
         });
-
-
-
     };
 
     //クッキーを取得
-    $.getCookie = function(key) {
+    $.getCookie = function (key) {
         var tmp = document.cookie + ";";
         var index1 = tmp.indexOf(key, 0);
         if (index1 != -1) {
@@ -444,41 +385,39 @@
         return null;
     };
 
-    $.isNull = function(str) {
+    $.isNull = function (str) {
         if (str == null) {
             return "";
         } else {
-
         }
 
         return str;
     };
 
-    $.dstop = function() {
-
+    $.dstop = function () {
         console.log("dstop");
-
     };
 
     //ユーザ環境を取得
-    $.userenv = function() {
-
+    $.userenv = function () {
         var ua = navigator.userAgent;
-        if (ua.indexOf('iPhone') > -1) {
-            return 'iphone';
-        } else if (ua.indexOf('iPad') > -1) {
-            return 'iphone';
-        } else if (ua.indexOf('Android') > -1) {
-            return 'android';
-        } else if (ua.indexOf('Chrome') > -1 && navigator.platform.indexOf('Linux') > -1) {
-            return 'android';
+        if (ua.indexOf("iPhone") > -1) {
+            return "iphone";
+        } else if (ua.indexOf("iPad") > -1) {
+            return "iphone";
+        } else if (ua.indexOf("Android") > -1) {
+            return "android";
+        } else if (
+            ua.indexOf("Chrome") > -1 &&
+            navigator.platform.indexOf("Linux") > -1
+        ) {
+            return "android";
         } else {
             return "pc";
         }
-
     };
 
-    $.isTyranoPlayer = function() {
+    $.isTyranoPlayer = function () {
         if (typeof _tyrano_player != "undefined") {
             return true;
         } else {
@@ -486,32 +425,30 @@
         }
     };
 
-    $.lang = function(key) {
-
+    $.lang = function (key) {
         if (tyrano_lang["word"][key]) {
             return tyrano_lang["word"][key];
         } else {
             return "NOT_DEFINED";
         }
-
     };
 
-    $.novel = function(key) {
-
+    $.novel = function (key) {
         if (tyrano_lang["novel"][key]) {
             return tyrano_lang["novel"][key];
         } else {
             return "NOT_DEFINED";
         }
-
     };
 
     //ユーザのブラウザ情報を取得
-    $.getBrowser = function() {
-
+    $.getBrowser = function () {
         var userAgent = window.navigator.userAgent.toLowerCase();
 
-        if (userAgent.indexOf('msie') >= 0 || userAgent.indexOf('trident') >= 0) {
+        if (
+            userAgent.indexOf("msie") >= 0 ||
+            userAgent.indexOf("trident") >= 0
+        ) {
             return "msie";
         } else if (userAgent.indexOf("edge") > -1) {
             return "edge";
@@ -528,24 +465,25 @@
         } else {
             return "unknown";
         }
-
     };
 
-    $.isNWJS = function() {
-
+    ($.isNWJS = function () {
         //Electronならfalse
         if ($.isElectron()) {
             return false;
         }
 
         // Node.js で動作しているか
-        var isNode = (typeof process !== "undefined" && typeof require !== "undefined");
+        var isNode =
+            typeof process !== "undefined" && typeof require !== "undefined";
         // ブラウザ上(非Node.js)で動作しているか
         var isBrowser = !isNode;
         // node-webkitで動作しているか
         var isNodeWebkit;
         try {
-            isNodeWebkit = isNode ? (typeof require('nw.gui') !== "undefined") : false;
+            isNodeWebkit = isNode
+                ? typeof require("nw.gui") !== "undefined"
+                : false;
         } catch (e) {
             isNodeWebkit = false;
         }
@@ -560,10 +498,8 @@
             //  通常のWebページとして動作している
             return false;
         }
-    },
-
-        $.isNeedClickAudio = function() {
-
+    }),
+        ($.isNeedClickAudio = function () {
             //プレイヤーはクリックの必要なし
             if ($.isTyranoPlayer()) {
                 return false;
@@ -575,63 +511,49 @@
             }
 
             return true;
+        });
 
-
-        };
-
-    $.isElectron = function() {
+    ($.isElectron = function () {
         if (navigator.userAgent.indexOf("TyranoErectron") != -1) {
             return true;
         } else {
             return false;
         }
-
-    },
-
+    }),
         //オブジェクトを引き継ぐ。
-        $.extendParam = function(pm, target) {
-
+        ($.extendParam = function (pm, target) {
             var tmp = target;
 
             for (key in target) {
-
                 if (pm[key]) {
                     if (pm[key] != "") {
                         target[key] = pm[key];
                     }
                 }
-
             }
 
             return target;
+        });
 
-        };
-
-
-    $.insertRule = function(css_str) {
-
-        var sheet = (function() {
+    ($.insertRule = function (css_str) {
+        var sheet = (function () {
             var style = document.createElement("style");
             document.getElementsByTagName("head")[0].appendChild(style);
             return style.sheet;
         })();
         sheet.insertRule(css_str, 0);
-
-    },
-
-        $.swfName = function(str) {
+    }),
+        ($.swfName = function (str) {
             if (navigator.appName.indexOf("Microsoft") != -1) {
                 return window[str];
             } else {
                 return document[str];
             }
-        };
+        });
 
     //古いトランス。
-    $.trans_old = function(method, j_obj, time, mode, callback) {
-
+    $.trans_old = function (method, j_obj, time, mode, callback) {
         if (method == "crossfade" || mode == "show") {
-
             if (time == 0) {
                 if (mode == "show") {
                     j_obj.show();
@@ -646,63 +568,56 @@
 
                 if (mode == "show") {
                     ta = {
-                        "opacity": "show"
+                        opacity: "show",
                     };
                 } else {
                     ta = {
-                        "opacity": "hide"
+                        opacity: "hide",
                     };
                 }
 
                 j_obj.animate(ta, {
                     duration: time,
                     easing: "linear",
-                    complete: function() {
+                    complete: function () {
                         if (callback) {
                             callback();
                         }
-                    }//end complerte
+                    }, //end complerte
                 });
             }
 
             return false;
-
         } else {
-
             if (mode == "hide") {
-                j_obj.hide(method, time, function() {
-                    if (callback)
-                        callback();
+                j_obj.hide(method, time, function () {
+                    if (callback) callback();
                 });
             } else if (mode == "show") {
-                j_obj.show(method, time, function() {
-                    if (callback)
-                        callback();
+                j_obj.show(method, time, function () {
+                    if (callback) callback();
                 });
             }
-
         }
-
     };
 
     //コンバート v450rc5以前
     var _map_conv_method = {
-        "corssfade": "fadeIn",
-        "explode": "zoomIn",
-        "slide": "slideInLeft",
-        "blind": "bounceIn",
-        "bounce": "bounceIn",
-        "clip": "flipInX",
-        "drop": "slideInLeft",
-        "fold": "fadeIn",
-        "puff": "fadeIn",
-        "scale": "zoomIn",
-        "shake": "fadeIn",
-        "size": "zoomIn"
+        corssfade: "fadeIn",
+        explode: "zoomIn",
+        slide: "slideInLeft",
+        blind: "bounceIn",
+        bounce: "bounceIn",
+        clip: "flipInX",
+        drop: "slideInLeft",
+        fold: "fadeIn",
+        puff: "fadeIn",
+        scale: "zoomIn",
+        shake: "fadeIn",
+        size: "zoomIn",
     };
 
-    $.trans = function(method, j_obj, time, mode, callback) {
-
+    $.trans = function (method, j_obj, time, mode, callback) {
         if (method == "crossfade") {
             method = "fadeIn";
         } else if (_map_conv_method[method]) {
@@ -714,8 +629,9 @@
         if (mode == "hide") {
             j_obj.show();
             method = $.replaceAll(method, "In", "Out");
-            var animationEnd = 'webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend';
-            j_obj.addClass('animated ' + method).one(animationEnd, function() {
+            var animationEnd =
+                "webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend";
+            j_obj.addClass("animated " + method).one(animationEnd, function () {
                 j_obj.off(animationEnd);
                 j_obj.css("animation-duration", "");
                 $(this).remove();
@@ -723,27 +639,23 @@
                     //callback();
                 }
             });
-
         } else if (mode == "show") {
             j_obj.show();
-            var animationEnd = 'webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend';
-            j_obj.addClass('animated ' + method).one(animationEnd, function() {
+            var animationEnd =
+                "webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend";
+            j_obj.addClass("animated " + method).one(animationEnd, function () {
                 j_obj.off(animationEnd);
                 j_obj.css("animation-duration", "");
-                $(this).removeClass('animated ' + method);
+                $(this).removeClass("animated " + method);
                 if (callback) {
                     callback();
                 }
             });
         }
-
-
-
     };
 
     //要素から空白のオブジェクトを削除して返却する
-    $.minifyObject = function(obj) {
-
+    $.minifyObject = function (obj) {
         for (key in obj) {
             if (obj[key] == null || obj[key] == "") {
                 delete obj[key];
@@ -751,26 +663,22 @@
         }
 
         return obj;
-
     };
 
-    $.preloadImgCallback = function(j_menu, cb, that) {
-
+    $.preloadImgCallback = function (j_menu, cb, that) {
         var img_storage = [];
 
-        j_menu.find("img").each(function() {
+        j_menu.find("img").each(function () {
             img_storage.push($(this).attr("src"));
         });
 
         //ロードが全て完了したら、ふわっと出す
         var sum = 0;
         for (var i = 0; i < img_storage.length; i++) {
-            that.kag.preload(img_storage[i], function() {
+            that.kag.preload(img_storage[i], function () {
                 sum++;
                 if (img_storage.length == sum) {
-
                     cb();
-
                 }
             });
         }
@@ -778,23 +686,16 @@
         if (img_storage.length == 0) {
             cb();
         }
-
     };
 
-    $.setStorage = function(key, val, type) {
-
+    $.setStorage = function (key, val, type) {
         if (type == "webstorage_compress") {
-
             $.setStorageCompress(key, val);
-
         } else if (type == "file") {
-
             $.setStorageFile(key, val);
-
         } else {
             $.setStorageWeb(key, val);
         }
-
     };
 
     //PC版のみ。実行フォルダを取得
@@ -821,8 +722,7 @@
     };
     */
 
-    $.getOS = function() {
-
+    $.getOS = function () {
         if ($.isElectron()) {
             let os = "";
 
@@ -832,29 +732,26 @@
                 os = "win";
             }
             return os;
-
         } else {
             return "";
         }
     };
 
-    $.makeSaveKey = function() {
-
-        var S = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    $.makeSaveKey = function () {
+        var S =
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
         var N = 16;
-        let key = Array.from(Array(N)).map(() => S[Math.floor(Math.random() * S.length)]).join('');
+        let key = Array.from(Array(N))
+            .map(() => S[Math.floor(Math.random() * S.length)])
+            .join("");
         return key;
-
     };
 
-    $.getStorage = function(key, type) {
-
+    $.getStorage = function (key, type) {
         var gv = "null";
 
         if (type == "webstorage_compress") {
-
             gv = $.getStorageCompress(key);
-
         } else if (type == "file") {
             gv = $.getStorageFile(key);
         } else {
@@ -862,10 +759,9 @@
         }
 
         return gv;
-
     };
 
-    $.setStorageWeb = function(key, val) {
+    $.setStorageWeb = function (key, val) {
         val = JSON.stringify(val);
         //localStorage.setItem(key, LZString.compress(escape(val)));
         try {
@@ -876,10 +772,8 @@
         }
     };
 
-    $.getStorageWeb = function(key) {
-
+    $.getStorageWeb = function (key) {
         try {
-
             var gv = "null";
 
             if (localStorage.getItem(key)) {
@@ -887,9 +781,7 @@
                 gv = unescape(localStorage.getItem(key));
             }
 
-            if (gv == "null")
-                return null;
-
+            if (gv == "null") return null;
         } catch (e) {
             //alert("この環境はセーブ機能を利用できません。ローカルで実行している場合などに発生します");
             //$.confirmSaveClear();
@@ -899,17 +791,13 @@
         }
 
         return gv;
-
     };
 
-    $.playerHtmlPath = function(html) {
-
+    $.playerHtmlPath = function (html) {
         if ("appJsInterface" in window) {
             //Android
         } else {
-
             if (typeof TyranoPlayer == "function") {
-
                 //playerの場合HTMLを修正する必要がある
                 var result_html = "";
                 while (1) {
@@ -918,50 +806,46 @@
                         result_html += html;
                         break;
                     } else {
-
                         result_html += html.substring(0, index);
                         html = html.substring(index, html.length);
 
                         var replace_index = html.indexOf("/game/data");
-                        tmp_html = html.substring(replace_index + "/game/data".length, html.length);
+                        tmp_html = html.substring(
+                            replace_index + "/game/data".length,
+                            html.length,
+                        );
                         html = "./data" + tmp_html;
-
-
                     }
-
                 }
 
                 if (result_html != "") {
                     html = result_html;
                 }
-
             }
-
-
         }
 
         return html;
-
     };
 
-
-    $.confirmSaveClear = function() {
-        if (confirm('セーブデータが壊れている可能性があります。セーブデータを初期化しますか？')) {
+    $.confirmSaveClear = function () {
+        if (
+            confirm(
+                "セーブデータが壊れている可能性があります。セーブデータを初期化しますか？",
+            )
+        ) {
             alert("初期化");
             localStorage.clear();
         }
     };
 
-    $.setStorageCompress = function(key, val) {
+    $.setStorageCompress = function (key, val) {
         val = JSON.stringify(val);
         localStorage.setItem(key, LZString.compress(escape(val)));
         //localStorage.setItem(key, escape(val));
     };
 
-    $.getStorageCompress = function(key) {
-
+    $.getStorageCompress = function (key) {
         try {
-
             var gv = "null";
 
             if (localStorage.getItem(key)) {
@@ -972,22 +856,20 @@
                 }
             }
 
-            if (gv == "null")
-                return null;
-
+            if (gv == "null") return null;
         } catch (e) {
             console.log("==============");
             console.log(e);
-            alert("この環境はセーブ機能を利用できません。ローカルで実行している場合などに発生します");
+            alert(
+                "この環境はセーブ機能を利用できません。ローカルで実行している場合などに発生します",
+            );
             $.confirmSaveClear();
         }
 
         return gv;
-
     };
 
-    $.getExtWithFile = function(str) {
-
+    $.getExtWithFile = function (str) {
         var filename = "";
         if (str.indexOf("/") != -1) {
             filename = str.split("/").pop();
@@ -1007,16 +889,12 @@
         }
         var name = $.replaceAll(filename, "." + ext, "");
 
-
         return { filename: filename, ext: ext, name: name, dir_name: dir_name };
-
-
     };
 
     //PC用の実行パスを取得
-    $.getExePath = function() {
-
-        const _app = require('electron').remote.app;
+    $.getExePath = function () {
+        const _app = require("electron").remote.app;
 
         //TyranoStudio.app/Contents/Resources/app
         let path = _app.getAppPath();
@@ -1026,7 +904,6 @@
         //console.log(path);
 
         if (process.platform == "darwin") {
-
             platrofm = "mac";
             //TyranoStudio-darwin-x64.asar
             if (path.indexOf(".asar") != -1) {
@@ -1036,25 +913,19 @@
             }
 
             path = $.getExtWithFile(path).dir_name;
-
-
         } else if (process.platform == "win32") {
-
             if (path.indexOf(".asar") != -1) {
                 path = $.replaceAll(path, "\\resources\\app.asar", "");
             } else {
                 path = $.replaceAll(path, "\\resources\\app", "");
             }
-
         }
 
         return path;
-
     };
 
     //展開先のパスを返す。
-    $.getUnzipPath = function() {
-
+    $.getUnzipPath = function () {
         let path = __dirname;
 
         if (path.indexOf(".asar") != -1) {
@@ -1062,13 +933,11 @@
         }
 
         return path;
-
     };
 
-    $.setStorageFile = function(key, val) {
-
+    $.setStorageFile = function (key, val) {
         val = JSON.stringify(val);
-        var fs = require('fs');
+        var fs = require("fs");
 
         var out_path = $.getExePath();
 
@@ -1082,18 +951,13 @@
             out_path = $.getExePath();
         }
 
-
         fs.writeFileSync(out_path + "/" + key + ".sav", escape(val));
-
     };
 
-
-    $.getStorageFile = function(key) {
-
+    $.getStorageFile = function (key) {
         try {
-
             var gv = "null";
-            var fs = require('fs');
+            var fs = require("fs");
             var out_path = "";
 
             var out_path = $.getExePath();
@@ -1118,15 +982,15 @@
             if (gv == "null") {
                 return null;
             }
-
         } catch (e) {
             console.log(e);
-            alert("この環境はセーブ機能を利用できません。ローカルで実行している場合などに発生します");
+            alert(
+                "この環境はセーブ機能を利用できません。ローカルで実行している場合などに発生します",
+            );
             $.confirmSaveClear();
         }
 
         return gv;
-
     };
 
     /*
@@ -1161,25 +1025,21 @@
     };
     */
 
-    $.alert = function(str, cb) {
-
+    $.alert = function (str, cb) {
         $(".remodal_title").html(str);
 
         $(".remodal").find(".remodal-cancel").hide();
         $(".remodal").find(".remodal-confirm").show();
 
-        var inst = $('[data-remodal-id=modal]').remodal();
+        var inst = $("[data-remodal-id=modal]").remodal();
         inst.open();
 
-        $(document).off('closed', '.remodal');
-        $(document).on('closed', '.remodal', function(e) {
-
+        $(document).off("closed", ".remodal");
+        $(document).on("closed", ".remodal", function (e) {
             if (typeof cb == "function") {
                 cb();
             }
-
         });
-
 
         /*
         if ($.userenv() != "pc") {
@@ -1196,50 +1056,44 @@
             });
         }
         */
-
     };
 
-    $.inform = function(str, type) {
+    $.inform = function (str, type) {
         alertify.log(str, type);
     };
 
-    $.confirm = function(str, cb_ok, cb_cancel) {
-
+    $.confirm = function (str, cb_ok, cb_cancel) {
         $(".remodal_title").html(str);
 
         $(".remodal").find(".remodal-cancel").show();
         $(".remodal").find(".remodal-confirm").show();
 
-        var inst = $('[data-remodal-id=modal]').remodal();
+        var inst = $("[data-remodal-id=modal]").remodal();
         inst.open();
 
         /////////OK /////////////
 
-        $(document).off('closed', '.remodal');
+        $(document).off("closed", ".remodal");
 
-        $(document).off('confirmation', '.remodal');
-        $(document).on('confirmation', '.remodal', function(e) {
-
-            $(document).off('confirmation', '.remodal');
-            $(document).off('cancellation', '.remodal');
+        $(document).off("confirmation", ".remodal");
+        $(document).on("confirmation", ".remodal", function (e) {
+            $(document).off("confirmation", ".remodal");
+            $(document).off("cancellation", ".remodal");
 
             if (typeof cb_ok == "function") {
                 cb_ok();
             }
-
         });
 
         ///////キャンセル//////////////
-        $(document).off('cancellation', '.remodal');
-        $(document).on('cancellation', '.remodal', function(e) {
-
-            $(document).off('confirmation', '.remodal');
-            $(document).off('cancellation', '.remodal');
+        $(document).off("cancellation", ".remodal");
+        $(document).on("cancellation", ".remodal", function (e) {
+            $(document).off("confirmation", ".remodal");
+            $(document).off("cancellation", ".remodal");
 
             if (typeof cb_cancel == "function") {
                 cb_cancel();
             }
-
         });
 
         /*
@@ -1263,12 +1117,10 @@
             });
         }
         */
-
     };
 
     //オブジェクトの個数をもってきます。1
-    $.countObj = function(obj) {
-
+    $.countObj = function (obj) {
         var num = 0;
         for (key in obj) {
             num++;
@@ -1276,46 +1128,39 @@
         return num;
     };
 
-    $.getUrlQuery = function(url) {
-
-        var hash = url.slice(1).split('&');
+    $.getUrlQuery = function (url) {
+        var hash = url.slice(1).split("&");
         var max = hash.length;
         var vars = {};
         var array = "";
 
         for (var i = 0; i < max; i++) {
-            array = hash[i].split('=');
+            array = hash[i].split("=");
             vars[array[0]] = array[1];
         }
 
         return vars;
-
-
     };
 
     //渡されたJqueryオブジェクトにクラスをセットします
-    $.setName = function(jobj, str) {
-
+    $.setName = function (jobj, str) {
         str = $.trim(str);
 
-        if (str == "")
-            return;
+        if (str == "") return;
 
         var array = str.split(",");
         for (var i = 0; i < array.length; i++) {
             jobj.addClass(array[i]);
-
         }
-
     };
 
     //フラッシュのインストール判定
-    $.isFlashInstalled = function() {
-        if (navigator.plugins['Shockwave Flash']) {
+    $.isFlashInstalled = function () {
+        if (navigator.plugins["Shockwave Flash"]) {
             return true;
         }
         try {
-            new ActiveXObject('ShockwaveFlash.ShockwaveFlash');
+            new ActiveXObject("ShockwaveFlash.ShockwaveFlash");
             return true;
         } catch (e) {
             return false;
@@ -1325,12 +1170,13 @@
     /*スマホの場合は、タッチでクリックを置き換える*/
     /*タッチ系、一応出来たけど、動作確認よくしなければならなｋ，問題なければR9にも適応*/
     if ($.userenv() != "pc") {
-        $.event.tap = function(o) {
-
-            o.bind('touchstart', onTouchStart_);
+        $.event.tap = function (o) {
+            o.bind("touchstart", onTouchStart_);
             function onTouchStart_(e) {
                 e.preventDefault();
-                o.data('event.tap.moved', false).one('touchmove', onTouchMove_).one('touchend', onTouchEnd_);
+                o.data("event.tap.moved", false)
+                    .one("touchmove", onTouchMove_)
+                    .one("touchend", onTouchEnd_);
                 e.stopPropagation();
             }
 
@@ -1340,18 +1186,16 @@
             }
 
             function onTouchEnd_(e) {
-                if (!o.data('event.tap.moved')) {
-                    o.unbind('touchmove', onTouchMove_);
-                    o.trigger('click').click();
+                if (!o.data("event.tap.moved")) {
+                    o.unbind("touchmove", onTouchMove_);
+                    o.trigger("click").click();
                     e.stopPropagation();
                 }
             }
-
         };
 
-        if ('ontouchend' in document) {
-            $.fn.tap = function(data, fn) {
-
+        if ("ontouchend" in document) {
+            $.fn.tap = function (data, fn) {
                 //alert("tap!");
 
                 if (fn == null) {
@@ -1360,21 +1204,20 @@
                 }
 
                 if (arguments.length > 0) {
-                    this.bind('tap', data, fn);
+                    this.bind("tap", data, fn);
                     $.event.tap(this);
                 } else {
-                    this.trigger('tap');
+                    this.trigger("tap");
                 }
                 return this;
             };
 
             if ($.attrFn) {
-                $.attrFn['tap'] = true;
+                $.attrFn["tap"] = true;
             }
 
             //クリック上書き
             $.fn.click = $.fn.tap;
-
         } else {
             //$.fn.tap = $.fn.click;
         }
@@ -1382,17 +1225,21 @@
 
     //////////////////////////////
 
-    $.error_message = function(str) {
+    $.error_message = function (str) {
         alert(str);
     };
 
     //クッキー設定
-    $.setCookie = function(key, val) {
-        document.cookie = key + "=" + escape(val) + ";expires=Fri, 31-Dec-2030 23:59:59;path=/;";
+    $.setCookie = function (key, val) {
+        document.cookie =
+            key +
+            "=" +
+            escape(val) +
+            ";expires=Fri, 31-Dec-2030 23:59:59;path=/;";
     };
 })(jQuery);
 
-jQuery.fn.outerHTML = function(s) {
+jQuery.fn.outerHTML = function (s) {
     if (s) {
         this.before(s);
         this.remove();
@@ -1406,180 +1253,186 @@ jQuery.fn.outerHTML = function(s) {
 };
 
 // t: current time, b: begInnIng value, c: change In value, d: duration
-jQuery.easing['jswing'] = jQuery.easing['swing'];
+jQuery.easing["jswing"] = jQuery.easing["swing"];
 
 jQuery.extend(jQuery.easing, {
-    def: 'easeOutQuad',
-    swing: function(x, t, b, c, d) {
+    def: "easeOutQuad",
+    swing: function (x, t, b, c, d) {
         //alert(jQuery.easing.default);
         return jQuery.easing[jQuery.easing.def](x, t, b, c, d);
     },
-    easeInQuad: function(x, t, b, c, d) {
+    easeInQuad: function (x, t, b, c, d) {
         return c * (t /= d) * t + b;
     },
-    easeOutQuad: function(x, t, b, c, d) {
+    easeOutQuad: function (x, t, b, c, d) {
         return -c * (t /= d) * (t - 2) + b;
     },
-    easeInOutQuad: function(x, t, b, c, d) {
-        if ((t /= d / 2) < 1)
-            return c / 2 * t * t + b;
-        return -c / 2 * ((--t) * (t - 2) - 1) + b;
+    easeInOutQuad: function (x, t, b, c, d) {
+        if ((t /= d / 2) < 1) return (c / 2) * t * t + b;
+        return (-c / 2) * (--t * (t - 2) - 1) + b;
     },
-    easeInCubic: function(x, t, b, c, d) {
+    easeInCubic: function (x, t, b, c, d) {
         return c * (t /= d) * t * t + b;
     },
-    easeOutCubic: function(x, t, b, c, d) {
+    easeOutCubic: function (x, t, b, c, d) {
         return c * ((t = t / d - 1) * t * t + 1) + b;
     },
-    easeInOutCubic: function(x, t, b, c, d) {
-        if ((t /= d / 2) < 1)
-            return c / 2 * t * t * t + b;
-        return c / 2 * ((t -= 2) * t * t + 2) + b;
+    easeInOutCubic: function (x, t, b, c, d) {
+        if ((t /= d / 2) < 1) return (c / 2) * t * t * t + b;
+        return (c / 2) * ((t -= 2) * t * t + 2) + b;
     },
-    easeInQuart: function(x, t, b, c, d) {
+    easeInQuart: function (x, t, b, c, d) {
         return c * (t /= d) * t * t * t + b;
     },
-    easeOutQuart: function(x, t, b, c, d) {
+    easeOutQuart: function (x, t, b, c, d) {
         return -c * ((t = t / d - 1) * t * t * t - 1) + b;
     },
-    easeInOutQuart: function(x, t, b, c, d) {
-        if ((t /= d / 2) < 1)
-            return c / 2 * t * t * t * t + b;
-        return -c / 2 * ((t -= 2) * t * t * t - 2) + b;
+    easeInOutQuart: function (x, t, b, c, d) {
+        if ((t /= d / 2) < 1) return (c / 2) * t * t * t * t + b;
+        return (-c / 2) * ((t -= 2) * t * t * t - 2) + b;
     },
-    easeInQuint: function(x, t, b, c, d) {
+    easeInQuint: function (x, t, b, c, d) {
         return c * (t /= d) * t * t * t * t + b;
     },
-    easeOutQuint: function(x, t, b, c, d) {
+    easeOutQuint: function (x, t, b, c, d) {
         return c * ((t = t / d - 1) * t * t * t * t + 1) + b;
     },
-    easeInOutQuint: function(x, t, b, c, d) {
-        if ((t /= d / 2) < 1)
-            return c / 2 * t * t * t * t * t + b;
-        return c / 2 * ((t -= 2) * t * t * t * t + 2) + b;
+    easeInOutQuint: function (x, t, b, c, d) {
+        if ((t /= d / 2) < 1) return (c / 2) * t * t * t * t * t + b;
+        return (c / 2) * ((t -= 2) * t * t * t * t + 2) + b;
     },
-    easeInSine: function(x, t, b, c, d) {
-        return -c * Math.cos(t / d * (Math.PI / 2)) + c + b;
+    easeInSine: function (x, t, b, c, d) {
+        return -c * Math.cos((t / d) * (Math.PI / 2)) + c + b;
     },
-    easeOutSine: function(x, t, b, c, d) {
-        return c * Math.sin(t / d * (Math.PI / 2)) + b;
+    easeOutSine: function (x, t, b, c, d) {
+        return c * Math.sin((t / d) * (Math.PI / 2)) + b;
     },
-    easeInOutSine: function(x, t, b, c, d) {
-        return -c / 2 * (Math.cos(Math.PI * t / d) - 1) + b;
+    easeInOutSine: function (x, t, b, c, d) {
+        return (-c / 2) * (Math.cos((Math.PI * t) / d) - 1) + b;
     },
-    easeInExpo: function(x, t, b, c, d) {
-        return (t == 0) ? b : c * Math.pow(2, 10 * (t / d - 1)) + b;
+    easeInExpo: function (x, t, b, c, d) {
+        return t == 0 ? b : c * Math.pow(2, 10 * (t / d - 1)) + b;
     },
-    easeOutExpo: function(x, t, b, c, d) {
-        return (t == d) ? b + c : c * (-Math.pow(2, -10 * t / d) + 1) + b;
+    easeOutExpo: function (x, t, b, c, d) {
+        return t == d ? b + c : c * (-Math.pow(2, (-10 * t) / d) + 1) + b;
     },
-    easeInOutExpo: function(x, t, b, c, d) {
-        if (t == 0)
-            return b;
-        if (t == d)
-            return b + c;
-        if ((t /= d / 2) < 1)
-            return c / 2 * Math.pow(2, 10 * (t - 1)) + b;
-        return c / 2 * (-Math.pow(2, -10 * --t) + 2) + b;
+    easeInOutExpo: function (x, t, b, c, d) {
+        if (t == 0) return b;
+        if (t == d) return b + c;
+        if ((t /= d / 2) < 1) return (c / 2) * Math.pow(2, 10 * (t - 1)) + b;
+        return (c / 2) * (-Math.pow(2, -10 * --t) + 2) + b;
     },
-    easeInCirc: function(x, t, b, c, d) {
+    easeInCirc: function (x, t, b, c, d) {
         return -c * (Math.sqrt(1 - (t /= d) * t) - 1) + b;
     },
-    easeOutCirc: function(x, t, b, c, d) {
+    easeOutCirc: function (x, t, b, c, d) {
         return c * Math.sqrt(1 - (t = t / d - 1) * t) + b;
     },
-    easeInOutCirc: function(x, t, b, c, d) {
-        if ((t /= d / 2) < 1)
-            return -c / 2 * (Math.sqrt(1 - t * t) - 1) + b;
-        return c / 2 * (Math.sqrt(1 - (t -= 2) * t) + 1) + b;
+    easeInOutCirc: function (x, t, b, c, d) {
+        if ((t /= d / 2) < 1) return (-c / 2) * (Math.sqrt(1 - t * t) - 1) + b;
+        return (c / 2) * (Math.sqrt(1 - (t -= 2) * t) + 1) + b;
     },
-    easeInElastic: function(x, t, b, c, d) {
+    easeInElastic: function (x, t, b, c, d) {
         var s = 1.70158;
         var p = 0;
         var a = c;
-        if (t == 0)
-            return b;
-        if ((t /= d) == 1)
-            return b + c;
-        if (!p)
-            p = d * .3;
+        if (t == 0) return b;
+        if ((t /= d) == 1) return b + c;
+        if (!p) p = d * 0.3;
         if (a < Math.abs(c)) {
             a = c;
             var s = p / 4;
-        } else
-            var s = p / (2 * Math.PI) * Math.asin(c / a);
-        return -(a * Math.pow(2, 10 * (t -= 1)) * Math.sin((t * d - s) * (2 * Math.PI) / p)) + b;
+        } else var s = (p / (2 * Math.PI)) * Math.asin(c / a);
+        return (
+            -(
+                a *
+                Math.pow(2, 10 * (t -= 1)) *
+                Math.sin(((t * d - s) * (2 * Math.PI)) / p)
+            ) + b
+        );
     },
-    easeOutElastic: function(x, t, b, c, d) {
+    easeOutElastic: function (x, t, b, c, d) {
         var s = 1.70158;
         var p = 0;
         var a = c;
-        if (t == 0)
-            return b;
-        if ((t /= d) == 1)
-            return b + c;
-        if (!p)
-            p = d * .3;
+        if (t == 0) return b;
+        if ((t /= d) == 1) return b + c;
+        if (!p) p = d * 0.3;
         if (a < Math.abs(c)) {
             a = c;
             var s = p / 4;
-        } else
-            var s = p / (2 * Math.PI) * Math.asin(c / a);
-        return a * Math.pow(2, -10 * t) * Math.sin((t * d - s) * (2 * Math.PI) / p) + c + b;
+        } else var s = (p / (2 * Math.PI)) * Math.asin(c / a);
+        return (
+            a *
+                Math.pow(2, -10 * t) *
+                Math.sin(((t * d - s) * (2 * Math.PI)) / p) +
+            c +
+            b
+        );
     },
-    easeInOutElastic: function(x, t, b, c, d) {
+    easeInOutElastic: function (x, t, b, c, d) {
         var s = 1.70158;
         var p = 0;
         var a = c;
-        if (t == 0)
-            return b;
-        if ((t /= d / 2) == 2)
-            return b + c;
-        if (!p)
-            p = d * (.3 * 1.5);
+        if (t == 0) return b;
+        if ((t /= d / 2) == 2) return b + c;
+        if (!p) p = d * (0.3 * 1.5);
         if (a < Math.abs(c)) {
             a = c;
             var s = p / 4;
-        } else
-            var s = p / (2 * Math.PI) * Math.asin(c / a);
+        } else var s = (p / (2 * Math.PI)) * Math.asin(c / a);
         if (t < 1)
-            return -.5 * (a * Math.pow(2, 10 * (t -= 1)) * Math.sin((t * d - s) * (2 * Math.PI) / p)) + b;
-        return a * Math.pow(2, -10 * (t -= 1)) * Math.sin((t * d - s) * (2 * Math.PI) / p) * .5 + c + b;
+            return (
+                -0.5 *
+                    (a *
+                        Math.pow(2, 10 * (t -= 1)) *
+                        Math.sin(((t * d - s) * (2 * Math.PI)) / p)) +
+                b
+            );
+        return (
+            a *
+                Math.pow(2, -10 * (t -= 1)) *
+                Math.sin(((t * d - s) * (2 * Math.PI)) / p) *
+                0.5 +
+            c +
+            b
+        );
     },
-    easeInBack: function(x, t, b, c, d, s) {
-        if (s == undefined)
-            s = 1.70158;
+    easeInBack: function (x, t, b, c, d, s) {
+        if (s == undefined) s = 1.70158;
         return c * (t /= d) * t * ((s + 1) * t - s) + b;
     },
-    easeOutBack: function(x, t, b, c, d, s) {
-        if (s == undefined)
-            s = 1.70158;
+    easeOutBack: function (x, t, b, c, d, s) {
+        if (s == undefined) s = 1.70158;
         return c * ((t = t / d - 1) * t * ((s + 1) * t + s) + 1) + b;
     },
-    easeInOutBack: function(x, t, b, c, d, s) {
-        if (s == undefined)
-            s = 1.70158;
+    easeInOutBack: function (x, t, b, c, d, s) {
+        if (s == undefined) s = 1.70158;
         if ((t /= d / 2) < 1)
-            return c / 2 * (t * t * (((s *= (1.525)) + 1) * t - s)) + b;
-        return c / 2 * ((t -= 2) * t * (((s *= (1.525)) + 1) * t + s) + 2) + b;
+            return (c / 2) * (t * t * (((s *= 1.525) + 1) * t - s)) + b;
+        return (c / 2) * ((t -= 2) * t * (((s *= 1.525) + 1) * t + s) + 2) + b;
     },
-    easeInBounce: function(x, t, b, c, d) {
+    easeInBounce: function (x, t, b, c, d) {
         return c - jQuery.easing.easeOutBounce(x, d - t, 0, c, d) + b;
     },
-    easeOutBounce: function(x, t, b, c, d) {
-        if ((t /= d) < (1 / 2.75)) {
+    easeOutBounce: function (x, t, b, c, d) {
+        if ((t /= d) < 1 / 2.75) {
             return c * (7.5625 * t * t) + b;
-        } else if (t < (2 / 2.75)) {
-            return c * (7.5625 * (t -= (1.5 / 2.75)) * t + .75) + b;
-        } else if (t < (2.5 / 2.75)) {
-            return c * (7.5625 * (t -= (2.25 / 2.75)) * t + .9375) + b;
+        } else if (t < 2 / 2.75) {
+            return c * (7.5625 * (t -= 1.5 / 2.75) * t + 0.75) + b;
+        } else if (t < 2.5 / 2.75) {
+            return c * (7.5625 * (t -= 2.25 / 2.75) * t + 0.9375) + b;
         } else {
-            return c * (7.5625 * (t -= (2.625 / 2.75)) * t + .984375) + b;
+            return c * (7.5625 * (t -= 2.625 / 2.75) * t + 0.984375) + b;
         }
     },
-    easeInOutBounce: function(x, t, b, c, d) {
+    easeInOutBounce: function (x, t, b, c, d) {
         if (t < d / 2)
-            return jQuery.easing.easeInBounce(x, t * 2, 0, c, d) * .5 + b;
-        return jQuery.easing.easeOutBounce(x, t * 2 - d, 0, c, d) * .5 + c * .5 + b;
-    }
+            return jQuery.easing.easeInBounce(x, t * 2, 0, c, d) * 0.5 + b;
+        return (
+            jQuery.easing.easeOutBounce(x, t * 2 - d, 0, c, d) * 0.5 +
+            c * 0.5 +
+            b
+        );
+    },
 });

--- a/tyrano/plugins/kag/kag.event.js
+++ b/tyrano/plugins/kag/kag.event.js
@@ -1,21 +1,15 @@
-
 //イベント管理用のクラス
 tyrano.plugin.kag.event = {
-
     tyrano: null,
 
-    init: function() {
-
+    init: function () {
         //alert("kag.order 初期化");
         //this.tyrano.test();
-
         //同じディレクトリにある、KAG関連のデータを読み込み
-
     },
 
     //イベント用のエレメントを設定する
-    addEventElement: function(obj) {
-
+    addEventElement: function (obj) {
         var j_obj = obj.j_target;
 
         j_obj.addClass("event-setting-element");
@@ -25,7 +19,5 @@ tyrano.plugin.kag.event = {
 
         //パラメータを格納してみてはどうか？
         j_obj.attr("data-event-pm", JSON.stringify(obj.pm));
-
-
-    }
+    },
 };

--- a/tyrano/plugins/kag/kag.js
+++ b/tyrano/plugins/kag/kag.js
@@ -1,6 +1,4 @@
-
 tyrano.plugin.kag = {
-
     version: 500,
 
     tyrano: null,
@@ -17,9 +15,7 @@ tyrano.plugin.kag = {
 
     cache_scenario: {},
 
-
     config: {
-
         defaultStorageExtension: "jpg",
         projectID: "tyranoproject",
         game_version: "0.0",
@@ -29,30 +25,25 @@ tyrano.plugin.kag = {
         mediaFormatDefault: "ogg",
         configSave: "webstorage",
         configSaveOverwrite: "false",
-
     }, //読み込んできた値 Config.tjs の値
 
     //変更されることが無い静的な値
     define: {
         TYRANO_ENGINE_VERSION: 400,
-        "BASE_DIV_NAME": "tyrano_base",
+        BASE_DIV_NAME: "tyrano_base",
         FLAG_APRI: false,
-
     },
-
 
     //各種変数
     variable: {
         //f:{},//ゲーム変数 stat に移動
-        sf: {},//システム変数
-        tf: {}//一時変数
+        sf: {}, //システム変数
+        tf: {}, //一時変数
         //mp:{}//マクロに引き渡された変数がココに入る
-
     },
 
     //一時保存オブジェクト
     tmp: {
-
         checking_macro: false, //マクロの登録時はスタックにつまれない
 
         ready_audio: false, //スマホブラウザ向け。オーディオ初期化を終えたか否か
@@ -75,7 +66,7 @@ tyrano.plugin.kag = {
         is_bgm_play: false, //BGMがプレイ中か否か
         is_bgm_play_wait: false, //BGMの完了を待っているか否か。
 
-        is_audio_stopping: false,//BGMがフェードアウト中かどうか。
+        is_audio_stopping: false, //BGMがフェードアウト中かどうか。
 
         loading_make_ref: false,
 
@@ -88,38 +79,29 @@ tyrano.plugin.kag = {
         video_playing: false,
 
         angle: 0, //スマホの場合盾持ちか否か。0なら盾持ち。
-        largerWidth: false,// 横幅の方が大きければ
+        largerWidth: false, // 横幅の方が大きければ
 
         three: {
-
             stat: {
-
                 is_load: false,
                 canvas_show: false,
                 start_event: true,
 
                 scene_pm: {}, //シーン情報の設定
-                init_pm: {},//初期設定のpm
+                init_pm: {}, //初期設定のpm
 
                 gyro: {
-
                     pm: {},
                     x: 0,
                     y: 0,
                     enable: -1,
                     mode: 0,
-
-
                 },
-
             },
 
             models: {},
             evt: {},
         },
-
-
-
     },
 
     //逐次変化するKAGシステムの動作に必要な状況変化ファイル
@@ -133,17 +115,17 @@ tyrano.plugin.kag = {
         vertical: "false", //縦書き
 
         f: {}, //ゲーム変数はstatの中
-        mp: {},//マクロもstat
+        mp: {}, //マクロもstat
 
         current_layer: "message0", //現在のメッセージレイヤ
         current_page: "fore",
-        is_stop: false,//停止中。クリックしても先に進ませない
+        is_stop: false, //停止中。クリックしても先に進ませない
         is_wait: false, //wait中。
         is_trans: false, //trans中
 
         is_wait_anim: false, //[wa]中
 
-        is_strong_stop: false,// [s]タグで立ち止まってる状態。強力な停止中。解除するにはジャンプやマクロが呼び出せれる
+        is_strong_stop: false, // [s]タグで立ち止まってる状態。強力な停止中。解除するにはジャンプやマクロが呼び出せれる
         strong_stop_recover_index: 0, //[s]タグ指定中に保存した場合、戻ってくるindex [_s]時のindexを保持しておく
 
         is_nowait: false, //ノーウェイト、テキスト瞬間表示状態
@@ -152,9 +134,9 @@ tyrano.plugin.kag = {
         current_save_str: "", //セーブの時に使用するメッセージ
 
         current_keyframe: "", //キーフレームの名前、スタートしている場合はキーフレーム名が入る
-        map_keyframe: {},     //キーフレームアニメーション情報を登録
+        map_keyframe: {}, //キーフレームアニメーション情報を登録
 
-        is_script: false,//スクリプト解析中。
+        is_script: false, //スクリプト解析中。
         buff_script: "", //スクリプトを格納しておく
 
         is_html: false, //htmlタグ解析中
@@ -164,10 +146,10 @@ tyrano.plugin.kag = {
 
         save_img: "", //セーブイメージ。ここにパスが入っている場合はその画像をサムネに使う。
 
-        stack: { "if": [], "call": [], "macro": [] }, //if文のスタック
+        stack: { if: [], call: [], macro: [] }, //if文のスタック
 
-        set_text_span: false,//メッセージ中のspanを新しく作成するときに真にする
-        current_scenario: "first.ks",//シナリオファイルを指定する
+        set_text_span: false, //メッセージ中のspanを新しく作成するときに真にする
+        current_scenario: "first.ks", //シナリオファイルを指定する
         is_skip: {},
         is_auto: {},
         current_bgm: "", //現在再生中のBGM
@@ -176,7 +158,7 @@ tyrano.plugin.kag = {
 
         current_se: {}, //現在再生中のループ効果音
 
-        load_auto_next: false,// ロード時にオートネクストするかどうか。showsave周りのときtrueになる。
+        load_auto_next: false, // ロード時にオートネクストするかどうか。showsave周りのときtrueになる。
 
         current_bgcamera: "", //bgcamerの有効性
 
@@ -184,13 +166,11 @@ tyrano.plugin.kag = {
 
         current_bgmovie: {
             storage: "",
-            volume: ""
+            volume: "",
         }, //再生中の背景動画
 
-        current_camera: {
-        },
+        current_camera: {},
         current_camera_layer: "",
-
 
         is_move_camera: false, //カメラの演出中かどうか
         is_wait_camera: false, //カメラの演出を待ってるかどうか
@@ -200,7 +180,7 @@ tyrano.plugin.kag = {
         is_hide_message: false, //メッセージエリアが非表示状態か否か
 
         is_click_text: false, //テキストメッセージがクリックされた常態化否か
-        is_adding_text: false,//テキストメッセージを追加中か否か
+        is_adding_text: false, //テキストメッセージを追加中か否か
 
         flag_ref_page: false, //このフラグが立っている場合、次のクリックで画面がクリアされます。
 
@@ -237,19 +217,18 @@ tyrano.plugin.kag = {
 
         //qr系の設定
         qr: {
-            "mode": "off",
-            "define": {}
+            mode: "off",
+            define: {},
         },
 
         //表示位置調整
         locate: {
             x: 0,
-            y: 0
+            y: 0,
         },
 
         //リセットされた時に適応されるオリジナルフォント設定
         default_font: {
-
             color: "",
             bold: "",
             size: "",
@@ -259,12 +238,10 @@ tyrano.plugin.kag = {
             shadow: "",
             effect: "",
             effect_speed: "",
-
         },
 
         //ふきだしで使用するパラメータ郡
         fuki: {
-
             def_style: {}, //ポジションで指定されたスタイルを保持する
             def_style_inner: {},
             def_pm: {}, //positionで指定されたパラメータを保持する
@@ -273,7 +250,6 @@ tyrano.plugin.kag = {
             marginb: 0,
 
             others_style: {},
-
         },
 
         //システム系で使用するHTMLの場所を保持
@@ -281,7 +257,7 @@ tyrano.plugin.kag = {
             save: "./tyrano/html/save.html",
             load: "./tyrano/html/load.html",
             backlog: "./tyrano/html/backlog.html",
-            menu: "./tyrano/html/menu.html"
+            menu: "./tyrano/html/menu.html",
         },
 
         /*** キャラクター操作系 ***/
@@ -291,7 +267,7 @@ tyrano.plugin.kag = {
         chara_ptext: "",
         chara_time: "600",
         chara_memory: "false",
-        chara_anim: "true",  //キャラクター追加時、位置が変わる場合にアニメーションで表示するか否か
+        chara_anim: "true", //キャラクター追加時、位置が変わる場合にアニメーションで表示するか否か
         pos_change_time: "600", //キャラクター自動配置のスピード
 
         chara_talk_focus: "none",
@@ -301,7 +277,6 @@ tyrano.plugin.kag = {
         chara_talk_anim: "none", //キャラクターが話す時にアニメーションするかどうか
         chara_talk_anim_time: 230,
         chara_talk_anim_value: 30,
-
 
         apply_filter_str: "",
 
@@ -313,7 +288,7 @@ tyrano.plugin.kag = {
         jcharas: {},
 
         play_bgm: true, //BGMを再生するか否か
-        play_se: true,  //SEを再生するか否か
+        play_se: true, //SEを再生するか否か
 
         play_speak: false, // 読み上げを行うか否か
 
@@ -322,8 +297,8 @@ tyrano.plugin.kag = {
 
         //ボイス周りの設定 vocoinfig
         map_vo: {
-            vobuf: {},//ボイスとして指定するplayseのbuf
-            vochara: {}//キャラ毎にボイスの設定が入る。
+            vobuf: {}, //ボイスとして指定するplayseのbuf
+            vochara: {}, //キャラ毎にボイスの設定が入る。
         },
         vostart: false, //vo管理が有効か否か
 
@@ -336,10 +311,8 @@ tyrano.plugin.kag = {
         visible_menu_button: false, //メニューボタンの表示状態
 
         resizecall: {
-
             storage: "",
             target: "",
-
         },
 
         vchat: {
@@ -349,13 +322,10 @@ tyrano.plugin.kag = {
             charas: {}, //キャラ一覧
         },
 
-        title: "" //ゲームのタイトル
-
+        title: "", //ゲームのタイトル
     }, //ゲームの現在の状態を保持する所 状況によって、いろいろ変わってくる
 
-
-    init: function() {
-
+    init: function () {
         this.kag = this;
 
         var that = this;
@@ -363,48 +333,42 @@ tyrano.plugin.kag = {
         this.tyrano.test();
 
         //コンフィグファイルの読み込み
-        this.parser.loadConfig(function(map_config) {
-
+        this.parser.loadConfig(function (map_config) {
             that.config = $.extend(true, that.config, map_config);
 
-            that.checkUpdate(function() {
-
+            that.checkUpdate(function () {
                 that.init_game(); //ゲーム画面生成
-
             });
-
-
         });
 
         //アプリか否かの設定
-        $("script").each(function() {
-
+        $("script").each(function () {
             if ($(this).attr("src")) {
-                if ($(this).attr("src").indexOf("cordova") != -1 || $(this).attr("src").indexOf("phonegap") != -1) {
+                if (
+                    $(this).attr("src").indexOf("cordova") != -1 ||
+                    $(this).attr("src").indexOf("phonegap") != -1
+                ) {
                     that.define.FLAG_APRI = true;
                 }
             }
-
         });
 
         //ティラノプレイヤーを使ってるなら
         if (typeof TyranoPlayer == "function") {
             this.tmp.ready_audio = true;
-        }
-        else if ($.isNWJS()) {
+        } else if ($.isNWJS()) {
             this.tmp.ready_audio = true;
         }
 
         //audio contextを設定　１回のみ実行
-        var AudioContext = window.AudioContext // Default
-            || window.webkitAudioContext // Safari and old versions of Chrome
-            || false;
+        var AudioContext =
+            window.AudioContext || // Default
+            window.webkitAudioContext || // Safari and old versions of Chrome
+            false;
 
         if (AudioContext) {
             this.tmp.audio_context = new AudioContext();
         }
-
-
 
         //フラッシュの設定
         try {
@@ -421,16 +385,13 @@ tyrano.plugin.kag = {
 
             }
             */
-
         } catch (e) {
             console.log(e);
         }
-
     },
 
     //ローカルにアップデート用のファイルがある場合は、確認する
-    checkUpdate: function(call_back) {
-
+    checkUpdate: function (call_back) {
         //NWJS環境以外では、アップデート不可
         if (!$.isNWJS() && !$.isElectron()) {
             call_back();
@@ -449,31 +410,27 @@ tyrano.plugin.kag = {
         patch_path = patch_path + "/" + this.kag.config.projectID + ".tpatch";
 
         this.applyPatch(patch_path, "true", call_back);
-
     },
 
     //パッチを反映します。
-    applyPatch: function(patch_path, flag_reload, call_back) {
-
+    applyPatch: function (patch_path, flag_reload, call_back) {
         //アップデートファイルの存在チェック
-        var fs = require('fs');
+        var fs = require("fs");
 
         if (!fs.existsSync(patch_path)) {
             call_back();
             return;
         }
 
-        var fse = require('fs-extra');
-        var _path = require('path');
+        var fse = require("fs-extra");
+        var _path = require("path");
         //リロードの場合は、アップデート不要
 
         var unzip_path = $.getUnzipPath();
 
-
         //asar化している場合は上書きできない
         if (unzip_path == "asar") {
-
-            const asar = require('asar');
+            const asar = require("asar");
 
             let path = __dirname;
 
@@ -482,18 +439,17 @@ tyrano.plugin.kag = {
             let out_path = $.localFilePath();
 
             if (process.platform == "darwin") {
-
-                alert("パッチを適応するゲーム実行ファイル（.app）の場所を選択してください。");
+                alert(
+                    "パッチを適応するゲーム実行ファイル（.app）の場所を選択してください。",
+                );
 
                 //実行パスを選択させる
-                let dialog = require('electron').remote.dialog;
+                let dialog = require("electron").remote.dialog;
 
                 let filenames = dialog.showOpenDialogSync(null, {
-                    properties: ['openFile'],
+                    properties: ["openFile"],
                     title: "パッチを適応するゲームの実行ファイル（app）を選択してください。",
-                    filters: [
-                        { name: '', extensions: ["app"] }
-                    ]
+                    filters: [{ name: "", extensions: ["app"] }],
                 });
 
                 if (typeof filenames == "undefined") {
@@ -504,7 +460,6 @@ tyrano.plugin.kag = {
 
                 path = filenames[0] + "/Contents/Resources/app.asar";
                 out_path = out_path + "/";
-
             } else {
                 out_path = out_path + "/";
             }
@@ -512,11 +467,14 @@ tyrano.plugin.kag = {
             fse.mkdirSync(_path.resolve(out_path + "/update_tmp"));
 
             (async () => {
-                await asar.extractAll(_path.resolve(path), _path.resolve(out_path + "/update_tmp/"));
+                await asar.extractAll(
+                    _path.resolve(path),
+                    _path.resolve(out_path + "/update_tmp/"),
+                );
             })();
 
             //ファイル全部コピーする
-            var AdmZip = require('adm-zip');
+            var AdmZip = require("adm-zip");
 
             // reading archives  ファイルを上書きしている。
             var zip = new AdmZip(patch_path);
@@ -529,28 +487,27 @@ tyrano.plugin.kag = {
             const dest = _path.resolve(path);
 
             (async () => {
-
                 await asar.createPackage(src, dest);
 
-                $.alert("パッチを適応しました。再度、起動してください。", function() {
-                    //パッチの削除。
-                    fse.removeSync(_path.resolve(patch_path));
+                $.alert(
+                    "パッチを適応しました。再度、起動してください。",
+                    function () {
+                        //パッチの削除。
+                        fse.removeSync(_path.resolve(patch_path));
 
-                    //作業ディレクトリ削除
-                    fse.removeSync(_path.resolve(out_path + "update_tmp"));
+                        //作業ディレクトリ削除
+                        fse.removeSync(_path.resolve(out_path + "update_tmp"));
 
-                    window.close();
-                });
-
+                        window.close();
+                    },
+                );
             })();
 
             return;
-
         } else {
+            var AdmZip = require("adm-zip");
 
-            var AdmZip = require('adm-zip');
-
-            var path = require('path');
+            var path = require("path");
             var abspath = path.resolve("./");
 
             // reading archives
@@ -564,7 +521,7 @@ tyrano.plugin.kag = {
             //パッチの削除。
             fse.removeSync(patch_path);
 
-            $.alert("パッチを適応しました。再起動します。", function() {
+            $.alert("パッチを適応しました。再起動します。", function () {
                 location.reload();
             });
 
@@ -577,14 +534,11 @@ tyrano.plugin.kag = {
                 call_back();
             }
             */
-
         }
-
     },
 
     //スクリプトを解釈して実行する
-    evalScript: function(str) {
-
+    evalScript: function (str) {
         var TG = this;
 
         var f = this.stat.f;
@@ -605,73 +559,66 @@ tyrano.plugin.kag = {
         if (this.kag.is_studio) {
             this.kag.studio.notifyChangeVariable();
         }
-
     },
 
     //式を評価して値を返却します
-    embScript: function(str, preexp) {
-
+    embScript: function (str, preexp) {
         try {
-
             var f = this.stat.f;
             var sf = this.variable.sf;
             var tf = this.variable.tf;
             var mp = this.stat.mp;
 
             return eval(str);
-
         } catch (e) {
             return undefined;
         }
-
     },
 
     //システム変数を保存する
-    saveSystemVariable: function() {
-
-        $.setStorage(this.kag.config.projectID + "_sf", this.variable.sf, this.kag.config.configSave);
-
+    saveSystemVariable: function () {
+        $.setStorage(
+            this.kag.config.projectID + "_sf",
+            this.variable.sf,
+            this.kag.config.configSave,
+        );
     },
 
     //すべての変数クリア
-    clearVariable: function() {
-
+    clearVariable: function () {
         this.stat.f = {}; //ゲーム変数
         this.variable.sf = {}; //システム変数
 
         //添付のシステムだけは残す
         this.clearTmpVariable();
         this.saveSystemVariable();
-
     },
 
     //添付変数の削除
-    clearTmpVariable: function() {
+    clearTmpVariable: function () {
         var tmp_sys = this.kag.variable.tf["system"];
         this.kag.variable.tf = {}; //一時変数かな
         this.kag.variable.tf["system"] = tmp_sys;
     },
 
     ///スタック管理用
-    pushStack: function(name, flag) {
+    pushStack: function (name, flag) {
         this.stat.stack[name].push(flag);
     },
 
-    popStack: function(name) {
+    popStack: function (name) {
         return this.stat.stack[name].pop();
     },
 
-    getStack: function(name) {
+    getStack: function (name) {
         return this.stat.stack[name][this.stat.stack[name].length - 1];
     },
 
-    setStack: function(name, flag) {
+    setStack: function (name, flag) {
         this.stat.stack[name][this.stat.stack[name].length - 1] = flag;
     },
 
-
-    endStorage: function() {
-
+    endStorage: function () {
         //ファイルの終端に来た時、スタックがたまってたらそこに戻らせる
         var pm = this.kag.getStack("call"); //最新のコールスタックを取得
         //呼び出し元に戻る
@@ -682,15 +629,13 @@ tyrano.plugin.kag = {
             return false;
         }
 
-        this.kag.popStack("call");//スタックを奪い取る
+        this.kag.popStack("call"); //スタックを奪い取る
         this.kag.ftag.nextOrderWithIndex(pm.index, pm.storage);
-
     },
 
     /////////////ゲーム初期化////////////
 
-    init_game: function() {
-
+    init_game: function () {
         var that = this;
 
         //kag.parser 追加
@@ -702,7 +647,7 @@ tyrano.plugin.kag = {
         this.ftag.kag = that;
         this.ftag.init();
 
-        //layer 追加　
+        //layer 追加
         this.layer = object(tyrano.plugin.kag.layer);
         this.layer.kag = that;
         this.layer.init();
@@ -734,18 +679,17 @@ tyrano.plugin.kag = {
 
         //セーブデータ認証用のKey確認（ローカルストレージ）
         if ($.isElectron() && that.kag.config.configSave == "file") {
-
             //PC
             if (process.execPath.indexOf("var/folders") != -1) {
                 that.save_key_id = that.kag.config.projectID + "_save_key";
             } else {
-                that.save_key_id = $.getExePath() + "_" + that.kag.config.projectID;
+                that.save_key_id =
+                    $.getExePath() + "_" + that.kag.config.projectID;
             }
 
             if (localStorage.getItem(that.save_key_id)) {
                 that.save_key_val = localStorage.getItem(that.save_key_id);
             } else {
-
                 //認証キーの書き出し
                 that.save_key_val = $.makeSaveKey();
                 localStorage.setItem(that.save_key_id, that.save_key_val);
@@ -754,71 +698,88 @@ tyrano.plugin.kag = {
                 var tmp_array = that.menu.getSaveData();
                 //ハッシュを上書き
                 tmp_array["hash"] = that.save_key_val;
-                $.setStorage(that.kag.config.projectID + "_tyrano_data", tmp_array, that.kag.config.configSave);
-
+                $.setStorage(
+                    that.kag.config.projectID + "_tyrano_data",
+                    tmp_array,
+                    that.kag.config.configSave,
+                );
             }
 
             //ハッシュに差分があったら、警告を表示して上書きするか確認。
             var tmp_array = that.menu.getSaveData();
 
             if (tmp_array["hash"] != that.save_key_val) {
-
                 alert($.lang("save_file_violation_1"));
 
                 if (that.kag.config.configSaveOverwrite == "true") {
-
                     if (confirm($.lang("save_file_violation_2"))) {
-
                         tmp_array["hash"] = that.save_key_val;
-                        $.setStorage(that.kag.config.projectID + "_tyrano_data", tmp_array, that.kag.config.configSave);
-
+                        $.setStorage(
+                            that.kag.config.projectID + "_tyrano_data",
+                            tmp_array,
+                            that.kag.config.configSave,
+                        );
                     } else {
-
                         alert($.lang("save_file_violation_3"));
                         return false;
-
                     }
-
                 } else {
                     alert($.lang("save_file_violation_3"));
                     return false;
                 }
-
             }
-
-
         }
 
-
         //システム変数の初期化
-        var tmpsf = $.getStorage(this.kag.config.projectID + "_sf", that.config.configSave);
+        var tmpsf = $.getStorage(
+            this.kag.config.projectID + "_sf",
+            that.config.configSave,
+        );
 
         if (tmpsf == null) {
             this.variable.sf = {};
         } else {
             this.variable.sf = JSON.parse(tmpsf);
-
         }
-
 
         /////////////システムで使用する変数の初期化設定////////////////////
         //コンフィグ
 
         //システムが永続させたい変数はすぐにコンフィグに反映
-        if (typeof that.variable.sf._system_config_bgm_volume !== "undefined") that.config["defaultBgmVolume"] = String(that.variable.sf._system_config_bgm_volume);
-        if (typeof that.variable.sf._system_config_se_volume !== "undefined") that.config["defaultSeVolume"] = String(that.variable.sf._system_config_se_volume);
+        if (typeof that.variable.sf._system_config_bgm_volume !== "undefined")
+            that.config["defaultBgmVolume"] = String(
+                that.variable.sf._system_config_bgm_volume,
+            );
+        if (typeof that.variable.sf._system_config_se_volume !== "undefined")
+            that.config["defaultSeVolume"] = String(
+                that.variable.sf._system_config_se_volume,
+            );
         //if(that.variable.sf._system_config_bgm_volume) that.config["defaultBgmVolume"] = that.variable.sf._system_config_bgm_volume;
         //if(that.variable.sf._system_config_se_volume) that.config["defaultSeVolume"] = that.variable.sf._system_config_se_volume;
-        if (that.variable.sf._config_ch_speed) that.config["chSpeed"] = that.variable.sf._config_ch_speed;
-        if (typeof that.variable.sf._system_config_auto_speed !== "undefined") that.config["autoSpeed"] = that.variable.sf._system_config_auto_speed;
-        if (that.variable.sf._system_config_auto_click) that.config["autoClickStop"] = that.variable.sf._system_config_auto_click_stop;
-        if (that.variable.sf._system_config_already_read_text_color) that.config["alreadyReadTextColor"] = that.variable.sf._system_config_already_read_text_color;
-        if (typeof that.variable.sf._system_config_unread_text_skip != "undefined") {
-            that.config["unReadTextSkip"] = that.variable.sf._system_config_unread_text_skip;
+        if (that.variable.sf._config_ch_speed)
+            that.config["chSpeed"] = that.variable.sf._config_ch_speed;
+        if (typeof that.variable.sf._system_config_auto_speed !== "undefined")
+            that.config["autoSpeed"] =
+                that.variable.sf._system_config_auto_speed;
+        if (that.variable.sf._system_config_auto_click)
+            that.config["autoClickStop"] =
+                that.variable.sf._system_config_auto_click_stop;
+        if (that.variable.sf._system_config_already_read_text_color)
+            that.config["alreadyReadTextColor"] =
+                that.variable.sf._system_config_already_read_text_color;
+        if (
+            typeof that.variable.sf._system_config_unread_text_skip !=
+            "undefined"
+        ) {
+            that.config["unReadTextSkip"] =
+                that.variable.sf._system_config_unread_text_skip;
         }
 
         //自動セーブのデータがあるかどうか
-        var auto_save_data = $.getStorage(this.kag.config.projectID + "_tyrano_auto_save", this.kag.config.configSave);
+        var auto_save_data = $.getStorage(
+            this.kag.config.projectID + "_tyrano_auto_save",
+            this.kag.config.configSave,
+        );
 
         this.variable.sf["system"] = {};
 
@@ -833,11 +794,18 @@ tyrano.plugin.kag = {
         this.variable.tf["system"]["backlog"] = [];
 
         //コンフィグボタン追加
-        var button_menu_obj = $("<div class='button_menu' style='z-index:100000000'><img src='./tyrano/images/system/" + $.novel("file_button_menu") + "'  /></div>");
+        var button_menu_obj = $(
+            "<div class='button_menu' style='z-index:100000000'><img src='./tyrano/images/system/" +
+                $.novel("file_button_menu") +
+                "'  /></div>",
+        );
 
         //コンフィグボタンの位置を指定する
 
-        if (this.kag.config.configLeft != "-1" && this.kag.config.configTop != "-1") {
+        if (
+            this.kag.config.configLeft != "-1" &&
+            this.kag.config.configTop != "-1"
+        ) {
             button_menu_obj.css("left", parseInt(this.kag.config.configLeft));
             button_menu_obj.css("top", parseInt(this.kag.config.configTop));
         } else {
@@ -845,7 +813,7 @@ tyrano.plugin.kag = {
             button_menu_obj.css("top", this.config.scHeight - 70);
         }
 
-        button_menu_obj.click(function() {
+        button_menu_obj.click(function () {
             that.menu.showMenu();
         });
 
@@ -859,24 +827,23 @@ tyrano.plugin.kag = {
 
         $("." + this.kag.define.BASE_DIV_NAME).append(button_menu_obj);
 
-
         //センタリングの調整
-        if (this.kag.config["ScreenCentering"] && this.kag.config["ScreenCentering"] == "false") {
-
+        if (
+            this.kag.config["ScreenCentering"] &&
+            this.kag.config["ScreenCentering"] == "false"
+        ) {
             //センタリングをキャンセルする
             $(".tyrano_base").css("transform-origin", "0 0");
             $(".tyrano_base").css({
-                margin: 0
+                margin: 0,
             });
-
         } else {
             //指定がない or yes なら こっち
             //$(".tyrano_base").css("transform-origin","50 50");
             $(".tyrano_base").css("transform-origin", "0 0");
             $(".tyrano_base").css({
-                margin: 0
+                margin: 0,
             });
-
         }
 
         //センタリングが有効な場合のみ
@@ -888,7 +855,6 @@ tyrano.plugin.kag = {
 
         //スマホの場合
         if ($.userenv() != "pc") {
-
             //absolute指定
             $("#tyrano_base").css("position", "absolute");
 
@@ -897,9 +863,10 @@ tyrano.plugin.kag = {
             }
             // スクロール禁止(SP) vchatのときは例外
             if (this.kag.config["vchat"] != "true") {
-                document.addEventListener('touchmove', noScroll, { passive: false });
+                document.addEventListener("touchmove", noScroll, {
+                    passive: false,
+                });
             }
-
         }
 
         //tyranoの大本部分の調整
@@ -907,7 +874,6 @@ tyrano.plugin.kag = {
 
         that.tmp.angle = $.getAngle();
         that.tmp.largerWidth = $.getLargeScreenWidth();
-
 
         //スマホの場合は、実施。 PCの場合でも画面を一致させる処理→すべての画面フィットさせる仕様に変更
         //       if($.userenv() !="pc"){
@@ -917,28 +883,31 @@ tyrano.plugin.kag = {
         //繰り返し実行用の関数
         var timerId = null;
 
-        $(window).bind("load orientationchange resize", function() {
-
+        $(window).bind("load orientationchange resize", function () {
             that.tmp.angle = $.getAngle();
 
             //リサイズコールの仕組み
             if (that.tmp.largerWidth != $.getLargeScreenWidth()) {
-
                 //resizecallが設定されていれば呼び出す。
                 if (that.stat.resizecall["storage"] != "") {
-
                     //画面変化中にリサイズするとすぐに反映されない仕組みを実装。
                     //クリックできない状態のときは実行しない
-                    if (that.kag.layer.layer_event.css("display") == "none" && that.kag.stat.is_strong_stop != true) {
-                        timerId = setTimeout(function() {
+                    if (
+                        that.kag.layer.layer_event.css("display") == "none" &&
+                        that.kag.stat.is_strong_stop != true
+                    ) {
+                        timerId = setTimeout(function () {
                             $(window).trigger("resize");
                         }, 1000);
                         return false;
                     }
 
                     //テキストが流れているときとwait中は実行しない
-                    if (that.kag.stat.is_adding_text == true || that.kag.stat.is_wait == true) {
-                        timerId = setTimeout(function() {
+                    if (
+                        that.kag.stat.is_adding_text == true ||
+                        that.kag.stat.is_wait == true
+                    ) {
+                        timerId = setTimeout(function () {
                             $(window).trigger("resize");
                         }, 1000);
                         return false;
@@ -980,29 +949,30 @@ tyrano.plugin.kag = {
                         return false;
                     }
                     */
-
-
                 }
-
             }
 
             that.tmp.largerWidth = $.getLargeScreenWidth();
 
             ////リサイズコールここまで
 
-
             if (Math.abs(window.orientation) === 90) {
                 window.scrollTo(0, 1);
-                that.tyrano.base.fitBaseSize(that.config.scWidth, that.config.scHeight);
-            }
-            else {
-                if (window.pageYOffset === 0) { window.scrollTo(0, 1); }
-                that.tyrano.base.fitBaseSize(that.config.scWidth, that.config.scHeight);
-
+                that.tyrano.base.fitBaseSize(
+                    that.config.scWidth,
+                    that.config.scHeight,
+                );
+            } else {
+                if (window.pageYOffset === 0) {
+                    window.scrollTo(0, 1);
+                }
+                that.tyrano.base.fitBaseSize(
+                    that.config.scWidth,
+                    that.config.scHeight,
+                );
             }
         });
         //        }
-
 
         this.layer.addLayer("base");
 
@@ -1025,7 +995,9 @@ tyrano.plugin.kag = {
         this.layer.appendObj("message0", "fore", j_message);
 
         //メッセージ表示領域
-        var j_message_inner = $("<div class='message_inner' style='z-index:1001'></div>");
+        var j_message_inner = $(
+            "<div class='message_inner' style='z-index:1001'></div>",
+        );
 
         //禁則処理
         if (this.config.WordBreak == "false") {
@@ -1033,7 +1005,11 @@ tyrano.plugin.kag = {
         }
 
         //１行目の上に余裕を持たせる。rubyカクつき対策
-        $.insertRule(".message_inner p{ padding-top:" + this.kag.config.defaultLineSpacing + "px;}");
+        $.insertRule(
+            ".message_inner p{ padding-top:" +
+                this.kag.config.defaultLineSpacing +
+                "px;}",
+        );
 
         this.layer.appendObj("message0", "fore", j_message_inner);
 
@@ -1043,7 +1019,6 @@ tyrano.plugin.kag = {
         var num_message_layer = parseInt(this.config.numMessageLayers);
 
         for (var i = 1; i < num_message_layer; i++) {
-
             var message_layer_name = "message" + i;
 
             this.layer.addLayer(message_layer_name);
@@ -1056,7 +1031,6 @@ tyrano.plugin.kag = {
             var j_message_inner1 = j_message_inner.clone(false);
 
             this.layer.appendObj(message_layer_name, "fore", j_message_inner1);
-
         }
 
         //メッセージレイヤの大きさをリフレッシュする命令
@@ -1066,25 +1040,30 @@ tyrano.plugin.kag = {
         var fore_layer_num = parseInt(this.config.numCharacterLayers);
         for (var i = 0; i < fore_layer_num; i++) {
             this.layer.addLayer("" + i);
-            this.layer.getLayer("" + i, "fore")
+            this.layer
+                .getLayer("" + i, "fore")
                 .css("display", "none")
                 .css("z-index", 10 + i); //デフォルト非表示　前景レイヤ
 
-            this.layer.getLayer("" + i, "back")
+            this.layer
+                .getLayer("" + i, "back")
                 .css("display", "none")
                 .css("z-index", 10 + i); //デフォルト非表示　前景レイヤ
-
         }
 
         //デフォルトフォントの設定
-        this.stat.default_font.color = $.convertColor(this.kag.config.defaultChColor);
-        this.stat.default_font.bold = $.convertBold(this.kag.config.defaultBold);
+        this.stat.default_font.color = $.convertColor(
+            this.kag.config.defaultChColor,
+        );
+        this.stat.default_font.bold = $.convertBold(
+            this.kag.config.defaultBold,
+        );
         this.stat.default_font.size = this.kag.config.defaultFontSize;
         this.stat.default_font.face = this.kag.config.userFace;
 
         this.stat.default_font.effect = this.kag.config.defaultChEffect;
-        this.stat.default_font.effect_speed = this.kag.config.defaultChEffectSpeed;
-
+        this.stat.default_font.effect_speed =
+            this.kag.config.defaultChEffectSpeed;
 
         //文字のアンチエイリアス効果
         var smooth = this.kag.config.defaultAntialiased; //アンチエイリアス効果
@@ -1094,24 +1073,34 @@ tyrano.plugin.kag = {
         } else if (smooth == "0") {
             $(".tyrano_base").css("-webkit-font-smoothing", "none");
         } else {
-            $(".tyrano_base").css("-webkit-font-smoothing", "subpixel-antialiased");
+            $(".tyrano_base").css(
+                "-webkit-font-smoothing",
+                "subpixel-antialiased",
+            );
         }
 
         //文字の影
         if (this.kag.config.defaultShadow == "true") {
-            this.stat.default_font.shadow = $.convertColor(this.kag.config.defaultShadowColor);
+            this.stat.default_font.shadow = $.convertColor(
+                this.kag.config.defaultShadowColor,
+            );
         }
 
         //文字の縁
         if (this.kag.config.defaultEdge == "true") {
-            this.stat.default_font.edge = $.convertColor(this.kag.config.defaultEdgeColor);
+            this.stat.default_font.edge = $.convertColor(
+                this.kag.config.defaultEdgeColor,
+            );
         }
-
 
         this.stat.vertical = this.kag.config.vertical;
 
         //デフォルトフォントの状態を設定
-        this.kag.stat.font = $.extend(true, $.cloneObject(this.kag.stat.font), this.stat.default_font);
+        this.kag.stat.font = $.extend(
+            true,
+            $.cloneObject(this.kag.stat.font),
+            this.stat.default_font,
+        );
 
         //タイトルの設定
         this.setTitle(this.config["System.title"]);
@@ -1124,20 +1113,15 @@ tyrano.plugin.kag = {
             this.tmp.ready_audio = true;
         }
 
-
         //index.htmlでのvchat定義を確認。index.htmlでコンフィグを調整したい。
-        $("[tyrano='config']").each(function() {
-
+        $("[tyrano='config']").each(function () {
             var key = $(this).attr("key");
             var val = $(this).val();
             that.kag.config[key] = "" + val;
-
         });
-
 
         //ビジュアルチャット形式/////////////////
         if (this.kag.config["vchat"] && this.kag.config["vchat"] == "true") {
-
             this.kag.config["ScreenCentering"] = "false";
             this.kag.config["ScreenRatio"] = "fix";
 
@@ -1160,7 +1144,6 @@ tyrano.plugin.kag = {
             this.kag.config.vertical = "false";
             this.stat.vertical = "false";
 
-
             this.kag.ftag.startTag("vchat_in", {});
 
             //テキスト部分にクリックイベントを挿入
@@ -1168,32 +1151,39 @@ tyrano.plugin.kag = {
                 $(".layer_event_click").trigger("click");
                 e.preventDefault();
             });
-
         }
 
         //vchat形式で便利なメニューの表示。
-        if (this.kag.config["vchatMenuVisible"] && this.kag.config["vchatMenuVisible"] == "true") {
-
+        if (
+            this.kag.config["vchatMenuVisible"] &&
+            this.kag.config["vchatMenuVisible"] == "true"
+        ) {
             //コンフィグを表示する。
-            setTimeout(function() {
-
-                (function() {
-
+            setTimeout(function () {
+                (function () {
                     var player_back_cnt = 0;
-                    var j_menu_button = $("<div id='player_menu_button' class='player_menu_area' style='display:none;opacity:0.6;border-radius:5px;padding:10px;margin:10px;cursor:pointer;position:absolute;left:0px;top:0px;background-color:white;font-size:2em'><span style='color:#6495ED'>メニュー</span></div>");
-                    var j_menu_area = $("<div style='display:none;position:absolute;left:10px;top:10px;font-size:2em'></div>");
+                    var j_menu_button = $(
+                        "<div id='player_menu_button' class='player_menu_area' style='display:none;opacity:0.6;border-radius:5px;padding:10px;margin:10px;cursor:pointer;position:absolute;left:0px;top:0px;background-color:white;font-size:2em'><span style='color:#6495ED'>メニュー</span></div>",
+                    );
+                    var j_menu_area = $(
+                        "<div style='display:none;position:absolute;left:10px;top:10px;font-size:2em'></div>",
+                    );
 
-                    var j_end_button = $("<div class='player_menu_area' id='player_end_button' style='opacity:0.6;border-radius:5px;padding:10px;margin:10px 10px 10px 10px;cursor:pointer;left:0px;top:0px;background-color:white;'><span style='color:#6495ED'>タイトルへ</span></div>");
-                    var j_auto_button = $("<div class='player_menu_area' id='player_auto_button' style='opacity:0.6;border-radius:5px;padding:10px;margin:10px 10px 10px 10px;cursor:pointer;left:0px;top:0px;background-color:white;'><span style='color:#6495ED'>オート</span></div>");
-                    var j_skip_button = $("<div class='player_menu_area' id='player_skip_button' style='opacity:0.6;border-radius:5px;padding:10px;margin:10px 10px 10px 10px;cursor:pointer;left:0px;top:0px;background-color:white;'><span style='color:#6495ED'>スキップ</span></div>");
+                    var j_end_button = $(
+                        "<div class='player_menu_area' id='player_end_button' style='opacity:0.6;border-radius:5px;padding:10px;margin:10px 10px 10px 10px;cursor:pointer;left:0px;top:0px;background-color:white;'><span style='color:#6495ED'>タイトルへ</span></div>",
+                    );
+                    var j_auto_button = $(
+                        "<div class='player_menu_area' id='player_auto_button' style='opacity:0.6;border-radius:5px;padding:10px;margin:10px 10px 10px 10px;cursor:pointer;left:0px;top:0px;background-color:white;'><span style='color:#6495ED'>オート</span></div>",
+                    );
+                    var j_skip_button = $(
+                        "<div class='player_menu_area' id='player_skip_button' style='opacity:0.6;border-radius:5px;padding:10px;margin:10px 10px 10px 10px;cursor:pointer;left:0px;top:0px;background-color:white;'><span style='color:#6495ED'>スキップ</span></div>",
+                    );
 
                     j_menu_area.append(j_end_button);
                     j_menu_area.append(j_auto_button);
                     j_menu_area.append(j_skip_button);
 
-
                     function hide_menu() {
-
                         j_menu_area.hide();
 
                         /*
@@ -1204,10 +1194,9 @@ tyrano.plugin.kag = {
 
                         j_menu_button.hide();
                         player_back_cnt = 0;
-
                     }
 
-                    j_menu_button.click(function(e) {
+                    j_menu_button.click(function (e) {
                         j_menu_button.hide();
                         j_menu_area.show();
 
@@ -1216,73 +1205,55 @@ tyrano.plugin.kag = {
                         j_auto_button.show();
                         j_skip_button.show();
                         */
-
                     });
 
-                    j_end_button.click(function(e) {
-
+                    j_end_button.click(function (e) {
                         //アンドロイドとiOSで処理分け
                         hide_menu();
                         location.reload();
                         e.stopPropagation();
-
                     });
 
-                    j_auto_button.click(function(e) {
-
+                    j_auto_button.click(function (e) {
                         hide_menu();
                         TYRANO.kag.ftag.startTag("autostart", {});
                         e.stopPropagation();
-
                     });
 
-                    j_skip_button.click(function(e) {
-
+                    j_skip_button.click(function (e) {
                         hide_menu();
                         TYRANO.kag.ftag.startTag("skipstart", {});
                         e.stopPropagation();
-
                     });
 
                     $("body").append(j_menu_button);
 
                     $("body").append(j_menu_area);
 
-                    $("#tyrano_base").on("click.player", function() {
-
+                    $("#tyrano_base").on("click.player", function () {
                         if (player_back_cnt > 8) {
                             hide_menu();
                         }
 
                         player_back_cnt = 0;
-
                     });
 
                     //10秒操作がなかったら、ボタンを表示する。
-                    setInterval(function() {
+                    setInterval(function () {
                         if (player_back_cnt == 9) {
                             j_menu_button.show();
                         } else if (player_back_cnt > 3) {
-
                         }
 
                         player_back_cnt++;
-
                     }, 1000);
-
                 })();
 
-
-                $("#tyrano_base").on("click.player", function() {
+                $("#tyrano_base").on("click.player", function () {
                     player_back_cnt = 0;
                 });
-
-
             }, 1000);
-
-
         }
-
 
         /////////////////////////////
 
@@ -1292,14 +1263,11 @@ tyrano.plugin.kag = {
             first_scenario_file = $("#first_scenario_file").val();
         }
 
-
         //追加分のプロジェクトファイルの読み込み
         var array_scripts = [];
 
         if (this.kag.config["use3D"] == "true") {
-
             array_scripts = [
-
                 "./tyrano/libs/three/three.js",
 
                 "./tyrano/libs/three/loader/GLTFLoader.js",
@@ -1309,25 +1277,17 @@ tyrano.plugin.kag = {
 
                 "./tyrano/libs/three/controls/OrbitControls.js",
                 "./tyrano/libs/three/classes/ThreeModel.js",
-
             ];
-
         }
 
-
         $.getMultiScripts(array_scripts, () => {
-
             //シナリオファイルの読み込み。parser から、シナリオを解析して、タグ管理画面を作る。
-            this.loadScenario(first_scenario_file, function(array_tag) {
-
+            this.loadScenario(first_scenario_file, function (array_tag) {
                 that.ftag.buildTag(array_tag);
                 //最初にレイヤをコピーしておく、、、その必要はない！コメント化20122119
                 //that.kag.ftag.startTag("backlay",{});
-
             });
-
         });
-
 
         //ティラノライダーからの通知の場合、発生させる
         //that.rider.complete(this);
@@ -1335,14 +1295,10 @@ tyrano.plugin.kag = {
         if (this.kag.is_studio) {
             that.studio.complete(this);
         }
-
     },
 
-
-
     //BackLogを格納します
-    pushBackLog: function(str, type) {
-
+    pushBackLog: function (str, type) {
         //バックログを記録するか否か
         if (this.stat.log_write == false) {
             return;
@@ -1361,11 +1317,13 @@ tyrano.plugin.kag = {
         }
 
         if (type == "join") {
-
             var index = this.variable.tf.system.backlog.length - 1;
-            if (index >= 0) { //配列が存在しない場合はpushだ
+            if (index >= 0) {
+                //配列が存在しない場合はpushだ
                 var tmp = this.variable.tf["system"]["backlog"][index];
-                this.variable.tf["system"]["backlog"][this.variable.tf.system.backlog.length - 1] = tmp + str;
+                this.variable.tf["system"]["backlog"][
+                    this.variable.tf.system.backlog.length - 1
+                ] = tmp + str;
             } else {
                 this.variable.tf["system"]["backlog"].push(str);
             }
@@ -1374,57 +1332,53 @@ tyrano.plugin.kag = {
         }
 
         //セーブ用のテキストファイルを保存
-        this.stat.current_save_str = this.variable.tf["system"]["backlog"][this.variable.tf.system.backlog.length - 1];
+        this.stat.current_save_str =
+            this.variable.tf["system"]["backlog"][
+                this.variable.tf.system.backlog.length - 1
+            ];
 
         //上限を超えたらFILO で処理
         if (max_back_log < this.variable.tf["system"]["backlog"].length) {
             this.variable.tf["system"]["backlog"].shift();
         }
-
     },
 
     //タイトル名を設定します
-    setTitle: function(title) {
-
+    setTitle: function (title) {
         //タイトルの設定
         this.stat.title = title;
         document.title = title;
-
     },
 
-    pushAnimStack: function() {
+    pushAnimStack: function () {
         this.kag.tmp.num_anim++;
     },
 
-    backTitle: function() {
-
+    backTitle: function () {
         if ("appJsInterface" in window) {
             appJsInterface.finishGame();
         } else {
-
             if (typeof TyranoPlayer == "function") {
                 //iphone
                 //location.href = "tyranoplayer-back://endgame";
                 webkit.messageHandlers.backHandler.postMessage("endgame");
-
             } else {
                 //その他
-                $.confirm($.lang("go_title"),
-                    function() {
+                $.confirm(
+                    $.lang("go_title"),
+                    function () {
                         location.href = "./index.html";
                     },
-                    function() {
+                    function () {
                         return false;
-                    }
+                    },
                 );
             }
-
         }
-
     },
 
     //スキップ中に演出をカットする
-    cutTimeWithSkip: function(time) {
+    cutTimeWithSkip: function (time) {
         if (this.kag.stat.is_skip == true) {
             if (this.kag.config.skipEffectIgnore == "true") {
                 //瞬時に終わるように設定
@@ -1435,27 +1389,21 @@ tyrano.plugin.kag = {
     },
 
     //スマホブラウザ向け、音楽再生設定
-    readyAudio: function() {
-
+    readyAudio: function () {
         this.tmp.ready_audio = true;
 
         if ($.isNeedClickAudio()) {
-
             var audio_obj = new Howl({
                 src: "./tyrano/audio/silent.mp3",
-                volume: 0.1
+                volume: 0.1,
             });
 
             audio_obj.play();
-
         }
-
-
     },
 
     //ゲームのカーソルを指定する
-    setCursor: function(cursor) {
-
+    setCursor: function (cursor) {
         this.stat.current_cursor = cursor;
 
         if (cursor === "default") {
@@ -1464,14 +1412,14 @@ tyrano.plugin.kag = {
         } else {
             $("body").css("cursor", "url(./data/image/" + cursor + "),default");
         }
-
     },
 
     //吹き出しのスタイルをアップデートする
-    updateFuki: function(chara_name, opt = {}) {
-
+    updateFuki: function (chara_name, opt = {}) {
         if (!$(".tyrano_base").find("#tmp_style").get(0)) {
-            $(".tyrano_base").prepend("<style id='tmp_style' type='text/css'></style>");
+            $(".tyrano_base").prepend(
+                "<style id='tmp_style' type='text/css'></style>",
+            );
         }
 
         var msg_inner_layer = this.kag.getMessageInnerLayer();
@@ -1498,15 +1446,11 @@ tyrano.plugin.kag = {
         let style_text_before = "";
 
         if (fuki_chara.sippo == "top" || fuki_chara.sippo == "bottom") {
-
             sippo_left = opt.sippo_left + parseInt(fuki_chara.sippo_left);
             style_text = "left:" + sippo_left + "px;";
-
         } else {
-
             sippo_left = opt.sippo_left + parseInt(fuki_chara.sippo_top);
             style_text = "top:" + sippo_left + "px;";
-
         }
 
         style_text_key = "";
@@ -1514,27 +1458,18 @@ tyrano.plugin.kag = {
         //トップ指定の場合
 
         if (fuki_chara.sippo == "top") {
-
             style_text += "bottom:100%;";
             style_text_key = "bottom";
-
         } else if (fuki_chara.sippo == "bottom") {
-
             style_text += "top:100%;";
             style_text_key = "top";
-
         } else if (fuki_chara.sippo == "left") {
-
             style_text += "right:100%;";
             style_text_key = "right";
-
         } else if (fuki_chara.sippo == "right") {
-
             style_text += "left:100%;";
             style_text_key = "left";
-
         }
-
 
         style_text_after = "border-bottom-color:";
 
@@ -1554,12 +1489,11 @@ tyrano.plugin.kag = {
         let str_css2 = "";
 
         if (fuki_chara.sippo == "top" || fuki_chara.sippo == "bottom") {
-
             str_css2 = `
 
 			.fuki_box:after{
 
-			    border-color: ${msg_outer_layer.css("border-color").replace(')', ',0)')};
+			    border-color: ${msg_outer_layer.css("border-color").replace(")", ",0)")};
 			    border-top-width:${fuki_chara["sippo_height"]}px;
 			    border-bottom-width:${fuki_chara["sippo_height"]}px;
 			    border-left-width:${fuki_chara["sippo_width"]}px;
@@ -1571,7 +1505,7 @@ tyrano.plugin.kag = {
 
 			.fuki_box:before{
 
-			    border-color: ${msg_outer_layer.css("border-color").replace(')', ',0)')};
+			    border-color: ${msg_outer_layer.css("border-color").replace(")", ",0)")};
 			    border-top-width:${fuki_chara["sippo_height"] + border_size}px;
 			    border-bottom-width:${fuki_chara["sippo_height"] + border_size}px;
 			    border-left-width:${fuki_chara["sippo_width"] + border_size}px;
@@ -1581,14 +1515,12 @@ tyrano.plugin.kag = {
 			    border-${style_text_key}-color:${msg_outer_layer.css("border-color")};
 
 			}`;
-
         } else {
-
             str_css2 = `
 
 			.fuki_box:after{
 
-			    border-color: ${msg_outer_layer.css("border-color").replace(')', ',0)')};
+			    border-color: ${msg_outer_layer.css("border-color").replace(")", ",0)")};
 			    border-top-width:${fuki_chara["sippo_width"]}px;
 			    border-bottom-width:${fuki_chara["sippo_width"]}px;
 			    border-left-width:${fuki_chara["sippo_height"] - 2}px;
@@ -1600,7 +1532,7 @@ tyrano.plugin.kag = {
 
 			.fuki_box:before{
 
-			    border-color: ${msg_outer_layer.css("border-color").replace(')', ',0)')};
+			    border-color: ${msg_outer_layer.css("border-color").replace(")", ",0)")};
 			    border-top-width:${fuki_chara["sippo_width"] + border_size}px;
 			    border-bottom-width:${fuki_chara["sippo_width"] + border_size}px;
 			    border-left-width:${fuki_chara["sippo_height"] + border_size - 2}px;
@@ -1610,23 +1542,18 @@ tyrano.plugin.kag = {
 			    border-${style_text_key}-color:${msg_outer_layer.css("border-color")};
 
 			}`;
-
         }
 
-
         $("#tmp_style").html(str_css + "\n" + str_css2);
-
     },
 
-    popAnimStack: function() {
-
+    popAnimStack: function () {
         if (this.kag.tmp.num_anim > 0) {
             this.kag.tmp.num_anim--;
         }
 
         //すべてのアニメーションが終了したら、
         if (this.kag.tmp.num_anim <= 0) {
-
             //停止中なら
             if (this.kag.stat.is_wait_anim == true) {
                 this.kag.stat.is_wait_anim = false;
@@ -1634,13 +1561,10 @@ tyrano.plugin.kag = {
                 this.kag.ftag.nextOrder();
             }
         }
-
     },
 
-
     //シナリオファイルの読み込み
-    loadScenario: function(file_name, call_back) {
-
+    loadScenario: function (file_name, call_back) {
         var that = this;
         this.stat.is_strong_stop = true;
 
@@ -1658,9 +1582,7 @@ tyrano.plugin.kag = {
 
         //キャッシュ確認
         if (that.cache_scenario[file_url]) {
-
             if (call_back) {
-
                 var result_obj = that.cache_scenario[file_url];
 
                 var tag_obj = result_obj.array_s;
@@ -1671,13 +1593,9 @@ tyrano.plugin.kag = {
                 that.stat.is_strong_stop = false;
 
                 call_back(tag_obj);
-
             }
-
         } else {
-
-            $.loadText(file_url, function(text_str) {
-
+            $.loadText(file_url, function (text_str) {
                 var result_obj = that.parser.parseScenario(text_str);
                 that.cache_scenario[file_url] = result_obj;
 
@@ -1688,80 +1606,70 @@ tyrano.plugin.kag = {
                 that.stat.map_label = map_label;
                 that.stat.is_strong_stop = false;
 
-
                 if (call_back) {
                     call_back(tag_obj);
                 }
-
             });
-
         }
-
     },
 
-    getMessageInnerLayer: function() {
-
+    getMessageInnerLayer: function () {
         //vchat形式の場合
         if (this.stat.vchat.is_active) {
             var j_msg_inner = $("#vchat_base").find(".current_vchat"); //.find(".vchat-text-inner").html(current_str);
             //j_msg_inner.show();
             return j_msg_inner;
         } else {
-            return this.layer.getLayer(this.stat.current_layer, this.stat.current_page).find(".message_inner");
+            return this.layer
+                .getLayer(this.stat.current_layer, this.stat.current_page)
+                .find(".message_inner");
         }
-
-
     },
 
-    getMessageOuterLayer: function() {
+    getMessageOuterLayer: function () {
         //console.trace();
-        return this.layer.getLayer(this.stat.current_layer, this.stat.current_page).find(".message_outer");
+        return this.layer
+            .getLayer(this.stat.current_layer, this.stat.current_page)
+            .find(".message_outer");
     },
 
-    getMessageCurrentSpan: function() {
-
+    getMessageCurrentSpan: function () {
         //ここでも、
-        var j_obj = this.layer.getLayer(this.stat.current_layer, this.stat.current_page).find(".message_inner").find("p").find(".current_span");
+        var j_obj = this.layer
+            .getLayer(this.stat.current_layer, this.stat.current_page)
+            .find(".message_inner")
+            .find("p")
+            .find(".current_span");
 
         return j_obj;
-
     },
 
     //即座に新しい領域を確保
-    setMessageCurrentSpan: function() {
-
+    setMessageCurrentSpan: function () {
         var jtext = this.getMessageInnerLayer();
 
         //縦書きと横書きで処理が別れる
         if (jtext.find("p").length == 0) {
-
             if (this.stat.vertical == "true") {
                 jtext.append($("<p class='vertical_text'></p>"));
             } else {
                 jtext.append($("<p class=''></p>"));
             }
-
         }
 
         if (jtext.find("p").find(".current_span").length > 0) {
-
             jtext.find("p").find(".current_span").removeClass("current_span");
             this.stat.set_text_span = false;
-
         }
 
         var j_span = $("<span class='current_span'></span>");
 
         jtext.find("p").append(j_span); //縦書きの場合、ここに追加されてないかも
 
-
         return j_span;
-
     },
 
-
-    checkMessage: function(jtext) {
-
+    checkMessage: function (jtext) {
         //新しい領域への切り替え
         if (this.stat.set_text_span == true) {
             jtext.find("p").find(".current_span").removeClass("current_span");
@@ -1772,32 +1680,31 @@ tyrano.plugin.kag = {
         if (jtext.find(".current_span").length == 0) {
             jtext.find("p").append($("<span class='current_span'></span>"));
         }
-
     },
 
     //対象のメッセージエリアにテキストを挿入します。
-    appendMessage: function(jtext, str) {
-
+    appendMessage: function (jtext, str) {
         jtext.find("p").find(".current_span").html(str);
-
     },
 
     //画像のプリロード オンの場合は、ロードが完了するまで次へ行かない
-    preload: function(src, callbk) {
-
+    preload: function (src, callbk) {
         var that = this;
 
         var ext = $.getExt(src);
 
         if (ext == "mp3" || ext == "ogg" || ext == "m4a") {
-
             // 相対パスの場合"./"を補完
-            if (src.indexOf("http://") !== 0 && src.indexOf("https://") !== 0 && src.indexOf("./") !== 0) {
+            if (
+                src.indexOf("http://") !== 0 &&
+                src.indexOf("https://") !== 0 &&
+                src.indexOf("./") !== 0
+            ) {
                 src = "./" + src;
             }
 
             var howl_opt = {
-                "src": src,
+                src: src,
                 preload: true,
                 onload: () => {
                     if (callbk) callbk();
@@ -1809,43 +1716,46 @@ tyrano.plugin.kag = {
             };
 
             let obj = new Howl(howl_opt);
-
-
         } else if ("mp4" == ext || "ogv" == ext || "webm" == ext) {
-
             //動画ファイルプリロード
-            $("<video />").attr("src", src).on("loadeddata", (function(e) {
-                callbk && callbk();
-            })).on("error", (function(e) {
-                that.kag.error("動画ファイル「" + src + "」が見つかりません。場所はフルパスで指定されていますか？ (例)data/video/file.mp4");
-                callbk && callbk();
-            }));
-
+            $("<video />")
+                .attr("src", src)
+                .on("loadeddata", function (e) {
+                    callbk && callbk();
+                })
+                .on("error", function (e) {
+                    that.kag.error(
+                        "動画ファイル「" +
+                            src +
+                            "」が見つかりません。場所はフルパスで指定されていますか？ (例)data/video/file.mp4",
+                    );
+                    callbk && callbk();
+                });
         } else {
+            $("<img />")
+                .attr("src", src)
+                .on("load", function (e) {
+                    if (callbk) callbk(this);
+                })
+                .on("error", function (e) {
+                    //画像が見つからなかった時のエラー
+                    //that.kag.message(画像ファイル「"+src+"」が見つかりません");
+                    that.kag.error(
+                        "画像ファイル「" +
+                            src +
+                            "」が見つかりません。場所はフルパスで指定されていますか？ (例)data/fgimage/file.png",
+                    );
 
-            $('<img />').attr('src', src).on("load", function(e) {
-                if (callbk) callbk(this);
-            }).on("error", function(e) {
-
-                //画像が見つからなかった時のエラー
-                //that.kag.message(画像ファイル「"+src+"」が見つかりません");
-                that.kag.error("画像ファイル「" + src + "」が見つかりません。場所はフルパスで指定されていますか？ (例)data/fgimage/file.png");
-
-                if (callbk) callbk();
-
-            });
-
+                    if (callbk) callbk();
+                });
         }
-
     },
 
     //配列の先読み
-    preloadAll: function(storage, callbk) {
-
+    preloadAll: function (storage, callbk) {
         var that = this;
         //配列で指定された場合
         if (typeof storage == "object" && storage.length >= 0) {
-
             if (storage.length == 0) {
                 callbk();
                 return;
@@ -1854,31 +1764,25 @@ tyrano.plugin.kag = {
             var sum = 0;
 
             for (var i = 0; i < storage.length; i++) {
-
-                that.kag.preload(storage[i], function() {
+                that.kag.preload(storage[i], function () {
                     sum++;
                     if (storage.length == sum) {
                         callbk();
                     }
                 });
             }
-
         } else {
-            this.kag.preload(pm.storage, function() {
+            this.kag.preload(pm.storage, function () {
                 callbk();
             });
         }
-
     },
 
     //値が空白のものは設定しない
-    setStyles: function(j_obj, array_style) {
-
+    setStyles: function (j_obj, array_style) {
         for (key in array_style) {
-
             if (typeof array_style[key] != "undefined") {
                 if (array_style[key] === "") {
-
                 } else {
                     j_obj.css(key, array_style[key]);
                 }
@@ -1886,15 +1790,13 @@ tyrano.plugin.kag = {
         }
 
         return j_obj;
-
     },
 
     //指定したHTMLを取得してかえす
-    html: function(html_file_name, data, callback) {
-
+    html: function (html_file_name, data, callback) {
         var that = this;
 
-        data = (data || {});
+        data = data || {};
 
         //キャッシュを確認して、すでに存在する場合はそれを返す
         if (this.cache_html[html_file_name]) {
@@ -1904,7 +1806,6 @@ tyrano.plugin.kag = {
                 callback($(html));
             }
         } else {
-
             //存在しない場合は初期化
             if (!this.kag.stat.sysview) {
                 this.kag.stat.sysview = {};
@@ -1912,14 +1813,13 @@ tyrano.plugin.kag = {
                     save: "./tyrano/html/save.html",
                     load: "./tyrano/html/load.html",
                     backlog: "./tyrano/html/backlog.html",
-                    menu: "./tyrano/html/menu.html"
+                    menu: "./tyrano/html/menu.html",
                 };
             }
 
             var path_html = this.kag.stat.sysview[html_file_name];
 
-            $.loadText(path_html, function(text_str) {
-
+            $.loadText(path_html, function (text_str) {
                 var tmpl = $.templates(text_str);
                 var html = tmpl.render(data);
 
@@ -1929,16 +1829,12 @@ tyrano.plugin.kag = {
                 if (callback) {
                     callback($(html));
                 }
-
             });
         }
-
     },
 
-    error: function(str) {
-
+    error: function (str) {
         if (this.kag.config["debugMenu.visible"] == "true") {
-
             //Error:first.ks：28行目:まるまるまる
             var current_storage = this.kag.stat.current_scenario;
             var line = parseInt(this.kag.stat.current_line) + 1;
@@ -1946,30 +1842,23 @@ tyrano.plugin.kag = {
             var err = "Error:" + current_storage + ":" + line + "行目:" + str;
 
             $.error_message(err);
-
         }
-
     },
     //警告表示
-    warning: function(str) {
+    warning: function (str) {
         if (this.kag.config["debugMenu.visible"] == "true") {
             alert(str);
         }
     },
 
-    log: function(obj) {
-
+    log: function (obj) {
         if (this.kag.config["debugMenu.visible"] == "true") {
             console.log(obj);
         }
-
     },
 
-    test: function() {
-
-    }
+    test: function () {},
 };
-
 
 //すべてのタグに共通する、拡張用
 tyrano.plugin.kag.tag = {};

--- a/tyrano/plugins/kag/kag.key_mouse.js
+++ b/tyrano/plugins/kag/kag.key_mouse.js
@@ -23,7 +23,7 @@ tyrano.plugin.kag.key_mouse = {
 
     //キーコンフィグ。デフォルトは用意しておく
     keyconfig: {
-        key: {}
+        key: {},
     },
 
     map_key: {},
@@ -40,79 +40,67 @@ tyrano.plugin.kag.key_mouse = {
     start_point: { x: 0, y: 0 },
     end_point: { x: 0, y: 0 },
 
-
-    init: function() {
+    init: function () {
         var that = this;
 
         //定義されてない場合デフォルトを設定
         if (typeof __tyrano_key_config == "undefined") {
-
             __tyrano_key_config = {
-
                 //キーボード操作
-                "key": {
-
-                    "32": "hidemessage", //Space
-                    "13": "next", // Enter
-                    "91": "skip", //Command(Mac)
-                    "17": "skip", //Ctrl (Windows)
-                    "67": function() { // c ボタン
-                    }
-
+                key: {
+                    32: "hidemessage", //Space
+                    13: "next", // Enter
+                    91: "skip", //Command(Mac)
+                    17: "skip", //Ctrl (Windows)
+                    67: function () {
+                        // c ボタン
+                    },
                 },
 
                 //マウス操作
-                "mouse": {
-                    "right": "hidemessage", //右クリックの動作
-                    "center": "menu", //センターボタンをクリック
-                    "wheel_up": "backlog", // ホイールをアップした時の動作
-                    "wheel_down": "next" //ホイールをダウンした時の動作
+                mouse: {
+                    right: "hidemessage", //右クリックの動作
+                    center: "menu", //センターボタンをクリック
+                    wheel_up: "backlog", // ホイールをアップした時の動作
+                    wheel_down: "next", //ホイールをダウンした時の動作
                 },
 
                 //ジェスチャー
-                "gesture": {
-                    "swipe_up_1": {
-                        "action": "backlog"
+                gesture: {
+                    swipe_up_1: {
+                        action: "backlog",
                     },
-                    "swipe_left_1": {
-                        "action": "auto"
+                    swipe_left_1: {
+                        action: "auto",
                     },
-                    "swipe_right_1": {
-                        "action": "menu"
+                    swipe_right_1: {
+                        action: "menu",
                     },
-                    "swipe_down_1": {
-                        "action": "load"
+                    swipe_down_1: {
+                        action: "load",
                     },
 
-                    "hold": {
-                        "action": "skip",
-                    }
-                }
-
+                    hold: {
+                        action: "skip",
+                    },
+                },
             };
-
         }
 
-
         this.keyconfig = __tyrano_key_config;
-
 
         this.map_key = this.keyconfig["key"];
         this.map_mouse = this.keyconfig["mouse"];
         this.map_ges = this.keyconfig["gesture"];
 
-        $(document).keydown(function(e) {
-
+        $(document).keydown(function (e) {
             if (that.kag.stat.enable_keyconfig == true) {
-
                 if (that.is_keydown == true) {
-
                     if (__tyrano_key_config.system_key_event == "true") {
                         return true;
                     }
 
                     return false;
-
                 }
 
                 //メニュー系が表示されている時。
@@ -123,7 +111,6 @@ tyrano.plugin.kag.key_mouse = {
 
                 //イベント登録済みなら
                 if (that.map_key[keycode]) {
-
                     if (typeof that.map_key[keycode] == "function") {
                         //関数の場合
                         that.map_key[keycode]();
@@ -133,16 +120,11 @@ tyrano.plugin.kag.key_mouse = {
                         }
                     }
                 }
-
             }
-
-
-
         });
 
         //keyup はコントローラーのときや押しっぱなし対応
-        $(document).keyup(function(e) {
-
+        $(document).keyup(function (e) {
             that.is_keydown = false;
 
             var keycode = e.keyCode;
@@ -151,25 +133,19 @@ tyrano.plugin.kag.key_mouse = {
             if (keycode == 91 || keycode == 17) {
                 that.kag.stat.is_skip = false;
             }
-
         });
 
-
-        $(document).on("mousedown", function(e) {
-
+        $(document).on("mousedown", function (e) {
             that.clearSkip();
 
             var target = null;
 
             //中央クリック
             if (e.which == 2) {
-
                 target = that.map_mouse["center"];
-
             } else if (e.which == 3) {
                 //右クリック
                 target = that.map_mouse["right"];
-
             }
 
             if (typeof target == "function") {
@@ -179,12 +155,15 @@ tyrano.plugin.kag.key_mouse = {
                     that[target]();
                 }
             }
-
         });
 
-        var mousewheelevent = 'onwheel' in document ? 'wheel' : 'onmousewheel' in document ? 'mousewheel' : 'DOMMouseScroll';
-        $(document).on(mousewheelevent, function(e) {
-
+        var mousewheelevent =
+            "onwheel" in document
+                ? "wheel"
+                : "onmousewheel" in document
+                ? "mousewheel"
+                : "DOMMouseScroll";
+        $(document).on(mousewheelevent, function (e) {
             //メニュー表示中は進めない。
             if (!that.canShowMenu()) {
                 return;
@@ -195,21 +174,25 @@ tyrano.plugin.kag.key_mouse = {
                 return;
             }
 
-
-
             //メニュー表示中は無効にする
-            if ($(".menu_close").length > 0 && $(".layer_menu").css("display") != "none") {
+            if (
+                $(".menu_close").length > 0 &&
+                $(".layer_menu").css("display") != "none"
+            ) {
                 return;
             }
 
-            var delta = e.originalEvent.deltaY ? -(e.originalEvent.deltaY) : e.originalEvent.wheelDelta ? e.originalEvent.wheelDelta : -(e.originalEvent.detail);
+            var delta = e.originalEvent.deltaY
+                ? -e.originalEvent.deltaY
+                : e.originalEvent.wheelDelta
+                ? e.originalEvent.wheelDelta
+                : -e.originalEvent.detail;
 
             var target = null;
 
             if (delta < 0) {
                 // マウスホイールを下にスクロールしたときの処理を記載
                 target = that.map_mouse["wheel_down"];
-
             } else {
                 // マウスホイールを上にスクロールしたときの処理を記載
                 target = that.map_mouse["wheel_up"];
@@ -222,78 +205,73 @@ tyrano.plugin.kag.key_mouse = {
                     that[target]();
                 }
             }
-
         });
-
 
         var layer_obj_click = $(".layer_event_click");
 
         //スマートフォンイベント
         if ($.userenv() != "pc") {
-            layer_obj_click.swipe(
-                {
-                    swipe: function(event, direction, distance, duration, fingerCount, fingerData) {
-                        that.is_swipe = true;
-                        //console.log("wwwwwwwwwwwwwww");
-                        //console.log(direction+":"+distance+":"+duration+":"+fingerCount+":"+fingerData);
-                        //$(this).text("You swiped " + direction );
+            layer_obj_click.swipe({
+                swipe: function (
+                    event,
+                    direction,
+                    distance,
+                    duration,
+                    fingerCount,
+                    fingerData,
+                ) {
+                    that.is_swipe = true;
+                    //console.log("wwwwwwwwwwwwwww");
+                    //console.log(direction+":"+distance+":"+duration+":"+fingerCount+":"+fingerData);
+                    //$(this).text("You swiped " + direction );
 
-                        var swipe_str = "swipe_" + direction + "_" + fingerCount;
+                    var swipe_str = "swipe_" + direction + "_" + fingerCount;
 
-
-                        if (that.map_ges[swipe_str]) {
-                            if (that[that.map_ges[swipe_str]["action"]]) {
-                                that[that.map_ges[swipe_str]["action"]]();
-                            }
+                    if (that.map_ges[swipe_str]) {
+                        if (that[that.map_ges[swipe_str]["action"]]) {
+                            that[that.map_ges[swipe_str]["action"]]();
                         }
-
-                        event.stopPropagation();
-                        event.preventDefault();
-                        return false;
-                    },
-
-                    fingers: "all"
-                }
-            );
-
-
-            layer_obj_click.on("touchstart", function() {
-
-                //スキップ中にクリックされたら元に戻す
-                that.clearSkip();
-
-
-                that.timeoutId = setTimeout(function() {
-                    if (that[that.map_ges["hold"]["action"]]) {
-                        that.is_swipe = true;
-                        that[that.map_ges["hold"]["action"]]();
                     }
 
-                }, 2000);
-            }).on('touchend', function() {
-                clearTimeout(that.timeoutId);
-                that.timeoutId = null;
+                    event.stopPropagation();
+                    event.preventDefault();
+                    return false;
+                },
+
+                fingers: "all",
             });
+
+            layer_obj_click
+                .on("touchstart", function () {
+                    //スキップ中にクリックされたら元に戻す
+                    that.clearSkip();
+
+                    that.timeoutId = setTimeout(function () {
+                        if (that[that.map_ges["hold"]["action"]]) {
+                            that.is_swipe = true;
+                            that[that.map_ges["hold"]["action"]]();
+                        }
+                    }, 2000);
+                })
+                .on("touchend", function () {
+                    clearTimeout(that.timeoutId);
+                    that.timeoutId = null;
+                });
 
             //スマホでのダブルタップ抑制
             var t = 0;
-            $(".tyrano_base").on('touchend', function(e) {
+            $(".tyrano_base").on("touchend", function (e) {
                 var now = new Date().getTime();
-                if ((now - t) < 350) {
+                if (now - t < 350) {
                     e.preventDefault();
                 }
                 t = now;
             });
-
-
         }
 
-        layer_obj_click.click(function(e) {
-
+        layer_obj_click.click(function (e) {
             if (that.kag.tmp.ready_audio == false) {
-
                 if ($.isNeedClickAudio()) {
-
                     that.kag.readyAudio();
                     that.kag.tmp.ready_audio = true;
 
@@ -303,10 +281,8 @@ tyrano.plugin.kag.key_mouse = {
                     }
                     that.kag.ftag.nextOrder();
                     return false;
-
                 }
             }
-
 
             if (that.is_swipe) {
                 that.is_swipe = false;
@@ -321,7 +297,7 @@ tyrano.plugin.kag.key_mouse = {
             //テキスト再生中にクリックされた場合、文字列を進めて終了にする
             if (that.kag.stat.is_adding_text == true) {
                 that.kag.stat.is_click_text = true;
-                return false;;
+                return false;
             }
 
             //テキストマッハ表示時もリターン。
@@ -339,13 +315,10 @@ tyrano.plugin.kag.key_mouse = {
             }
 
             that.kag.ftag.nextOrder();
-
         });
-
-
     },
 
-    next: function() {
+    next: function () {
         //指定された動作を発火させる
         if (this.kag.key_mouse.canClick()) {
             this.clearSkip();
@@ -353,9 +326,12 @@ tyrano.plugin.kag.key_mouse = {
         }
     },
 
-    showmenu: function() {
+    showmenu: function () {
         if (this.canShowMenu()) {
-            if ($(".menu_close").length > 0 && $(".layer_menu").css("display") != "none") {
+            if (
+                $(".menu_close").length > 0 &&
+                $(".layer_menu").css("display") != "none"
+            ) {
                 $(".menu_close").click();
             } else {
                 $(".button_menu").click();
@@ -363,9 +339,12 @@ tyrano.plugin.kag.key_mouse = {
         }
     },
 
-    hidemessage: function() {
+    hidemessage: function () {
         if (this.canShowMenu()) {
-            if ($(".menu_close").length > 0 && $(".layer_menu").css("display") != "none") {
+            if (
+                $(".menu_close").length > 0 &&
+                $(".layer_menu").css("display") != "none"
+            ) {
                 $(".menu_close").click();
             } else {
                 if (!this.kag.stat.is_strong_stop) {
@@ -379,42 +358,41 @@ tyrano.plugin.kag.key_mouse = {
         }
     },
 
-    save: function() {
+    save: function () {
         this._role("save");
     },
-    load: function() {
+    load: function () {
         this._role("load");
     },
-    menu: function() {
+    menu: function () {
         this._role("menu");
     },
-    title: function() {
+    title: function () {
         this._role("title");
     },
-    skip: function() {
+    skip: function () {
         if (this.canClick()) {
             this._role("skip");
         }
     },
-    backlog: function() {
+    backlog: function () {
         this._role("backlog");
     },
-    fullscreen: function() {
+    fullscreen: function () {
         this._role("fullscreen");
     },
-    qsave: function() {
+    qsave: function () {
         this._role("quicksave");
     },
-    qload: function() {
+    qload: function () {
         this._role("quickload");
     },
-    auto: function() {
+    auto: function () {
         this._role("auto");
     },
 
     //役割系のロジック
-    _role: function(role) {
-
+    _role: function (role) {
         var that = this;
 
         //roleがクリックされたら、skip停止。スキップ繰り返しでやったりやめたり
@@ -424,7 +402,10 @@ tyrano.plugin.kag.key_mouse = {
         }
 
         //画面効果中は実行できないようにする
-        if (that.kag.layer.layer_event.css("display") == "none" && that.kag.stat.is_strong_stop != true) {
+        if (
+            that.kag.layer.layer_event.css("display") == "none" &&
+            that.kag.stat.is_strong_stop != true
+        ) {
             return false;
         }
 
@@ -441,17 +422,22 @@ tyrano.plugin.kag.key_mouse = {
         }
 
         //文字が流れているときは、セーブ出来ないようにする。
-        if (role == "save" || role == "menu" || role == "quicksave" || role == "sleepgame") {
-
+        if (
+            role == "save" ||
+            role == "menu" ||
+            role == "quicksave" ||
+            role == "sleepgame"
+        ) {
             //テキストが流れているときとwait中は実行しない
-            if (that.kag.stat.is_adding_text == true || that.kag.stat.is_wait == true) {
+            if (
+                that.kag.stat.is_adding_text == true ||
+                that.kag.stat.is_wait == true
+            ) {
                 return false;
             }
-
         }
 
         switch (role) {
-
             case "save":
                 //すでにメニュー画面が見えてる場合は無効にする
                 if ($(".layer_menu").css("display") == "none") {
@@ -470,12 +456,15 @@ tyrano.plugin.kag.key_mouse = {
                 that.kag.layer.hideMessageLayers();
                 break;
             case "title":
-
-                $.confirm($.lang("go_title"), function() {
-                    location.reload();
-                }, function() {
-                    return false;
-                });
+                $.confirm(
+                    $.lang("go_title"),
+                    function () {
+                        location.reload();
+                    },
+                    function () {
+                        return false;
+                    },
+                );
                 break;
 
             case "menu":
@@ -505,7 +494,6 @@ tyrano.plugin.kag.key_mouse = {
                 break;
 
             case "sleepgame":
-
                 if (that.kag.tmp.sleep_game != null) {
                     return false;
                 }
@@ -515,29 +503,29 @@ tyrano.plugin.kag.key_mouse = {
 
                 that.kag.ftag.startTag("sleepgame", _pm);
                 break;
-
         }
-
-
     },
 
-    canClick: function() {
-
-        if ($(".layer_event_click").css("display") != "none" && $(".layer_menu").css("display") == "none") {
+    canClick: function () {
+        if (
+            $(".layer_event_click").css("display") != "none" &&
+            $(".layer_menu").css("display") == "none"
+        ) {
             return true;
         }
-
 
         return false;
     },
 
     //スキップやオートをクリアする
-    clearSkip: function() {
-
+    clearSkip: function () {
         var that = this;
 
         //スキップ中にクリックされたら元に戻す
-        if (that.kag.stat.is_skip == true && that.kag.stat.is_strong_stop == false) {
+        if (
+            that.kag.stat.is_skip == true &&
+            that.kag.stat.is_strong_stop == false
+        ) {
             that.kag.stat.is_skip = false;
             return false;
         }
@@ -553,13 +541,13 @@ tyrano.plugin.kag.key_mouse = {
         if (that.kag.stat.is_wait_auto == true) {
             that.kag.stat.is_wait_auto = false;
         }
-
     },
 
-    canShowMenu: function() {
-
-
-        if (this.kag.layer.layer_event.css("display") == "none" && this.kag.stat.is_strong_stop != true) {
+    canShowMenu: function () {
+        if (
+            this.kag.layer.layer_event.css("display") == "none" &&
+            this.kag.stat.is_strong_stop != true
+        ) {
             return false;
         }
 
@@ -577,7 +565,7 @@ tyrano.plugin.kag.key_mouse = {
         return false;
 
         */
-    }
+    },
 };
 
 /*

--- a/tyrano/plugins/kag/kag.layer.js
+++ b/tyrano/plugins/kag/kag.layer.js
@@ -1,6 +1,4 @@
-
 tyrano.plugin.kag.layer = {
-
     tyrano: null,
     kag: null,
 
@@ -8,7 +6,7 @@ tyrano.plugin.kag.layer = {
 
     layer_menu: {}, //メニュー用の画面。イベントレイヤーよりも更に上
 
-    layer_free: {},// フリーレイヤー 用　画像の配置などはここで設定する
+    layer_free: {}, // フリーレイヤー 用　画像の配置などはここで設定する
 
     map_layer_fore: {},
     map_layer_back: {},
@@ -21,20 +19,27 @@ tyrano.plugin.kag.layer = {
     start_point: { x: 0, y: 0 },
     end_point: { x: 0, y: 0 },
 
-    init: function() {
-
+    init: function () {
         var that = this;
         //同じディレクトリにある、KAG関連のデータを読み込み
 
         //分割用のレイヤ
-        $("#tyrano_base").append('<div id="root_layer_game" class="root_layer_game"></div>');
-        $("#tyrano_base").append('<div id="root_layer_system" class="root_layer_system"></div>');
+        $("#tyrano_base").append(
+            '<div id="root_layer_game" class="root_layer_game"></div>',
+        );
+        $("#tyrano_base").append(
+            '<div id="root_layer_system" class="root_layer_system"></div>',
+        );
 
         //隠しレイヤの登録
         //画面クリックのレイヤ
-        var layer_obj_click = $("<div class='layer layer_event_click' style='z-index:9999;display:none'></div>");
-        layer_obj_click.css("width", this.kag.config.scWidth).css("height", this.kag.config.scHeight).css("position", "absolute");
-
+        var layer_obj_click = $(
+            "<div class='layer layer_event_click' style='z-index:9999;display:none'></div>",
+        );
+        layer_obj_click
+            .css("width", this.kag.config.scWidth)
+            .css("height", this.kag.config.scHeight)
+            .css("position", "absolute");
 
         //スキップやオートキャンセルの停止、画面がクリックされた時。
         /*
@@ -61,43 +66,53 @@ tyrano.plugin.kag.layer = {
         });
         */
 
-
-
         this.layer_event = layer_obj_click;
         this.appendLayer(this.layer_event, "root_layer_system");
 
-
         //メニュー画面用のレイヤ
-        var layer_menu = $("<div class='layer layer_menu' style='z-index:1000000000;display:none'  align='center'></div>");
-        layer_menu.css("width", this.kag.config.scWidth).css("height", this.kag.config.scHeight).css("position", "absolute");
+        var layer_menu = $(
+            "<div class='layer layer_menu' style='z-index:1000000000;display:none'  align='center'></div>",
+        );
+        layer_menu
+            .css("width", this.kag.config.scWidth)
+            .css("height", this.kag.config.scHeight)
+            .css("position", "absolute");
         this.layer_menu = layer_menu;
         this.appendLayer(this.layer_menu, "root_layer_system");
 
         //フリーレイヤ
-        var layer_free = $("<div class='layer layer_free' style='z-index:9998;display:none' ></div>");
-        layer_free.css("width", this.kag.config.scWidth).css("height", this.kag.config.scHeight).css("position", "absolute");
+        var layer_free = $(
+            "<div class='layer layer_free' style='z-index:9998;display:none' ></div>",
+        );
+        layer_free
+            .css("width", this.kag.config.scWidth)
+            .css("height", this.kag.config.scHeight)
+            .css("position", "absolute");
         this.layer_free = layer_free;
         this.appendLayer(this.layer_free, "root_layer_system");
-
-
     },
 
     //メニューレイヤーを返す
-    getMenuLayer: function() {
+    getMenuLayer: function () {
         return this.layer_menu;
     },
 
     //フリーレイヤを返却します
-    getFreeLayer: function() {
+    getFreeLayer: function () {
         return this.layer_free;
     },
 
-    addLayer: function(layer_name) {
-
+    addLayer: function (layer_name) {
         var system_layer = "";
 
-        var layer_obj_fore = $("<div class='layer " + layer_name + "_fore layer_fore'></div>");
-        var layer_obj_back = $("<div class='layer " + layer_name + "_back layer_back' style='display:none'></div>");
+        var layer_obj_fore = $(
+            "<div class='layer " + layer_name + "_fore layer_fore'></div>",
+        );
+        var layer_obj_back = $(
+            "<div class='layer " +
+                layer_name +
+                "_back layer_back' style='display:none'></div>",
+        );
 
         if (layer_name.indexOf("message") == -1) {
             layer_obj_fore.addClass("layer_camera");
@@ -106,8 +121,14 @@ tyrano.plugin.kag.layer = {
             system_layer = "root_layer_system";
         }
 
-        layer_obj_fore.css("width", this.kag.config.scWidth).css("height", this.kag.config.scHeight).css("position", "absolute");
-        layer_obj_back.css("width", this.kag.config.scWidth).css("height", this.kag.config.scHeight).css("position", "absolute");
+        layer_obj_fore
+            .css("width", this.kag.config.scWidth)
+            .css("height", this.kag.config.scHeight)
+            .css("position", "absolute");
+        layer_obj_back
+            .css("width", this.kag.config.scWidth)
+            .css("height", this.kag.config.scHeight)
+            .css("position", "absolute");
 
         this.map_layer_fore[layer_name] = layer_obj_fore;
         this.map_layer_back[layer_name] = layer_obj_back;
@@ -116,65 +137,56 @@ tyrano.plugin.kag.layer = {
         this.map_layer_fore[layer_name].attr("l_visible", "true");
         this.map_layer_back[layer_name].attr("l_visible", "true");
 
-
         this.appendLayer(this.map_layer_fore[layer_name], system_layer);
         this.appendLayer(this.map_layer_back[layer_name], system_layer);
-
     },
 
     //メッセージレイヤ追加用
-    appendLayer: function(layer_obj, system) {
-
+    appendLayer: function (layer_obj, system) {
         system = system || "root_layer_game";
 
         layer_obj.attr("data-parent-layer", system);
 
         if (system != "") {
-            $("." + this.kag.define.BASE_DIV_NAME).find("#" + system).append(layer_obj);
+            $("." + this.kag.define.BASE_DIV_NAME)
+                .find("#" + system)
+                .append(layer_obj);
         } else {
             $("." + this.kag.define.BASE_DIV_NAME).append(layer_obj);
         }
-
     },
 
     //全景レイヤにオブジェクトを追加する
-    appendImage: function(image_obj) {
-
+    appendImage: function (image_obj) {
         $("." + this.kag.define.BASE_DIV_NAME).append(layer_obj);
-
     },
 
-    getLayer: function(layer_name, page) {
-
+    getLayer: function (layer_name, page) {
         if (layer_name == "fix") {
             return $("#tyrano_base");
         }
 
-        page = page || 'fore';
+        page = page || "fore";
 
         if (page == "fore") {
             return this.map_layer_fore[layer_name];
         } else {
             return this.map_layer_back[layer_name];
         }
-
     },
 
-    updateLayer: function(layer_name, page, layer_obj) {
-
-        page = page || 'fore';
+    updateLayer: function (layer_name, page, layer_obj) {
+        page = page || "fore";
 
         if (page == "fore") {
             this.map_layer_fore[layer_name] = layer_obj;
         } else {
             this.map_layer_back[layer_name] = layer_obj;
         }
-
     },
 
     //メッセージレイヤの消去
-    hideMessageLayers: function() {
-
+    hideMessageLayers: function () {
         //link表示中はダメ。
         if (this.kag.stat.display_link == true) {
             return false;
@@ -193,109 +205,109 @@ tyrano.plugin.kag.layer = {
     },
 
     //メッセージレイヤの表示
-    showMessageLayers: function() {
-
+    showMessageLayers: function () {
         this.kag.stat.is_hide_message = false;
 
         var num_message_layer = parseInt(this.kag.config.numMessageLayers);
 
         //表示するときに、もともと表示状態のもののみ、表示する必要がある
         for (var i = 0; i < num_message_layer; i++) {
-
             var j_layer = this.getLayer("message" + i);
 
             //もともと、表示状態の場合のみ、再表示する
             if (j_layer.attr("l_visible") == "true") {
                 j_layer.show();
             }
-
         }
 
         //fixレイヤも
         this.showFixLayer();
-
     },
 
-    showFixLayer: function() {
+    showFixLayer: function () {
         $(".fixlayer").show();
     },
 
-    hideFixLayer: function() {
+    hideFixLayer: function () {
         $(".fixlayer").hide();
     },
 
-
-    appendObj: function(layer_name, page, obj) {
-
+    appendObj: function (layer_name, page, obj) {
         obj.css("position", "absolute");
         this.getLayer(layer_name, page).append(obj);
-
     },
 
-
     //メッセージレイヤのインナーを最適化する
-    refMessageLayer: function(target_layer) {
-
+    refMessageLayer: function (target_layer) {
         var num = 0;
 
         if (!target_layer) {
-
             while (true) {
-
                 if (this.map_layer_fore["message" + num]) {
-
-                    var j_message_outer = this.map_layer_fore["message" + num].find(".message_outer");
-                    var j_message_inner = this.map_layer_fore["message" + num].find(".message_inner");
+                    var j_message_outer =
+                        this.map_layer_fore["message" + num].find(
+                            ".message_outer",
+                        );
+                    var j_message_inner =
+                        this.map_layer_fore["message" + num].find(
+                            ".message_inner",
+                        );
 
                     j_message_inner
                         .css("left", parseInt(j_message_outer.css("left")) + 10)
                         .css("top", parseInt(j_message_outer.css("top")) + 10)
-                        .css("width", parseInt(j_message_outer.css("width")) - 10)
-                        .css("height", parseInt(j_message_outer.css("height")) - 10);
-
+                        .css(
+                            "width",
+                            parseInt(j_message_outer.css("width")) - 10,
+                        )
+                        .css(
+                            "height",
+                            parseInt(j_message_outer.css("height")) - 10,
+                        );
                 } else {
                     break;
                 }
 
                 num++;
             }
-
         } else {
-
             if (this.map_layer_fore[target_layer]) {
-
-                var j_message_outer = this.map_layer_fore[target_layer].find(".message_outer");
-                var j_message_inner = this.map_layer_fore[target_layer].find(".message_inner");
+                var j_message_outer =
+                    this.map_layer_fore[target_layer].find(".message_outer");
+                var j_message_inner =
+                    this.map_layer_fore[target_layer].find(".message_inner");
 
                 j_message_inner
                     .css("left", parseInt(j_message_outer.css("left")) + 10)
                     .css("top", parseInt(j_message_outer.css("top")) + 10)
                     .css("width", parseInt(j_message_outer.css("width")) - 10)
-                    .css("height", parseInt(j_message_outer.css("height")) - 10);
+                    .css(
+                        "height",
+                        parseInt(j_message_outer.css("height")) - 10,
+                    );
             }
-
         }
-
     },
 
     //レイヤに関連するHTMLファイルを文字列でぶっこ抜きます
-    getLayeyHtml: function() {
-
+    getLayeyHtml: function () {
         var layer_info = {
-
             map_layer_fore: {},
             map_layer_back: {},
             layer_free: {},
             layer_fix: {},
-            layer_blend: {}
-
+            layer_blend: {},
         };
 
         for (key in this.map_layer_fore) {
-            layer_info["map_layer_fore"][key] = $.playerHtmlPath(this.map_layer_fore[key].outerHTML());
+            layer_info["map_layer_fore"][key] = $.playerHtmlPath(
+                this.map_layer_fore[key].outerHTML(),
+            );
         }
         for (key in this.map_layer_back) {
-            layer_info["map_layer_back"][key] = $.playerHtmlPath(this.map_layer_back[key].outerHTML());
+            layer_info["map_layer_back"][key] = $.playerHtmlPath(
+                this.map_layer_back[key].outerHTML(),
+            );
         }
 
         /*
@@ -304,54 +316,46 @@ tyrano.plugin.kag.layer = {
         }
         */
 
-        layer_info["layer_free"] = $.playerHtmlPath(this.layer_free.outerHTML());
+        layer_info["layer_free"] = $.playerHtmlPath(
+            this.layer_free.outerHTML(),
+        );
 
         var n = 0;
-        $(".fixlayer").each(function() {
-
+        $(".fixlayer").each(function () {
             layer_info["layer_fix"][n] = $.playerHtmlPath($(this).outerHTML());
             n++;
-
         });
 
         var m = 0;
-        $(".blendlayer").each(function() {
-            layer_info["layer_blend"][m] = $.playerHtmlPath($(this).outerHTML());
+        $(".blendlayer").each(function () {
+            layer_info["layer_blend"][m] = $.playerHtmlPath(
+                $(this).outerHTML(),
+            );
             m++;
-
         });
 
         return layer_info;
-
-
     },
 
     //スタジオから利用。レイヤーの情報を取得する予定
     getLayerInfo() {
-
         var layer_info = {
-
-            "map_layer_fore": this.map_layer_fore,
-            "layer_free": this.layer_free,
-            "layer_blend": this.layer_blend,
-            "layer_fix": {},
-
+            map_layer_fore: this.map_layer_fore,
+            layer_free: this.layer_free,
+            layer_blend: this.layer_blend,
+            layer_fix: {},
         };
 
         var n = 0;
-        $(".fixlayer").each(function() {
-
+        $(".fixlayer").each(function () {
             layer_info["layer_fix"][n] = $(this);
             n++;
-
         });
 
         return layer_info;
-
     },
 
-    setLayerHtml: function(layer) {
-
+    setLayerHtml: function (layer) {
         var that = this;
 
         for (key in layer.map_layer_fore) {
@@ -359,9 +363,9 @@ tyrano.plugin.kag.layer = {
             delete this["map_layer_fore"][key];
             this["map_layer_fore"][key] = $(layer["map_layer_fore"][key]);
 
-            var parent_layer = this["map_layer_fore"][key].attr("data-parent-layer");
+            var parent_layer =
+                this["map_layer_fore"][key].attr("data-parent-layer");
             this.appendLayer(this["map_layer_fore"][key], parent_layer);
-
         }
 
         for (key in layer.map_layer_back) {
@@ -369,21 +373,20 @@ tyrano.plugin.kag.layer = {
             delete this["map_layer_back"][key];
             this["map_layer_back"][key] = $(layer["map_layer_back"][key]);
 
-            var parent_layer = this["map_layer_fore"][key].attr("data-parent-layer");
+            var parent_layer =
+                this["map_layer_fore"][key].attr("data-parent-layer");
             this.appendLayer(this["map_layer_back"][key], parent_layer);
-
         }
 
         //fixlayerの削除
-        $(".fixlayer").each(function() {
+        $(".fixlayer").each(function () {
             $(this).remove();
         });
 
         //canvasは削除 → 3Dレイヤのcanvasは削除
-        $(".three_canvas").each(function() {
+        $(".three_canvas").each(function () {
             $(this).remove();
         });
-
 
         //fixlayer は復元しない
 
@@ -394,7 +397,6 @@ tyrano.plugin.kag.layer = {
         //ブレンド演出の復元
         $(".blendlayer").remove();
         for (key in layer.layer_blend) {
-
             var obj = $(layer.layer_blend[key]);
             if (obj.hasClass("blendvideo")) {
                 //ビデオの再現
@@ -404,55 +406,41 @@ tyrano.plugin.kag.layer = {
                 video_pm.stop = "true";
                 video_pm.time = 10;
                 //ビデオレイヤ追加だお。
-                (function() {
+                (function () {
                     var _video_pm = video_pm;
-                    setTimeout(function() {
+                    setTimeout(function () {
                         that.kag.ftag.startTag("layermode_movie", _video_pm);
                     }, 10);
                 })();
-
             } else {
                 //画像のブレンド
                 $("#tyrano_base").append(obj);
             }
-
         }
-
-
 
         this.layer_free.remove();
         delete this.layer_free;
         this.layer_free = $(layer.layer_free);
         this.appendLayer(this.layer_free, "root_layer_system");
-
-
     },
 
     //すべてのメッセージインナーレイヤ削除
-    clearMessageInnerLayerAll: function() {
-
+    clearMessageInnerLayerAll: function () {
         for (key in this.map_layer_fore) {
-
             if (key.indexOf("message") != -1) {
                 //メッセージインナーの削除
                 this.map_layer_fore[key].find(".message_inner").html("");
-
             }
-
         }
-
     },
 
     //前景レイヤを背景レイヤにコピーする
-    backlay: function(layer) {
-
+    backlay: function (layer) {
         //レイヤが指定されている場合は、そのレイヤのみコピーする
         layer = layer || "";
 
         for (key in this.map_layer_fore) {
-
             if (layer == "" || layer == key) {
-
                 var fore_class_name = this.map_layer_fore[key].attr("class");
                 var back_class_name = this.map_layer_back[key].attr("class");
 
@@ -470,34 +458,28 @@ tyrano.plugin.kag.layer = {
                 //追加
                 this.map_layer_back[key].hide();
                 this.appendLayer(this.map_layer_back[key]);
-
             }
-
         }
-
     },
 
     //全面のイベントレイヤを削除する
-    showEventLayer: function() {
+    showEventLayer: function () {
         this.kag.stat.is_stop = false;
         this.layer_event.show();
     },
 
-    hideEventLayer: function() {
+    hideEventLayer: function () {
         this.kag.stat.is_stop = true;
         this.layer_event.hide();
     },
 
     //backlayの逆 トランスの後に実施する
-    forelay: function(layer) {
-
+    forelay: function (layer) {
         //レイヤが指定されている場合は、そのレイヤのみコピーする
         layer = layer || "";
 
         for (key in this.map_layer_back) {
-
             if (layer == "" || layer == key) {
-
                 var fore_class_name = this.map_layer_fore[key].attr("class");
                 var back_class_name = this.map_layer_back[key].attr("class");
 
@@ -516,7 +498,6 @@ tyrano.plugin.kag.layer = {
                 //this.appendLayer(this.map_layer_fore[key]);
                 this.map_layer_back[key].before(this.map_layer_fore[key]);
 
-
                 //バックレイヤは隠す
                 this.map_layer_back[key].css("display", "none");
 
@@ -525,13 +506,9 @@ tyrano.plugin.kag.layer = {
                 if (key.indexOf("message") != -1) {
                     this.map_layer_fore[key].css("opacity", "");
                 }
-
             }
-
         }
     },
 
-    test: function() {
-
-    }
+    test: function () {},
 };

--- a/tyrano/plugins/kag/kag.menu.js
+++ b/tyrano/plugins/kag/kag.menu.js
@@ -1,17 +1,16 @@
 tyrano.plugin.kag.menu = {
-
     tyrano: null,
     kag: null,
 
     snap: null,
 
-    init: function() {
+    init: function () {},
 
-    },
-
-    showMenu: function(call_back) {
-
-        if (this.kag.layer.layer_event.css("display") == "none" && this.kag.stat.is_strong_stop != true) {
+    showMenu: function (call_back) {
+        if (
+            this.kag.layer.layer_event.css("display") == "none" &&
+            this.kag.stat.is_strong_stop != true
+        ) {
             return false;
         }
 
@@ -32,115 +31,107 @@ tyrano.plugin.kag.menu = {
 
         var button_clicked = false;
 
-        this.kag.html("menu", {
-            "novel": $.novel
-        }, function(html_str) {
+        this.kag.html(
+            "menu",
+            {
+                novel: $.novel,
+            },
+            function (html_str) {
+                var j_menu = $(html_str);
 
-            var j_menu = $(html_str);
+                layer_menu.append(j_menu);
 
-            layer_menu.append(j_menu);
+                layer_menu.find(".menu_skip").click(function (e) {
+                    //スキップを開始する
+                    layer_menu.html("");
+                    layer_menu.hide();
+                    if (that.kag.stat.visible_menu_button == true) {
+                        $(".button_menu").show();
+                    }
+                    //nextOrder にして、
+                    that.kag.stat.is_skip = true;
 
-            layer_menu.find(".menu_skip").click(function(e) {
+                    ///処理待ち状態の時は、実行してはいけない
+                    if (that.kag.layer.layer_event.css("display") == "none") {
+                        //alert("今、スキップしない");
+                        //that.kag.ftag.nextOrder();
+                    } else {
+                        //alert("スキップするよ");
+                        that.kag.ftag.nextOrder();
+                    }
 
-                //スキップを開始する
-                layer_menu.html("");
-                layer_menu.hide();
-                if (that.kag.stat.visible_menu_button == true) {
-                    $(".button_menu").show();
-                }
-                //nextOrder にして、
-                that.kag.stat.is_skip = true;
+                    e.stopPropagation();
+                });
 
-                ///処理待ち状態の時は、実行してはいけない
-                if (that.kag.layer.layer_event.css("display") == "none") {
-                    //alert("今、スキップしない");
-                    //that.kag.ftag.nextOrder();
-                } else {
-                    //alert("スキップするよ");
-                    that.kag.ftag.nextOrder();
+                layer_menu.find(".menu_close").click(function (e) {
+                    layer_menu.hide();
+                    if (that.kag.stat.visible_menu_button == true) {
+                        $(".button_menu").show();
+                    }
 
-                }
+                    e.stopPropagation();
+                });
 
-                e.stopPropagation();
+                layer_menu.find(".menu_window_close").click(function (e) {
+                    //ウィンドウ消去
+                    that.kag.layer.hideMessageLayers();
 
+                    layer_menu.hide();
+                    if (that.kag.stat.visible_menu_button == true) {
+                        $(".button_menu").show();
+                    }
 
-            });
+                    e.stopPropagation();
+                });
 
-            layer_menu.find(".menu_close").click(function(e) {
-                layer_menu.hide();
-                if (that.kag.stat.visible_menu_button == true) {
-                    $(".button_menu").show();
-                }
+                layer_menu.find(".menu_save").click(function (e) {
+                    //連続クリック対策
+                    if (button_clicked == true) {
+                        return;
+                    }
+                    button_clicked = true;
 
-                e.stopPropagation();
+                    that.displaySave();
+                    e.stopPropagation();
+                });
 
-            });
+                layer_menu.find(".menu_load").click(function (e) {
+                    //連続クリック対策
+                    if (button_clicked == true) {
+                        return;
+                    }
+                    button_clicked = true;
 
-            layer_menu.find(".menu_window_close").click(function(e) {
+                    that.displayLoad();
+                    e.stopPropagation();
+                });
 
-                //ウィンドウ消去
-                that.kag.layer.hideMessageLayers();
+                //タイトルに戻る
+                layer_menu.find(".menu_back_title").click(function () {
+                    that.kag.backTitle();
 
-                layer_menu.hide();
-                if (that.kag.stat.visible_menu_button == true) {
-                    $(".button_menu").show();
-                }
-
-                e.stopPropagation();
-
-
-            });
-
-            layer_menu.find(".menu_save").click(function(e) {
-
-                //連続クリック対策
-                if (button_clicked == true) {
-                    return;
-                }
-                button_clicked = true;
-
-                that.displaySave();
-                e.stopPropagation();
-
-            });
-
-            layer_menu.find(".menu_load").click(function(e) {
-                //連続クリック対策
-                if (button_clicked == true) {
-                    return;
-                }
-                button_clicked = true;
-
-                that.displayLoad();
-                e.stopPropagation();
-
-            });
-
-            //タイトルに戻る
-            layer_menu.find(".menu_back_title").click(function() {
-
-                that.kag.backTitle();
-
-                /*
+                    /*
                 if (!confirm($.lang("go_title"))) {
                     return false;
                 }
                 */
-                //first.ks の *start へ戻ります
-                //location.reload();
-            });
+                    //first.ks の *start へ戻ります
+                    //location.reload();
+                });
 
-            $.preloadImgCallback(j_menu, function() {
-                layer_menu.stop(true, true).fadeIn(300);
-                $(".button_menu").hide();
-            }, that);
-
-        });
-
+                $.preloadImgCallback(
+                    j_menu,
+                    function () {
+                        layer_menu.stop(true, true).fadeIn(300);
+                        $(".button_menu").hide();
+                    },
+                    that,
+                );
+            },
+        );
     },
 
-    displaySave: function(cb) {
-
+    displaySave: function (cb) {
         //セーブ画面作成
 
         var that = this;
@@ -157,25 +148,27 @@ tyrano.plugin.kag.menu = {
             array[i].num = i;
         }
 
-        this.kag.html("save", {
-            array_save: array,
-            "novel": $.novel
-        }, function(html_str) {
+        this.kag.html(
+            "save",
+            {
+                array_save: array,
+                novel: $.novel,
+            },
+            function (html_str) {
+                var j_save = $(html_str);
 
-            var j_save = $(html_str);
+                //フォントをゲームで指定されているフォントにする。
+                j_save
+                    .find(".save_list")
+                    .css("font-family", that.kag.config.userFace);
 
-            //フォントをゲームで指定されているフォントにする。
-            j_save.find(".save_list").css("font-family", that.kag.config.userFace);
+                j_save.find(".save_display_area").each(function () {
+                    $(this).click(function (e) {
+                        var num = $(this).attr("data-num");
 
-            j_save.find(".save_display_area").each(function() {
+                        that.snap = null;
 
-                $(this).click(function(e) {
-
-                    var num = $(this).attr("data-num");
-
-                    that.snap = null;
-
-                    /*
+                        /*
                     var layer_menu = that.kag.layer.getMenuLayer();
                     layer_menu.hide();
                     layer_menu.empty();
@@ -184,60 +177,76 @@ tyrano.plugin.kag.menu = {
                     }
                     */
 
-                    that.doSave(num, function(save_data) {
+                        that.doSave(num, function (save_data) {
+                            var j_slot = layer_menu.find(
+                                "[data-num='" + num + "']",
+                            );
 
-                        var j_slot = layer_menu.find("[data-num='" + num + "']");
-
-                        if (save_data["img_data"] != "") {
-
-                            if (j_slot.find(".save_list_item_thumb").find("img").get(0)) {
-                                j_slot.find(".save_list_item_thumb").find("img").attr("src", save_data["img_data"]);
-                            } else {
-                                j_slot.find(".save_list_item_thumb").css("background-image", "");
-                                j_slot.find(".save_list_item_thumb").append("<img>");
-                                j_slot.find(".save_list_item_thumb").find("img").attr("src", save_data["img_data"]);
+                            if (save_data["img_data"] != "") {
+                                if (
+                                    j_slot
+                                        .find(".save_list_item_thumb")
+                                        .find("img")
+                                        .get(0)
+                                ) {
+                                    j_slot
+                                        .find(".save_list_item_thumb")
+                                        .find("img")
+                                        .attr("src", save_data["img_data"]);
+                                } else {
+                                    j_slot
+                                        .find(".save_list_item_thumb")
+                                        .css("background-image", "");
+                                    j_slot
+                                        .find(".save_list_item_thumb")
+                                        .append("<img>");
+                                    j_slot
+                                        .find(".save_list_item_thumb")
+                                        .find("img")
+                                        .attr("src", save_data["img_data"]);
+                                }
                             }
 
-                        }
+                            j_slot
+                                .find(".save_list_item_date")
+                                .html(save_data["save_date"]);
+                            j_slot
+                                .find(".save_list_item_text")
+                                .html(save_data["title"]);
 
-                        j_slot.find(".save_list_item_date").html(save_data["save_date"]);
-                        j_slot.find(".save_list_item_text").html(save_data["title"]);
+                            if (typeof cb == "function") {
+                                cb();
+                            }
+                        });
+                    });
+                });
 
-                        if (typeof cb == "function") {
-                            cb();
-                        }
-
-
+                //スマホの場合はボタンの上下でスクロールできるようにする
+                j_save.find(".button_smart").hide();
+                if ($.userenv() != "pc") {
+                    j_save.find(".button_smart").show();
+                    j_save.find(".button_arrow_up").click(function () {
+                        var now = j_save.find(".area_save_list").scrollTop();
+                        var pos = now - 160;
+                        layer_menu
+                            .find(".area_save_list")
+                            .animate({ scrollTop: pos }, { queue: false });
                     });
 
+                    j_save.find(".button_arrow_down").click(function () {
+                        var now = j_save.find(".area_save_list").scrollTop();
+                        var pos = now + 160;
+                        j_save
+                            .find(".area_save_list")
+                            .animate({ scrollTop: pos }, { queue: false });
+                    });
+                }
 
-                });
-            });
+                var layer_menu = that.kag.layer.getMenuLayer();
 
-            //スマホの場合はボタンの上下でスクロールできるようにする
-            j_save.find(".button_smart").hide();
-            if ($.userenv() != "pc") {
-                j_save.find(".button_smart").show();
-                j_save.find(".button_arrow_up").click(function() {
-                    var now = j_save.find(".area_save_list").scrollTop();
-                    var pos = now - 160;
-                    layer_menu.find(".area_save_list").animate({ scrollTop: pos }, { queue: false });
-                });
-
-                j_save.find(".button_arrow_down").click(function() {
-                    var now = j_save.find(".area_save_list").scrollTop();
-                    var pos = now + 160;
-                    j_save.find(".area_save_list").animate({ scrollTop: pos }, { queue: false });
-                });
-
-            }
-
-
-            var layer_menu = that.kag.layer.getMenuLayer();
-
-            that.setMenu(j_save, cb);
-
-        });
+                that.setMenu(j_save, cb);
+            },
+        );
 
         //背景素材挿入
         /*
@@ -246,12 +255,10 @@ tyrano.plugin.kag.menu = {
          j_menu_save_img.css("height",this.kag.config.scHeight);
          j_save.append(j_menu_save_img);
          */
-
     },
 
     //セーブを実行する
-    doSave: function(num, cb) {
-
+    doSave: function (num, cb) {
         var array_save = this.getSaveData();
 
         var data = {};
@@ -259,7 +266,7 @@ tyrano.plugin.kag.menu = {
 
         if (this.snap == null) {
             //ここはサムネイルイメージ作成のため、callback指定する
-            this.snapSave(this.kag.stat.current_save_str, function() {
+            this.snapSave(this.kag.stat.current_save_str, function () {
                 //現在、停止中のステータスなら、[_s]ポジションからセーブデータ取得
 
                 /*
@@ -272,49 +279,58 @@ tyrano.plugin.kag.menu = {
                 data = that.snap;
                 data.save_date = $.getNowDate() + "　" + $.getNowTime();
                 array_save.data[num] = data;
-                $.setStorage(that.kag.config.projectID + "_tyrano_data", array_save, that.kag.config.configSave);
+                $.setStorage(
+                    that.kag.config.projectID + "_tyrano_data",
+                    array_save,
+                    that.kag.config.configSave,
+                );
 
                 if (typeof cb == "function") {
                     //終わったタイミングでコールバックを返す
                     cb(data);
                 }
-
             });
-
         } else {
-
             data = that.snap;
             data.save_date = $.getNowDate() + "　" + $.getNowTime();
             array_save.data[num] = data;
-            $.setStorage(that.kag.config.projectID + "_tyrano_data", array_save, that.kag.config.configSave);
+            $.setStorage(
+                that.kag.config.projectID + "_tyrano_data",
+                array_save,
+                that.kag.config.configSave,
+            );
 
             if (typeof cb == "function") {
                 //終わったタイミングでコールバックを返す
                 cb(data);
             }
-
         }
-
     },
 
-    setQuickSave: function() {
+    setQuickSave: function () {
         var that = this;
 
         var saveTitle = that.kag.stat.current_save_str;
 
-        that.kag.menu.snapSave(saveTitle, function() {
+        that.kag.menu.snapSave(saveTitle, function () {
             var data = that.snap;
             data.save_date = $.getNowDate() + "　" + $.getNowTime();
-            $.setStorage(that.kag.config.projectID + "_tyrano_quick_save", data, that.kag.config.configSave);
+            $.setStorage(
+                that.kag.config.projectID + "_tyrano_quick_save",
+                data,
+                that.kag.config.configSave,
+            );
 
             var layer_menu = that.kag.layer.getMenuLayer();
             layer_menu.hide();
-
         });
     },
 
-    loadQuickSave: function() {
-        var data = $.getStorage(this.kag.config.projectID + "_tyrano_quick_save", this.kag.config.configSave);
+    loadQuickSave: function () {
+        var data = $.getStorage(
+            this.kag.config.projectID + "_tyrano_quick_save",
+            this.kag.config.configSave,
+        );
 
         if (data) {
             data = JSON.parse(data);
@@ -326,20 +342,25 @@ tyrano.plugin.kag.menu = {
     },
 
     //doSaveSnap 自動セーブのデータを保存する
-    doSetAutoSave: function() {
-
+    doSetAutoSave: function () {
         var data = this.snap;
         data.save_date = $.getNowDate() + "　" + $.getNowTime();
-        $.setStorage(this.kag.config.projectID + "_tyrano_auto_save", data, this.kag.config.configSave);
+        $.setStorage(
+            this.kag.config.projectID + "_tyrano_auto_save",
+            data,
+            this.kag.config.configSave,
+        );
 
         var layer_menu = this.kag.layer.getMenuLayer();
         layer_menu.hide();
-
     },
 
     //自動保存のデータを読み込む
-    loadAutoSave: function() {
-        var data = $.getStorage(this.kag.config.projectID + "_tyrano_auto_save", this.kag.config.configSave);
+    loadAutoSave: function () {
+        var data = $.getStorage(
+            this.kag.config.projectID + "_tyrano_auto_save",
+            this.kag.config.configSave,
+        );
 
         if (data) {
             data = JSON.parse(data);
@@ -347,18 +368,16 @@ tyrano.plugin.kag.menu = {
             return false;
         }
 
-        this.loadGameData($.extend(true, {}, data), { "auto_next": "yes" });
+        this.loadGameData($.extend(true, {}, data), { auto_next: "yes" });
     },
 
     //セーブ状態のスナップを保存します。
-    snapSave: function(title, call_back, flag_thumb) {
-
+    snapSave: function (title, call_back, flag_thumb) {
         var that = this;
 
         //画面のキャプチャも取るよ
         var _current_order_index = that.kag.ftag.current_order_index - 1;
         var _stat = $.extend(true, {}, $.cloneObject(that.kag.stat));
-
 
         //3Dオブジェクトが実装されてる場合復元させる。////////////////////
 
@@ -375,10 +394,8 @@ tyrano.plugin.kag.menu = {
         var save_models = {};
 
         for (var key in models) {
-
             var model = models[key];
             save_models[key] = model.toSaveObj();
-
         }
 
         three_save.models = save_models;
@@ -390,7 +407,6 @@ tyrano.plugin.kag.menu = {
         }
 
         if (flag_thumb == "false") {
-
             //サムネデータを保存しない
             var img_code = "";
             var data = {};
@@ -412,15 +428,11 @@ tyrano.plugin.kag.menu = {
             if (call_back) {
                 call_back();
             }
-
         } else {
-
             $("#tyrano_base").find(".layer_blend_mode").css("display", "none");
 
-            setTimeout(function() {
-
-                var completeImage = function(img_code) {
-
+            setTimeout(function () {
+                var completeImage = function (img_code) {
                     var data = {};
 
                     data.title = title;
@@ -441,34 +453,28 @@ tyrano.plugin.kag.menu = {
                     if (call_back) {
                         call_back();
                     }
-
                 };
 
                 if (that.kag.stat.save_img != "") {
                     var img = new Image();
                     img.src = _stat.save_img;
-                    img.onload = function() {
-
-                        var canvas = document.createElement('canvas');
+                    img.onload = function () {
+                        var canvas = document.createElement("canvas");
                         canvas.width = that.kag.config.scWidth;
                         canvas.height = that.kag.config.scHeight;
                         // Draw Image
-                        var ctx = canvas.getContext('2d');
+                        var ctx = canvas.getContext("2d");
                         ctx.drawImage(img, 0, 0);
                         // To Base64
                         var img_code = that.createImgCode(canvas);
 
                         completeImage(img_code);
-
-
                     };
-
                 } else {
-
                     //ビデオをキャプチャするための仕組み
-                    let canvas = document.createElement('canvas'); // declare a canvas element in your html
-                    let ctx = canvas.getContext('2d');
-                    let videos = document.querySelectorAll('video');
+                    let canvas = document.createElement("canvas"); // declare a canvas element in your html
+                    let ctx = canvas.getContext("2d");
+                    let videos = document.querySelectorAll("video");
                     let w, h;
                     for (let i = 0, len = videos.length; i < len; i++) {
                         const v = videos[i];
@@ -489,23 +495,23 @@ tyrano.plugin.kag.menu = {
                             ctx.fillRect(0, 0, w, h);
                             ctx.drawImage(v, 0, 0, w, h);
                             v.style.backgroundImage = `url(${canvas.toDataURL()})`; // here is the magic
-                            v.style.backgroundSize = 'cover';
+                            v.style.backgroundSize = "cover";
                             v.classList.add("tmp_video_canvas");
 
                             ctx.clearRect(0, 0, w, h); // clean the canvas
-
                         } catch (e) {
                             continue;
                         }
-
                     }
 
                     //canvasがある場合は、オリジナルをクローン。画面サイズによっては、カクつく問題が残る
                     var flag_canvas = false;
                     var array_canvas = [];
-                    $("#tyrano_base").find("canvas").each(function(index, element) {
-                        array_canvas.push(element);
-                    });
+                    $("#tyrano_base")
+                        .find("canvas")
+                        .each(function (index, element) {
+                            array_canvas.push(element);
+                        });
                     if (array_canvas.length > 0) {
                         flag_canvas = true;
                     }
@@ -536,17 +542,19 @@ tyrano.plugin.kag.menu = {
                         width: that.kag.config.scWidth,
                     };
 
-                    html2canvas(tmp_base.get(0), opt).then(function(canvas) {
-
-                        $("#tyrano_base").find(".layer_blend_mode").css("display", "");
-                        $("#tyrano_base").find(".tmp_video_canvas").css("backgroundImage", "");
+                    html2canvas(tmp_base.get(0), opt).then(function (canvas) {
+                        $("#tyrano_base")
+                            .find(".layer_blend_mode")
+                            .css("display", "");
+                        $("#tyrano_base")
+                            .find(".tmp_video_canvas")
+                            .css("backgroundImage", "");
 
                         // canvas is the final rendered <canvas> element
                         //console.log(canvas);
                         var img_code = that.createImgCode(canvas);
 
                         completeImage(img_code);
-
                     });
 
                     tmp_base.hide();
@@ -558,18 +566,13 @@ tyrano.plugin.kag.menu = {
                     $("body").find(".snap_tmp_base").remove();
 
                     tmp_base.show();
-
                 }
-
             }, 20);
-
         }
-
     },
 
     //サムネ画像の作成　thanks @hororo_memocho
-    createImgCode: function(canvas) {
-
+    createImgCode: function (canvas) {
         var code = "";
 
         var q = this.kag.config.configThumbnailQuality;
@@ -583,11 +586,9 @@ tyrano.plugin.kag.menu = {
         }
 
         return code;
-
     },
 
-    setGameSleep: function(next_flag) {
-
+    setGameSleep: function (next_flag) {
         //awake時にnextOrderするか否か
         if (next_flag) {
             this.kag.tmp.sleep_game_next = true;
@@ -596,12 +597,9 @@ tyrano.plugin.kag.menu = {
         }
 
         this.kag.tmp.sleep_game = this.snap;
-
     },
 
-
-    displayLoad: function(cb) {
-
+    displayLoad: function (cb) {
         var that = this;
 
         this.kag.stat.is_skip = false;
@@ -616,68 +614,70 @@ tyrano.plugin.kag.menu = {
             array[i].num = i;
         }
 
-        this.kag.html("load", {
-            array_save: array,
-            "novel": $.novel
-        }, function(html_str) {
-            var j_save = $(html_str);
+        this.kag.html(
+            "load",
+            {
+                array_save: array,
+                novel: $.novel,
+            },
+            function (html_str) {
+                var j_save = $(html_str);
 
-            j_save.find(".save_list").css("font-family", that.kag.config.userFace);
+                j_save
+                    .find(".save_list")
+                    .css("font-family", that.kag.config.userFace);
 
-            j_save.find(".save_display_area").each(function() {
+                j_save.find(".save_display_area").each(function () {
+                    $(this).click(function (e) {
+                        var num = $(this).attr("data-num");
 
-                $(this).click(function(e) {
-                    var num = $(this).attr("data-num");
+                        //セーブデータが存在しない場合
+                        if (array[num]["save_date"] == "") {
+                            return;
+                        }
 
-                    //セーブデータが存在しない場合
-                    if (array[num]["save_date"] == "") {
-                        return;
-                    }
+                        that.snap = null;
+                        that.loadGame(num);
 
-                    that.snap = null;
-                    that.loadGame(num);
-
-                    var layer_menu = that.kag.layer.getMenuLayer();
-                    layer_menu.hide();
-                    layer_menu.empty();
-                    if (that.kag.stat.visible_menu_button == true) {
-                        $(".button_menu").show();
-                    }
-
-                });
-            });
-
-
-            //スマホの場合はボタンの上下でスクロールできるようにする
-            j_save.find(".button_smart").hide();
-            if ($.userenv() != "pc") {
-                j_save.find(".button_smart").show();
-                j_save.find(".button_arrow_up").click(function() {
-                    var now = j_save.find(".area_save_list").scrollTop();
-                    var pos = now - 160;
-                    layer_menu.find(".area_save_list").animate({ scrollTop: pos }, { queue: false });
+                        var layer_menu = that.kag.layer.getMenuLayer();
+                        layer_menu.hide();
+                        layer_menu.empty();
+                        if (that.kag.stat.visible_menu_button == true) {
+                            $(".button_menu").show();
+                        }
+                    });
                 });
 
-                j_save.find(".button_arrow_down").click(function() {
-                    var now = j_save.find(".area_save_list").scrollTop();
-                    var pos = now + 160;
-                    j_save.find(".area_save_list").animate({ scrollTop: pos }, { queue: false });
-                });
+                //スマホの場合はボタンの上下でスクロールできるようにする
+                j_save.find(".button_smart").hide();
+                if ($.userenv() != "pc") {
+                    j_save.find(".button_smart").show();
+                    j_save.find(".button_arrow_up").click(function () {
+                        var now = j_save.find(".area_save_list").scrollTop();
+                        var pos = now - 160;
+                        layer_menu
+                            .find(".area_save_list")
+                            .animate({ scrollTop: pos }, { queue: false });
+                    });
 
-            }
+                    j_save.find(".button_arrow_down").click(function () {
+                        var now = j_save.find(".area_save_list").scrollTop();
+                        var pos = now + 160;
+                        j_save
+                            .find(".area_save_list")
+                            .animate({ scrollTop: pos }, { queue: false });
+                    });
+                }
 
+                var layer_menu = that.kag.layer.getMenuLayer();
 
-            var layer_menu = that.kag.layer.getMenuLayer();
-
-            that.setMenu(j_save, cb);
-
-        });
-
+                that.setMenu(j_save, cb);
+            },
+        );
     },
 
     //ゲームを途中から開始します
-    loadGame: function(num) {
-
+    loadGame: function (num) {
         var array_save = this.getSaveData();
         var array = array_save.data;
         //セーブデータ配列
@@ -694,12 +694,12 @@ tyrano.plugin.kag.menu = {
             auto_next = "yes";
         }
 
-        this.loadGameData($.extend(true, {}, array[num]), { "auto_next": auto_next });
-
+        this.loadGameData($.extend(true, {}, array[num]), {
+            auto_next: auto_next,
+        });
     },
 
-    loadGameData: function(data, options) {
-
+    loadGameData: function (data, options) {
         var auto_next = "no";
 
         //普通のロードの場合
@@ -749,14 +749,13 @@ tyrano.plugin.kag.menu = {
 
         //BGMを引き継ぐかどうか。
         if (options.bgm_over == "false") {
-
             //全BGMを一旦止める
             var map_se = this.kag.tmp.map_se;
             for (var key in map_se) {
                 if (map_se[key]) {
                     this.kag.ftag.startTag("stopse", {
                         stop: "true",
-                        buf: key
+                        buf: key,
                     });
                 }
             }
@@ -765,14 +764,12 @@ tyrano.plugin.kag.menu = {
             for (var key in map_bgm) {
                 this.kag.ftag.startTag("stopbgm", {
                     stop: "true",
-                    buf: key
+                    buf: key,
                 });
             }
 
-
             //音楽再生
             if (this.kag.stat.current_bgm != "") {
-
                 var mstorage = this.kag.stat.current_bgm;
 
                 var pm = {
@@ -781,7 +778,7 @@ tyrano.plugin.kag.menu = {
                     html5: this.kag.stat.current_bgm_html5,
                     /*fadein:"true",*/
                     /*time:2000,*/
-                    stop: "true"
+                    stop: "true",
                 };
 
                 //ボリュームが設定されいる場合
@@ -790,7 +787,6 @@ tyrano.plugin.kag.menu = {
                 }
 
                 this.kag.ftag.startTag("playbgm", pm);
-
             }
 
             //効果音再生
@@ -798,20 +794,21 @@ tyrano.plugin.kag.menu = {
                 var pm_obj = this.kag.stat.current_se[key];
                 pm_obj["stop"] = "true";
                 this.kag.ftag.startTag("playse", pm_obj);
-
             }
-
         }
 
         //読み込んだCSSがある場合
-        $('head').find("._tyrano_cssload_tag").remove();
+        $("head").find("._tyrano_cssload_tag").remove();
         if (this.kag.stat.cssload) {
             for (file in this.kag.stat.cssload) {
-                var style = '<link class="_tyrano_cssload_tag" rel="stylesheet" href="' + $.escapeHTML(file) + "?" + Math.floor(Math.random() * 10000000) + '">';
-                $('head link:last').after(style);
-
+                var style =
+                    '<link class="_tyrano_cssload_tag" rel="stylesheet" href="' +
+                    $.escapeHTML(file) +
+                    "?" +
+                    Math.floor(Math.random() * 10000000) +
+                    '">';
+                $("head link:last").after(style);
             }
-
         } else {
             this.kag.stat.cssload = {};
         }
@@ -819,13 +816,12 @@ tyrano.plugin.kag.menu = {
         if (!this.kag.stat.current_bgmovie) {
             this.kag.stat.current_bgmovie = {
                 storage: "",
-                volume: ""
+                volume: "",
             };
         }
 
         //カメラ設定を復旧 ///////////////
         if (this.kag.config.useCamera == "true") {
-
             $(".layer_camera").css({
                 "-animation-name": "",
                 "-animation-duration": "",
@@ -834,52 +830,50 @@ tyrano.plugin.kag.menu = {
                 "-animation-iteration-count": "",
                 "-animation-direction": "",
                 "-animation-fill-mode": "",
-                "-animation-timing-function": ""
+                "-animation-timing-function": "",
             });
 
             for (key in this.kag.stat.current_camera) {
-
                 var a3d_define = {
                     frames: {
                         "0%": {
-                            trans: this.kag.stat.current_camera[key]
+                            trans: this.kag.stat.current_camera[key],
                         },
                         "100%": {
-                            trans: this.kag.stat.current_camera[key]
-                        }
+                            trans: this.kag.stat.current_camera[key],
+                        },
                     },
 
                     config: {
                         duration: "5ms",
                         state: "running",
-                        easing: "ease"
+                        easing: "ease",
                     },
 
-                    complete: function() {
+                    complete: function () {
                         //特に処理なし
-                    }
-
+                    },
                 };
 
                 //アニメーションの実行
                 if (key == "layer_camera") {
-
-                    $(".layer_camera").css("-webkit-transform-origin", "center center");
-                    setTimeout(function() {
+                    $(".layer_camera").css(
+                        "-webkit-transform-origin",
+                        "center center",
+                    );
+                    setTimeout(function () {
                         $(".layer_camera").a3d(a3d_define);
                     }, 1);
-
                 } else {
-
-                    $("." + key + "_fore").css("-webkit-transform-origin", "center center");
-                    setTimeout(function() {
+                    $("." + key + "_fore").css(
+                        "-webkit-transform-origin",
+                        "center center",
+                    );
+                    setTimeout(function () {
                         $("." + key + "_fore").a3d(a3d_define);
                     }, 1);
-
                 }
-
             }
-
         }
         ///////////カメラここまで
 
@@ -887,40 +881,31 @@ tyrano.plugin.kag.menu = {
         $(".tyrano_base").find("video").remove();
         this.kag.tmp.video_playing = false;
 
-
         //背景動画が設定中なら
         if (this.kag.stat.current_bgmovie["storage"] != "") {
-
             var vstorage = this.kag.stat.current_bgmovie["storage"];
             var volume = this.kag.stat.current_bgmovie["volume"];
 
             var pm = {
-
                 storage: vstorage,
                 volume: volume,
-                stop: "true"
-
+                stop: "true",
             };
 
             this.kag.tmp.video_playing = false;
 
             this.kag.ftag.startTag("bgmovie", pm);
-
         }
 
         //カメラが設定中なら
         if (this.kag.stat.current_bgcamera != "") {
-
             this.kag.stat.current_bgcamera["stop"] = "true";
             this.kag.ftag.startTag("bgcamera", this.kag.stat.current_bgcamera);
-
         }
-
 
         //3Dモデルの復元/////////////////////////////////////////////
         var three = data.three;
         if (three.stat.is_load == true) {
-
             this.kag.stat.is_strong_stop = true;
             var init_pm = three.stat.init_pm;
 
@@ -938,9 +923,7 @@ tyrano.plugin.kag.menu = {
 
             this.kag.ftag.startTag("3d_scene", scene_pm);
 
-
             for (var key in models) {
-
                 var model = models[key];
                 var pm = model.pm;
 
@@ -958,7 +941,6 @@ tyrano.plugin.kag.menu = {
                 pm["next"] = "false";
 
                 this.kag.ftag.startTag(tag, pm);
-
             }
 
             //ジャイロの復元
@@ -969,7 +951,6 @@ tyrano.plugin.kag.menu = {
                 gyro_pm["next"] = "false";
                 this.kag.ftag.startTag("3d_gyro", gyro_pm);
             }
-
 
             if (three.stat.canvas_show) {
                 this.kag.tmp.three.j_canvas.show();
@@ -984,10 +965,7 @@ tyrano.plugin.kag.menu = {
 
             this.kag.stat.is_strong_stop = false;
 
-
-
             //},10);
-
         }
 
         /////////////////////////////////////////////
@@ -1003,13 +981,12 @@ tyrano.plugin.kag.menu = {
         }
 
         //イベントの復元
-        $(".event-setting-element").each(function() {
+        $(".event-setting-element").each(function () {
             var j_elm = $(this);
             var kind = j_elm.attr("data-event-tag");
             var pm = JSON.parse(j_elm.attr("data-event-pm"));
             var event_tag = object(tyrano.plugin.kag.tag[kind]);
             event_tag.setEvent(j_elm, pm);
-
         });
 
         //ジャンプ
@@ -1021,16 +998,13 @@ tyrano.plugin.kag.menu = {
         //auto_next 一旦makeを経由するときに、auto_nextを考えておく
         //alert(auto_next);
 
-
         var insert = {
-
             name: "call",
             pm: {
                 storage: "make.ks",
-                "auto_next": auto_next
+                auto_next: auto_next,
             },
-            val: ""
-
+            val: "",
         };
 
         //auto_next = "yes";
@@ -1041,78 +1015,76 @@ tyrano.plugin.kag.menu = {
         //添付変数は消す。
         this.kag.clearTmpVariable();
 
-        this.kag.ftag.nextOrderWithIndex(data.current_order_index, data.stat.current_scenario, true, insert, "yes");
-
-
-
+        this.kag.ftag.nextOrderWithIndex(
+            data.current_order_index,
+            data.stat.current_scenario,
+            true,
+            insert,
+            "yes",
+        );
     },
 
     //メニュー画面に指定のJクエリオブジェクト追加
-    setMenu: function(j_obj, cb) {
-
+    setMenu: function (j_obj, cb) {
         var that = this;
 
         var layer_menu = this.kag.layer.getMenuLayer();
 
         //        layer_menu.empty();
 
-        j_obj.find(".menu_close").click(function(e) {
-
-            layer_menu.fadeOut(300, function() {
+        j_obj.find(".menu_close").click(function (e) {
+            layer_menu.fadeOut(300, function () {
                 layer_menu.empty();
 
                 if (typeof cb == "function") {
                     //終わったタイミングでコールバックを返す
                     cb();
                 }
-
             });
             if (that.kag.stat.visible_menu_button == true) {
                 $(".button_menu").show();
             }
-
         });
 
         j_obj.hide();
         layer_menu.append(j_obj);
         layer_menu.show();
-        $.preloadImgCallback(layer_menu, function() {
-            j_obj.stop(true, true).fadeIn(300);
-            layer_menu.find(".block_menu").fadeOut(300);
-        }, that);
-
+        $.preloadImgCallback(
+            layer_menu,
+            function () {
+                j_obj.stop(true, true).fadeIn(300);
+                layer_menu.find(".block_menu").fadeOut(300);
+            },
+            that,
+        );
     },
 
     //メニューを隠します
-    hideMenu: function() {
-
-    },
+    hideMenu: function () {},
 
     //セーブデータを取得します
-    getSaveData: function() {
-
-        var tmp_array = $.getStorage(this.kag.config.projectID + "_tyrano_data", this.kag.config.configSave);
+    getSaveData: function () {
+        var tmp_array = $.getStorage(
+            this.kag.config.projectID + "_tyrano_data",
+            this.kag.config.configSave,
+        );
 
         if (tmp_array) {
-
             // データがある場合は一覧として表示します
             //return eval("(" + tmp_array + ")");
             return JSON.parse(tmp_array);
-
-
         } else {
             tmp_array = new Array();
 
             var root = {
                 kind: "save",
-                hash: this.kag.save_key_val
+                hash: this.kag.save_key_val,
             };
 
             //セーブ数の上限を変更する。
             var save_slot_num = this.kag.config.configSaveSlotNum || 5;
 
             for (var i = 0; i < save_slot_num; i++) {
-
                 var json = {};
                 json.title = $.lang("not_saved");
                 // ラストテキスト
@@ -1122,95 +1094,96 @@ tyrano.plugin.kag.menu = {
                 json.stat = {};
 
                 tmp_array.push(json);
-
             }
 
             root.data = tmp_array;
 
             return root;
-
         }
-
     },
 
     //バックログ画面表示
-    displayLog: function() {
-
+    displayLog: function () {
         var that = this;
         this.kag.stat.is_skip = false;
 
         var j_save = $("<div></div>");
 
-        this.kag.html("backlog", {
-            "novel": $.novel
-        }, function(html_str) {
+        this.kag.html(
+            "backlog",
+            {
+                novel: $.novel,
+            },
+            function (html_str) {
+                var j_menu = $(html_str);
 
-            var j_menu = $(html_str);
+                var layer_menu = that.kag.layer.getMenuLayer();
+                layer_menu.empty();
+                layer_menu.append(j_menu);
 
-            var layer_menu = that.kag.layer.getMenuLayer();
-            layer_menu.empty();
-            layer_menu.append(j_menu);
-
-            layer_menu.find(".menu_close").click(function() {
-                layer_menu.fadeOut(300, function() {
-                    layer_menu.empty();
+                layer_menu.find(".menu_close").click(function () {
+                    layer_menu.fadeOut(300, function () {
+                        layer_menu.empty();
+                    });
+                    if (that.kag.stat.visible_menu_button == true) {
+                        $(".button_menu").show();
+                    }
                 });
-                if (that.kag.stat.visible_menu_button == true) {
-                    $(".button_menu").show();
+
+                //スマホの場合はボタンの上下でスクロールできるようにする
+                layer_menu.find(".button_smart").hide();
+                if ($.userenv() != "pc") {
+                    layer_menu.find(".button_smart").show();
+                    layer_menu.find(".button_arrow_up").click(function () {
+                        var now = layer_menu.find(".log_body").scrollTop();
+                        var pos = now - 60;
+                        layer_menu
+                            .find(".log_body")
+                            .animate({ scrollTop: pos }, { queue: false });
+                    });
+
+                    layer_menu.find(".button_arrow_down").click(function () {
+                        var now = layer_menu.find(".log_body").scrollTop();
+                        var pos = now + 60;
+                        layer_menu
+                            .find(".log_body")
+                            .animate({ scrollTop: pos }, { queue: false });
+                    });
                 }
-            });
 
-            //スマホの場合はボタンの上下でスクロールできるようにする
-            layer_menu.find(".button_smart").hide();
-            if ($.userenv() != "pc") {
-                layer_menu.find(".button_smart").show();
-                layer_menu.find(".button_arrow_up").click(function() {
-                    var now = layer_menu.find(".log_body").scrollTop();
-                    var pos = now - 60;
-                    layer_menu.find(".log_body").animate({ scrollTop: pos }, { queue: false });
-                });
+                var log_str = "";
 
-                layer_menu.find(".button_arrow_down").click(function() {
-                    var now = layer_menu.find(".log_body").scrollTop();
-                    var pos = now + 60;
-                    layer_menu.find(".log_body").animate({ scrollTop: pos }, { queue: false });
-                });
+                var array_log = that.kag.variable.tf.system.backlog;
 
-            }
+                for (var i = 0; i < array_log.length; i++) {
+                    log_str += array_log[i] + "<br />";
+                }
 
-            var log_str = "";
+                layer_menu.find(".log_body").html(log_str);
 
-            var array_log = that.kag.variable.tf.system.backlog;
+                layer_menu
+                    .find(".log_body")
+                    .css("font-family", that.kag.config.userFace);
 
-            for (var i = 0; i < array_log.length; i++) {
-                log_str += array_log[i] + "<br />";
-            }
+                $.preloadImgCallback(
+                    layer_menu,
+                    function () {
+                        layer_menu.stop(true, true).fadeIn(300);
+                        //一番下固定させる
+                        layer_menu.find(".log_body").scrollTop(9999999999);
+                    },
+                    that,
+                );
 
-            layer_menu.find(".log_body").html(log_str);
-
-            layer_menu.find(".log_body").css("font-family", that.kag.config.userFace);
-
-
-            $.preloadImgCallback(layer_menu, function() {
-                layer_menu.stop(true, true).fadeIn(300);
-                //一番下固定させる
-                layer_menu.find(".log_body").scrollTop(9999999999);
-
-            }, that);
-
-
-            $(".button_menu").hide();
-
-        });
-
+                $(".button_menu").hide();
+            },
+        );
     },
 
     //画面をフルスクリーンにします
-    screenFull: function() {
-
+    screenFull: function () {
         //V5以降は使用しない
         if (false) {
-
             var gui = require("nw.gui");
             var win = gui.Window.get();
             if (win.isFullscreen) {
@@ -1218,15 +1191,22 @@ tyrano.plugin.kag.menu = {
             } else {
                 win.enterFullscreen();
             }
-
         } else {
-
-            var isFullScreen = document.webkitFullscreenElement || document.mozFullScreenElement || document.msFullscreenElement || document.fullScreenElement || false;
-            var isEnableFullScreen = document.fullscreenEnabled || document.webkitFullscreenEnabled || document.mozFullScreenEnabled || document.msFullscreenEnabled || false;
+            var isFullScreen =
+                document.webkitFullscreenElement ||
+                document.mozFullScreenElement ||
+                document.msFullscreenElement ||
+                document.fullScreenElement ||
+                false;
+            var isEnableFullScreen =
+                document.fullscreenEnabled ||
+                document.webkitFullscreenEnabled ||
+                document.mozFullScreenEnabled ||
+                document.msFullscreenEnabled ||
+                false;
             var elem = document.body;
 
             if (isEnableFullScreen) {
-
                 if (elem.requestFullscreen) {
                     if (isFullScreen) {
                         document.exitFullscreen();
@@ -1253,12 +1233,8 @@ tyrano.plugin.kag.menu = {
                     }
                 }
             }
-
         }
-
     },
 
-    test: function() {
-
-    }
+    test: function () {},
 };

--- a/tyrano/plugins/kag/kag.parser.js
+++ b/tyrano/plugins/kag/kag.parser.js
@@ -1,59 +1,46 @@
-
 tyrano.plugin.kag.parser = {
-
     tyrano: null,
     kag: null,
 
     flag_script: false, //スクリプト解析中なら
     deep_if: 0,
 
-    init: function() {
-
+    init: function () {
         //alert("kag.parser 初期化");
         //this.tyrano.test();
-
-
     },
 
-    loadConfig: function(call_back) {
-
+    loadConfig: function (call_back) {
         var that = this;
 
         //同じディレクトリにある、KAG関連のデータを読み込み
-        $.loadText("./data/system/Config.tjs", function(text_str) {
-
+        $.loadText("./data/system/Config.tjs", function (text_str) {
             var map_config = that.compileConfig(text_str);
 
             if (call_back) {
                 call_back(map_config);
             }
-
         });
-
     },
 
     //コンフィグファイルをデータ構造に格納
-    compileConfig: function(text_str) {
-
+    compileConfig: function (text_str) {
         var error_str = "";
         var map_config = {};
 
         var array_config = text_str.split("\n");
 
         for (var i = 0; i < array_config.length; i++) {
-
             try {
-
                 var line_str = $.trim(array_config[i]);
                 if (line_str != "" && line_str.substr(0, 1) === ";") {
-
                     var tmp_comment = line_str.split("//");
                     if (tmp_comment.length > 1) {
                         line_str = $.trim(tmp_comment[0]);
                     }
 
                     line_str = $.replaceAll(line_str, ";", "");
-                    line_str = $.replaceAll(line_str, "\"", "");
+                    line_str = $.replaceAll(line_str, '"', "");
 
                     var tmp = line_str.split("=");
 
@@ -61,13 +48,9 @@ tyrano.plugin.kag.parser = {
                     var val = $.trim(tmp[1]);
                     map_config[key] = val;
                 }
-
             } catch (e) {
-
                 error_str += "Error:Config.tjsに誤りがあります/行:" + i + "";
-
             }
-
         }
 
         if (error_str != "") {
@@ -75,12 +58,10 @@ tyrano.plugin.kag.parser = {
         }
 
         return map_config;
-
     },
 
     //シナリオをオブジェクト化する
-    parseScenario: function(text_str) {
-
+    parseScenario: function (text_str) {
         var array_s = [];
 
         var map_label = {}; //ラベル一覧
@@ -90,7 +71,6 @@ tyrano.plugin.kag.parser = {
         var flag_comment = false; //コメント中なら
 
         for (var i = 0; i < array_row.length; i++) {
-
             var line_str = $.trim(array_row[i]);
             var first_char = line_str.substr(0, 1);
 
@@ -104,9 +84,7 @@ tyrano.plugin.kag.parser = {
             } else if (line_str === "/*") {
                 flag_comment = true;
             } else if (flag_comment == true || first_char === ";") {
-
             } else if (first_char === "#") {
-
                 var tmp_line = $.trim(line_str.replace("#", ""));
                 var chara_name = "";
                 var chara_face = "";
@@ -121,13 +99,11 @@ tyrano.plugin.kag.parser = {
                 var text_obj = {
                     line: i,
                     name: "chara_ptext",
-                    pm: { "name": chara_name, "face": chara_face },
-                    val: text
+                    pm: { name: chara_name, face: chara_face },
+                    val: text,
                 };
 
                 array_s.push(text_obj);
-
-
             } else if (first_char === "*") {
                 //ラベル
 
@@ -145,12 +121,12 @@ tyrano.plugin.kag.parser = {
                 var label_obj = {
                     name: "label",
                     pm: {
-                        "line": i,
-                        "index": array_s.length,
-                        "label_name": label_key,
-                        "val": label_val
+                        line: i,
+                        index: array_s.length,
+                        label_name: label_key,
+                        val: label_val,
                     },
-                    val: label_val
+                    val: label_val,
                 };
 
                 //ラベル
@@ -158,19 +134,25 @@ tyrano.plugin.kag.parser = {
 
                 if (map_label[label_obj.pm.label_name]) {
                     //this.kag.warning("警告:"+i+"行目:"+"ラベル名「"+label_obj.pm.label_name+"」は同一シナリオファイル内に重複しています");
-                    this.kag.warning("Warning line:" + i + " " + $.lang("label") + "'" + label_obj.pm.label_name + "'" + $.lang("label_double"));
-
+                    this.kag.warning(
+                        "Warning line:" +
+                            i +
+                            " " +
+                            $.lang("label") +
+                            "'" +
+                            label_obj.pm.label_name +
+                            "'" +
+                            $.lang("label_double"),
+                    );
                 } else {
                     map_label[label_obj.pm.label_name] = label_obj.pm;
                 }
-
             } else if (first_char === "@") {
                 //コマンド行確定なので、その残りの部分を、ごそっと回す
                 var tag_str = line_str.substr(1, line_str.length); // "image split=2 samba = 5"
                 var tmpobj = this.makeTag(tag_str, i);
                 array_s.push(tmpobj);
             } else {
-
                 //半角アンダーバーで始まっている場合は空白ではじめる
                 if (first_char === "_") {
                     line_str = line_str.substring(1, line_str.length);
@@ -178,7 +160,7 @@ tyrano.plugin.kag.parser = {
 
                 var array_char = line_str.split("");
 
-                var text = "";//命令じゃない部分はここに配置していく
+                var text = ""; //命令じゃない部分はここに配置していく
 
                 var tag_str = "";
 
@@ -191,43 +173,37 @@ tyrano.plugin.kag.parser = {
                     var c = array_char[j];
 
                     if (flag_tag === true) {
-
                         if (c === "]" && this.flag_script == false) {
-
                             num_kakko--;
 
                             if (num_kakko == 0) {
-
                                 flag_tag = false;
                                 array_s.push(this.makeTag(tag_str, i));
                                 //tag_str をビルドして、命令配列に格納
                                 tag_str = "";
-
                             } else {
                                 tag_str += c;
                             }
                         } else if (c === "[" && this.flag_script == false) {
-
                             num_kakko++;
                             tag_str += c;
-
                         } else {
                             tag_str += c;
                         }
-
-                    }
-                    else if (flag_tag === false && c === "[" && this.flag_script == false) {
-
+                    } else if (
+                        flag_tag === false &&
+                        c === "[" &&
+                        this.flag_script == false
+                    ) {
                         num_kakko++;
 
                         //テキストファイルを命令に格納
                         if (text != "") {
-
                             var text_obj = {
                                 line: i,
                                 name: "text",
-                                pm: { "val": text },
-                                val: text
+                                pm: { val: text },
+                                val: text,
                             };
 
                             array_s.push(text_obj);
@@ -236,59 +212,50 @@ tyrano.plugin.kag.parser = {
                         }
 
                         flag_tag = true;
-
                     } else {
-
                         text += c;
                     }
-
                 }
 
                 if (text != "") {
                     var text_obj = {
                         line: i,
                         name: "text",
-                        pm: { "val": text },
-                        val: text
+                        pm: { val: text },
+                        val: text,
                     };
 
                     array_s.push(text_obj);
                 }
 
                 //console.log(array_char);
-
             }
             //１行づつ解析解析していく
-
         }
 
         var result_obj = {
-
             array_s: array_s,
-            map_label: map_label
-
+            map_label: map_label,
         };
 
         if (this.deep_if != 0) {
-            alert("[if]と[endif]の数が一致しません。シナリオを見直してみませんか？");
+            alert(
+                "[if]と[endif]の数が一致しません。シナリオを見直してみませんか？",
+            );
             this.deep_if = 0;
         }
 
         return result_obj;
-
-
     },
 
     //タグ情報から、オブジェクトを作成して返却する
-    makeTag: function(str, line) {
-
+    makeTag: function (str, line) {
         var obj = {
             line: line,
             name: "",
             pm: {},
-            val: ""
+            val: "",
         };
-
 
         var array_c = str.split("");
 
@@ -299,20 +266,16 @@ tyrano.plugin.kag.parser = {
         var cnt_quot_c = 0;
 
         for (var j = 0; j < array_c.length; j++) {
-
             var c = array_c[j];
 
-            if (flag_quot_c == "" && (c === "\"" || c === "'")) {
+            if (flag_quot_c == "" && (c === '"' || c === "'")) {
                 flag_quot_c = c;
                 cnt_quot_c = 0;
             } else {
-
                 //特殊自体発生中
                 if (flag_quot_c != "") {
-
                     //特殊状態解除
                     if (c === flag_quot_c) {
-
                         flag_quot_c = "";
 
                         //""のように直後に"が出てきた場合undefinedを代入
@@ -321,9 +284,7 @@ tyrano.plugin.kag.parser = {
                         }
 
                         cnt_quot_c = 0;
-
                     } else {
-
                         if (c == "=") {
                             c = "#";
                         }
@@ -336,18 +297,11 @@ tyrano.plugin.kag.parser = {
 
                         tmp_str += c;
                         cnt_quot_c++;
-
                     }
-
-
-
                 } else {
                     tmp_str += c;
                 }
-
             }
-
-
         }
 
         str = tmp_str;
@@ -362,20 +316,15 @@ tyrano.plugin.kag.parser = {
 
         //=のみが出てきた場合は前後のをくっつけて、ひとつの変数にしてしまって良い
         for (var k = 1; k < array.length; k++) {
-
             if (array[k] == "") {
-
                 array.splice(k, 1);
                 k--;
-            }
-
-            else if (array[k] === "=") {
+            } else if (array[k] === "=") {
                 if (array[k - 1]) {
                     if (array[k + 1]) {
                         array[k - 1] = array[k - 1] + "=" + array[k + 1];
                         array.splice(k, 2);
                         k--;
-
                     }
                 }
             } else if (array[k].substr(0, 1) === "=") {
@@ -384,26 +333,22 @@ tyrano.plugin.kag.parser = {
                         array[k - 1] = array[k - 1] + array[k];
                         array.splice(k, 1);
                         //k--;
-
                     }
                 }
-            } else if (array[k].substr(array[k].length - 1, array[k].length) === "=") {
+            } else if (
+                array[k].substr(array[k].length - 1, array[k].length) === "="
+            ) {
                 if (array[k + 1]) {
                     if (array[k]) {
                         array[k] = array[k] + array[k + 1];
                         array.splice(k + 1, 1);
                         //k--;
-
                     }
                 }
             }
-
-
-
         }
 
         for (var i = 1; i < array.length; i++) {
-
             var tmp = $.trim(array[i]).split("=");
 
             var pm_key = $.trim(tmp[0]);
@@ -421,7 +366,6 @@ tyrano.plugin.kag.parser = {
             if (pm_val == "undefined") {
                 obj.pm[pm_key] = "";
             }
-
         }
 
         if (obj.name == "iscript") {
@@ -430,7 +374,6 @@ tyrano.plugin.kag.parser = {
         if (obj.name == "endscript") {
             this.flag_script = false;
         }
-
 
         switch (obj.name) {
             case "if":
@@ -443,13 +386,10 @@ tyrano.plugin.kag.parser = {
                 obj.pm.deep_if = this.deep_if;
                 this.deep_if--;
                 break;
-        };
+        }
 
         return obj;
-
     },
 
-    test: function() {
-
-    }
+    test: function () {},
 };

--- a/tyrano/plugins/kag/kag.rider.js
+++ b/tyrano/plugins/kag/kag.rider.js
@@ -2,16 +2,15 @@
 //デバッグツール向けの処理が集中します。
 
 tyrano.plugin.kag.rider = {
-
     app: {}, //ライダー側のルート
     tyrano: null,
     rider_view: {},
 
-    init: function() {
+    init: function () {
         //alert("init rider");
     },
 
-    complete: function(TG) {
+    complete: function (TG) {
         //ゲームがスタートした時にライダー側に通知する
         //alert("complete!");
         //riderからの起動かどうかを判定する必要あり
@@ -21,18 +20,14 @@ tyrano.plugin.kag.rider = {
                 this.app = window.opener.app;
                 this.app.completeRider(TG);
             }
-
         }
     },
 
-    cutTyranoTag: function(tag, pm) {
-
+    cutTyranoTag: function (tag, pm) {
         TYRANO.kag.ftag.startTag(tag, pm);
-
     },
 
-    cutTyranoScript: function(str) {
-
+    cutTyranoScript: function (str) {
         var result = TYRANO.kag.parser.parseScenario(str);
 
         var array_s = result.array_s;
@@ -41,89 +36,83 @@ tyrano.plugin.kag.rider = {
             this.app.rider_view.pushConsoleGrid("tag", tag);
             this.cutTyranoTag(tag.name, tag.pm);
         }
-
     },
 
-    insertElement: function(category, file) {
-
+    insertElement: function (category, file) {
         var path = "./data/" + category + "/" + file;
 
         if (category == "fgimage" || category == "image") {
-            var j_img = $("<div style='position:absolute;z-index:9999999;'><div class='area_pos' style='position:absolute;width:100px;opacity:0.5;background-color:black;color:white'></div><div class='button_delete' style='position:absolute;right:0px;border:solid 1px gray;background-color:white;width:20px;height:20px;cursor:pointer' >×</div><img style='border:solid 1px green;' src='" + path + "' /></div>");
+            var j_img = $(
+                "<div style='position:absolute;z-index:9999999;'><div class='area_pos' style='position:absolute;width:100px;opacity:0.5;background-color:black;color:white'></div><div class='button_delete' style='position:absolute;right:0px;border:solid 1px gray;background-color:white;width:20px;height:20px;cursor:pointer' >×</div><img style='border:solid 1px green;' src='" +
+                    path +
+                    "' /></div>",
+            );
 
-            (function() {
-
+            (function () {
                 var _j_img = j_img;
                 var _category = category;
                 var _file = file;
 
-
                 j_img.draggable({
-
                     scroll: false,
                     //containment:".tyrano_base",
-                    stop: function(e, ui) {
-
+                    stop: function (e, ui) {
                         //j_x.html(ui.position.left);
                         //j_y.html(ui.position.top);
-                        _j_img.find(".area_pos").html("x:" + ui.position.left + " y:" + ui.position.top);
+                        _j_img
+                            .find(".area_pos")
+                            .html(
+                                "x:" +
+                                    ui.position.left +
+                                    " y:" +
+                                    ui.position.top,
+                            );
 
                         //タグのプレビューがここに表示される
-
-                    }
+                    },
                 });
 
-                _j_img.find(".button_delete").click(function() {
+                _j_img.find(".button_delete").click(function () {
                     _j_img.remove();
                 });
 
                 //ドラッグを出来るように
                 $(".tyrano_base").attr("ondragstart", "");
                 $(".tyrano_base").append(_j_img);
-
             })();
-
         } else if (category == "bgimage") {
             //背景画像変更
             var j_new_bg = TYRANO.kag.layer.getLayer("base", "fore");
             j_new_bg.css("background-image", "url(" + path + ")");
-
         }
-
     },
 
     //シナリオのラベル一覧を取得する
-    getScenario: function(scenario_name, call_back) {
-
+    getScenario: function (scenario_name, call_back) {
         var that = this;
 
         var file_url = "./data/scenario/" + scenario_name;
 
-        $.loadText(file_url, function(text_str) {
-
+        $.loadText(file_url, function (text_str) {
             var result_obj = TYRANO.kag.parser.parseScenario(text_str);
 
             if (call_back) {
                 call_back(result_obj);
             }
-
         });
         //ラベルの一覧を取得
 
         //呼び出し元（riderの関数呼び出し方法）
         //window.opener.myFunc();
-
     },
 
     //キャラクター情報を返却する
-    getCharaInfo: function() {
-
+    getCharaInfo: function () {
         return TYRANO.kag.stat.charas;
-
     },
 
     //変数を取得する
-    getVariables: function() {
+    getVariables: function () {
         var map_variable = TYRANO.kag.variable;
 
         var f = TYRANO.kag.stat.f;
@@ -136,24 +125,23 @@ tyrano.plugin.kag.rider = {
     },
 
     //ライダー側で変数が編集された
-    evalScript: function(str) {
+    evalScript: function (str) {
         TYRANO.kag.evalScript(str);
     },
 
     //変数値を更新します
-    pushVariableGrid: function() {
+    pushVariableGrid: function () {
         //更新が合ったことを通知するだけ
         this.app.rider_view.updateVariable();
     },
 
-    initSave: function() {
+    initSave: function () {
         localStorage.clear();
     },
 
     //命令が実行されて、デバッグツール側にコンソールを発信する
-    pushConsoleLog: function(tag) {
+    pushConsoleLog: function (tag) {
         //タグをアプリ側にプッシュします
         this.app.rider_view.pushConsoleGrid("tag", tag);
-
-    }
+    },
 };

--- a/tyrano/plugins/kag/kag.studio.js
+++ b/tyrano/plugins/kag/kag.studio.js
@@ -2,7 +2,6 @@
 //デバッグツール向けの処理が集中します。
 
 tyrano.plugin.kag.studio = {
-
     app: {}, //ライダー側のルート
     tyrano: null,
     rider_view: {},
@@ -13,34 +12,30 @@ tyrano.plugin.kag.studio = {
 
     map_watch: {},
 
-    init: function() {
+    init: function () {
         //alert("init rider");
 
         if (window.navigator.userAgent.indexOf("TyranoStudio") != -1) {
-
             //スタジオ拡張用。iframeで読み込んだときの対応
             try {
-                this.ipc = require('electron');
+                this.ipc = require("electron");
             } catch (e) {
                 return false;
             }
 
-
             TYRANO.kag.is_studio = true;
 
-            this.ipc = require('electron');
+            this.ipc = require("electron");
 
-            this.ipc.ipcRenderer.on('ping', (event, arg) => {
-                this.send('asynchronous-reply', JSON.stringify(arg));
+            this.ipc.ipcRenderer.on("ping", (event, arg) => {
+                this.send("asynchronous-reply", JSON.stringify(arg));
             });
 
-            this.ipc.ipcRenderer.on('variable-add', (event, arg) => {
-
+            this.ipc.ipcRenderer.on("variable-add", (event, arg) => {
                 let data = JSON.parse(arg);
                 let array_name = data["names"];
 
                 for (let i = 0; i < array_name.length; i++) {
-
                     let name = array_name[i]["name"];
 
                     let val = "" + this.kag.embScript(name);
@@ -48,25 +43,20 @@ tyrano.plugin.kag.studio = {
                     this.map_watch[name] = val;
 
                     array_name[i]["val"] = val;
-
                 }
 
                 data["names"] = array_name;
 
-                this.send('changed-variable', data);
-
+                this.send("changed-variable", data);
             });
 
             //セーブデータの消去
-            this.ipc.ipcRenderer.on('status-clear-save-data', (event, arg) => {
-
+            this.ipc.ipcRenderer.on("status-clear-save-data", (event, arg) => {
                 localStorage.clear();
-
             });
 
             //ステータスのロード
             this.ipc.ipcRenderer.on("status-load-save", (event, arg) => {
-
                 let data = JSON.parse(arg);
                 let slot = data["slot"];
 
@@ -76,35 +66,30 @@ tyrano.plugin.kag.studio = {
                         clearInterval(timer_id);
                         this.kag.menu.loadGame(slot);
                     }
-
                 }, 100);
-
             });
 
             //タグの実行
             this.ipc.ipcRenderer.on("exe-tag", (event, arg) => {
-
                 let data = JSON.parse(arg);
                 let tag_text = data["tag_text"];
 
                 this.cutTyranoScript(tag_text);
-
             });
 
-            this.ipc.ipcRenderer.on("material-preview-position", (event, arg) => {
+            this.ipc.ipcRenderer.on(
+                "material-preview-position",
+                (event, arg) => {
+                    let data = JSON.parse(arg);
 
-                let data = JSON.parse(arg);
+                    let file = data["file"];
+                    let category = data["category"];
 
-                let file = data["file"];
-                let category = data["category"];
-
-                this.insertElement(category, file);
-
-
-            });
+                    this.insertElement(category, file);
+                },
+            );
 
             this.ipc.ipcRenderer.on("variable-add-all", (event, arg) => {
-
                 //すべての変数を読み込んでスタジオに通知する
                 var map_variable = TYRANO.kag.variable;
 
@@ -115,28 +100,24 @@ tyrano.plugin.kag.studio = {
                 map_variable.mp = mp;
 
                 this.send("init-variable-all", map_variable);
-
-
             });
 
             //キャラの情報をアップデートする
             setInterval((e) => {
-
                 let charas = this.kag.stat.charas;
                 this.send("chara-update-charas", charas);
-
             }, 5000);
 
-
             //リロードボタンの配置
-            var j_reload_button = $("<div style='position:absolute;z-index:999999999;padding:10px;opacity:0.8;background-color:white;left:0px;top:0px'><button style='cursor:pointer'><span style=''>" + $.lang("reload") + "</span></button></div>");
+            var j_reload_button = $(
+                "<div style='position:absolute;z-index:999999999;padding:10px;opacity:0.8;background-color:white;left:0px;top:0px'><button style='cursor:pointer'><span style=''>" +
+                    $.lang("reload") +
+                    "</span></button></div>",
+            );
             j_reload_button.draggable({
-
                 scroll: false,
                 //containment:".tyrano_base",
-                stop: (e, ui) => {
-
-                }
+                stop: (e, ui) => {},
             });
 
             j_reload_button.find("button").on("click", (e) => {
@@ -147,13 +128,8 @@ tyrano.plugin.kag.studio = {
 
             ////////////////
 
-
-
             //初期化
-            this.send('init-variable', {});
-
-
-
+            this.send("init-variable", {});
         }
 
         //ユーザーエージェントに TyranoStudio があるかどうかで判定する
@@ -162,55 +138,49 @@ tyrano.plugin.kag.studio = {
             console.log(arg) // pong
         })
         */
-
-
     },
 
-
-
-    insertElement: function(category, file) {
-
+    insertElement: function (category, file) {
         var path = "./data/" + category + "/" + file;
 
         if (category == "fgimage" || category == "image") {
-            var j_img = $("<div style='position:absolute;z-index:9999999999;'><div class='area_pos' style='position:absolute;width:100px;opacity:0.5;background-color:black;color:white'></div><div class='button_delete' style='position:absolute;right:0px;border:solid 1px gray;background-color:white;width:20px;height:20px;cursor:pointer' >×</div><img style='width:100%;border:solid 1px green;' src='" + path + "' /></div>");
+            var j_img = $(
+                "<div style='position:absolute;z-index:9999999999;'><div class='area_pos' style='position:absolute;width:100px;opacity:0.5;background-color:black;color:white'></div><div class='button_delete' style='position:absolute;right:0px;border:solid 1px gray;background-color:white;width:20px;height:20px;cursor:pointer' >×</div><img style='width:100%;border:solid 1px green;' src='" +
+                    path +
+                    "' /></div>",
+            );
 
             (() => {
-
                 var _j_img = j_img;
                 var _category = category;
                 var _file = file;
 
-
                 j_img.draggable({
-
                     scroll: false,
                     //containment:".tyrano_base",
                     stop: (e, ui) => {
-
                         //j_x.html(ui.position.left);
                         //j_y.html(ui.position.top);
                         let left = Math.floor(ui.position.left);
                         let top = Math.floor(ui.position.top);
 
-                        _j_img.find(".area_pos").html("x:" + left + " y:" + top);
+                        _j_img
+                            .find(".area_pos")
+                            .html("x:" + left + " y:" + top);
 
                         let obj = {
-                            "left": left,
-                            "top": top
+                            left: left,
+                            top: top,
                         };
 
                         this.send("material-update-pos", obj);
 
                         //タグのプレビューがここに表示される
                         //元に渡す
-
-                    }
+                    },
                 });
 
-
                 j_img.resizable({
-
                     aspectRatio: true,
                     handles: "all",
                     resize: (e, ui) => {
@@ -219,54 +189,41 @@ tyrano.plugin.kag.studio = {
                         var height = parseInt(target.css("height"));
 
                         let obj = {
-                            "width": width,
-                            "height": height
+                            width: width,
+                            height: height,
                         };
 
                         this.send("material-update-size", obj);
 
                         //j_text_width.val(that.map_anim["width"]);
                         //j_text_height.val(that.map_anim["height"]);
-
-                    }
+                    },
                 });
 
-
-
-                _j_img.find(".button_delete").click(function() {
+                _j_img.find(".button_delete").click(function () {
                     _j_img.remove();
                 });
 
                 //ドラッグを出来るように
                 $(".tyrano_base").attr("ondragstart", "");
                 $(".tyrano_base").append(_j_img);
-
             })();
-
         } else if (category == "bgimage") {
             //背景画像変更
             var j_new_bg = TYRANO.kag.layer.getLayer("base", "fore");
             j_new_bg.css("background-image", "url(" + path + ")");
-
         }
-
     },
 
-
-
-    send: function(key, json_obj) {
+    send: function (key, json_obj) {
         this.ipc.ipcRenderer.send(key, JSON.stringify(json_obj));
     },
 
-
-    notifyChangeVariable: function() {
-
+    notifyChangeVariable: function () {
         let data = {};
         let array_name = [];
 
-
         for (let key in this.map_watch) {
-
             if (typeof this.map_watch[key] == "undefined") {
                 this.map_watch[key] = "";
             }
@@ -274,18 +231,15 @@ tyrano.plugin.kag.studio = {
             let val = this.kag.embScript(key);
 
             this.map_watch[key] = val;
-            array_name.push({ "name": key, "val": val });
-
+            array_name.push({ name: key, val: val });
         }
 
         data["names"] = array_name;
 
         this.send("changed-variable", data);
-
     },
 
-    pushConsole: function(obj) {
-
+    pushConsole: function (obj) {
         this.last_push_console_obj = obj;
 
         if (this.flag_push_console == true) {
@@ -295,30 +249,24 @@ tyrano.plugin.kag.studio = {
                 this.send("replay-console", this.last_push_console_obj);
             }, 1000);
         }
-
     },
 
     //完了時に入ってくる
-    complete: function(TG) {
-
+    complete: function (TG) {
         let array_save = TG.kag.menu.getSaveData();
 
         let init_data = {
-            "array_save": array_save
+            array_save: array_save,
         };
 
         this.send("load-complete", init_data);
-
     },
 
-    cutTyranoTag: function(tag, pm) {
-
+    cutTyranoTag: function (tag, pm) {
         TYRANO.kag.ftag.startTag(tag, pm);
-
     },
 
-    cutTyranoScript: function(str) {
-
+    cutTyranoScript: function (str) {
         var result = TYRANO.kag.parser.parseScenario(str);
 
         var array_s = result.array_s;
@@ -326,9 +274,5 @@ tyrano.plugin.kag.studio = {
             var tag = array_s[i];
             this.cutTyranoTag(tag.name, tag.pm);
         }
-
     },
-
-
-
 };

--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -1,6 +1,5 @@
 //タグ総合管理　ゲーム全体の進捗も管理する
 tyrano.plugin.kag.ftag = {
-
     tyrano: null,
     kag: null,
 
@@ -8,21 +7,18 @@ tyrano.plugin.kag.ftag = {
     master_tag: {}, //使用可能なタグの種類
     current_order_index: -1, //現在の命令実行インデックス
 
-    init: function() {
-
+    init: function () {
         // タグの種類を確定させる
         for (var order_type in tyrano.plugin.kag.tag) {
-
-            this.master_tag[order_type] = object(tyrano.plugin.kag.tag[order_type]);
+            this.master_tag[order_type] = object(
+                tyrano.plugin.kag.tag[order_type],
+            );
             this.master_tag[order_type].kag = this.kag;
-
         }
-
     },
 
     //命令を元に、命令配列を作り出します
-    buildTag: function(array_tag, label_name) {
-
+    buildTag: function (array_tag, label_name) {
         this.array_tag = array_tag;
 
         //ラベル名が指定されている場合は
@@ -33,19 +29,22 @@ tyrano.plugin.kag.ftag = {
             this.nextOrderWithLabel("");
             //ここどうなんだろう
         }
-
     },
 
-    buildTagIndex: function(array_tag, index, auto_next) {
-
+    buildTagIndex: function (array_tag, index, auto_next) {
         this.array_tag = array_tag;
 
-        this.nextOrderWithIndex(index, undefined, undefined, undefined, auto_next);
-
+        this.nextOrderWithIndex(
+            index,
+            undefined,
+            undefined,
+            undefined,
+            auto_next,
+        );
     },
 
     //トランジション完了 だけにとどまらず、再生を強制的に再開させる
-    completeTrans: function() {
+    completeTrans: function () {
         //処理停止中なら
         this.kag.stat.is_trans = false;
         if (this.kag.stat.is_stop == true) {
@@ -55,30 +54,30 @@ tyrano.plugin.kag.ftag = {
     },
 
     //次へボタンを隠します
-    hideNextImg: function() {
-
+    hideNextImg: function () {
         $(".img_next").remove();
         $(".glyph_image").hide();
     },
 
-    showNextImg: function() {
-
+    showNextImg: function () {
         //グリフが指定されている場合はこちらを適用
         if (this.kag.stat.flag_glyph == "false") {
             $(".img_next").remove();
             var jtext = this.kag.getMessageInnerLayer();
-            jtext.find("p").append("<img class='img_next' src='./tyrano/images/system/" + this.kag.stat.path_glyph + "' />");
-
+            jtext
+                .find("p")
+                .append(
+                    "<img class='img_next' src='./tyrano/images/system/" +
+                        this.kag.stat.path_glyph +
+                        "' />",
+                );
         } else {
             $(".glyph_image").show();
         }
-
-
     },
 
     //次の命令を実行する
-    nextOrder: function() {
-
+    nextOrder: function () {
         //基本非表示にする。
         this.kag.layer.layer_event.hide();
 
@@ -110,41 +109,39 @@ tyrano.plugin.kag.ftag = {
         this.kag.stat.current_line = tag.line;
 
         if (this.kag.is_rider) {
-
             tag.ks_file = this.kag.stat.current_scenario;
             this.kag.rider.pushConsoleLog(tag);
-
         } else if (this.kag.is_studio) {
-
             tag.ks_file = this.kag.stat.current_scenario;
             this.kag.studio.pushConsole(tag);
 
-            this.kag.log("**:" + this.current_order_index + "　line:" + tag.line);
+            this.kag.log(
+                "**:" + this.current_order_index + "　line:" + tag.line,
+            );
             this.kag.log(tag);
-
-
         } else {
-            this.kag.log("**:" + this.current_order_index + "　line:" + tag.line);
+            this.kag.log(
+                "**:" + this.current_order_index + "　line:" + tag.line,
+            );
             this.kag.log(tag);
         }
         //前に改ページ指定が入っている場合はテキスト部分をクリアする
         if (
             (tag.name == "call" && tag.pm.storage == "make.ks") ||
             this.kag.stat.current_scenario == "make.ks" ||
-            (tag.name == "call" && tag.pm.storage == this.kag.stat.resizecall["storage"]) ||
-            (this.kag.stat.current_scenario == this.kag.stat.resizecall["storage"])) {
-
+            (tag.name == "call" &&
+                tag.pm.storage == this.kag.stat.resizecall["storage"]) ||
+            this.kag.stat.current_scenario ==
+                this.kag.stat.resizecall["storage"]
+        ) {
             //make or resize中 です
             //make中は基本、メッセージクリアを行わない
             if (this.kag.stat.flag_ref_page == true) {
                 this.kag.tmp.loading_make_ref = true;
                 this.kag.stat.flag_ref_page = false;
             }
-
         } else {
-
             if (this.kag.stat.flag_ref_page == true) {
-
                 this.kag.stat.flag_ref_page = false;
 
                 //バックログ、画面クリア後は強制的に画面クリア
@@ -158,9 +155,7 @@ tyrano.plugin.kag.ftag = {
                 } else {
                     this.kag.getMessageInnerLayer().html("");
                 }
-
             }
-
         }
 
         //タグを無視する
@@ -170,15 +165,15 @@ tyrano.plugin.kag.ftag = {
         }
 
         //メッセージ非表示状態の場合は、表示して、テキスト表示
-        if (this.kag.stat.is_hide_message == true && that.kag.stat.fuki.active != true) {
-
+        if (
+            this.kag.stat.is_hide_message == true &&
+            that.kag.stat.fuki.active != true
+        ) {
             this.kag.layer.showMessageLayers();
             this.kag.stat.is_hide_message = false;
-
         }
 
         if (this.master_tag[tag.name]) {
-
             //この時点で、変数の中にエンティティがあれば、置き換える必要あり
             tag.pm = this.convertEntity(tag.pm);
 
@@ -187,17 +182,13 @@ tyrano.plugin.kag.ftag = {
 
             //バックログに入れるかどうか。
             if (this.master_tag[tag.name].log_join) {
-
                 this.kag.stat.log_join = "true";
-
             } else {
-
                 if (tag.name == "text") {
                     //何もしない
                 } else {
                     this.kag.stat.log_join = "false";
                 }
-
             }
 
             //クリック待ち解除フラグがたってるなら
@@ -209,13 +200,15 @@ tyrano.plugin.kag.ftag = {
                 this.kag.error(err_str);
             } else {
                 tag.pm["_tag"] = tag.name;
-                this.master_tag[tag.name].start($.extend(true, $.cloneObject(this.master_tag[tag.name].pm), tag.pm));
+                this.master_tag[tag.name].start(
+                    $.extend(
+                        true,
+                        $.cloneObject(this.master_tag[tag.name].pm),
+                        tag.pm,
+                    ),
+                );
             }
-
-
-
         } else if (this.kag.stat.map_macro[tag.name]) {
-
             tag.pm = this.convertEntity(tag.pm);
 
             //マクロの場合、その位置へジャンプ
@@ -236,10 +229,11 @@ tyrano.plugin.kag.ftag = {
             this.kag.pushStack("macro", back_pm);
 
             this.kag.ftag.nextOrderWithIndex(map_obj.index, map_obj.storage);
-
         } else {
             //実装されていないタグの場合は、もう帰る
-            $.error_message($.lang("tag") + "：[" + tag.name + "]" + $.lang("not_exists"));
+            $.error_message(
+                $.lang("tag") + "：[" + tag.name + "]" + $.lang("not_exists"),
+            );
 
             this.nextOrder();
         }
@@ -252,33 +246,29 @@ tyrano.plugin.kag.ftag = {
         */
 
         //ラベルといった、先行してオンメモリにしておく必要が有る命令に関しては、ここで精査しておく
-
     },
 
-    checkCw: function(tag) {
-
+    checkCw: function (tag) {
         var master_tag = this.master_tag[tag.name];
 
         if (master_tag.cw) {
-
-            if (this.kag.stat.is_script != true && this.kag.stat.is_html != true && this.kag.stat.checking_macro != true) {
+            if (
+                this.kag.stat.is_script != true &&
+                this.kag.stat.is_html != true &&
+                this.kag.stat.checking_macro != true
+            ) {
                 return true;
-
             } else {
                 return false;
             }
-
         } else {
             return false;
         }
-
     },
 
     //次のタグを実行。ただし、指定のタグの場合のみ
-    nextOrderWithTag: function(target_tags) {
-
+    nextOrderWithTag: function (target_tags) {
         try {
-
             this.current_order_index++;
             var tag = this.array_tag[this.current_order_index];
 
@@ -289,41 +279,42 @@ tyrano.plugin.kag.ftag = {
             }
 
             if (target_tags[tag.name] == "") {
-
                 if (this.master_tag[tag.name]) {
-
                     switch (tag.name) {
                         case "elsif":
                         case "else":
                         case "endif":
                             var root = this.kag.getStack("if");
-                            if (!root || tag.pm.deep_if != root.deep) return false;
-                    };
+                            if (!root || tag.pm.deep_if != root.deep)
+                                return false;
+                    }
 
                     //この時点で、変数の中にエンティティがあれば、置き換える必要あり
                     tag.pm = this.convertEntity(tag.pm);
                     tag.pm["_tag"] = tag.name;
-                    this.master_tag[tag.name].start($.extend(true, $.cloneObject(this.master_tag[tag.name].pm), tag.pm));
+                    this.master_tag[tag.name].start(
+                        $.extend(
+                            true,
+                            $.cloneObject(this.master_tag[tag.name].pm),
+                            tag.pm,
+                        ),
+                    );
                     return true;
                 } else {
                     return false;
                 }
-
             } else {
                 return false;
             }
-
         } catch (e) {
             //console.log(this.array_tag);
             console.log(e);
             return false;
         }
-
     },
 
     //要素にエンティティが含まれている場合は評価値を代入する
-    convertEntity: function(pm) {
-
+    convertEntity: function (pm) {
         var that = this;
 
         //もし、pmの中に、*が入ってたら、引き継いだ引数を全て、pmに統合させる。その上で実行
@@ -331,7 +322,6 @@ tyrano.plugin.kag.ftag = {
         if (pm["*"] == "") {
             //マクロ呼び出し元の変数から継承、引き継ぐ
             pm = $.extend(true, this.kag.stat.mp, $.cloneObject(pm));
-
         }
 
         //ストレージ要素が存在する場合、拡張子がついていなかったら、指定した拡張子を負荷する
@@ -343,7 +333,6 @@ tyrano.plugin.kag.ftag = {
          */
 
         for (key in pm) {
-
             var val = pm[key];
 
             var c = "";
@@ -352,11 +341,8 @@ tyrano.plugin.kag.ftag = {
                 c = val.substr(0, 1);
             }
             if (val.length > 0 && c === "&") {
-
                 pm[key] = this.kag.embScript(val.substr(1, val.length));
-
             } else if (val.length > 0 && c === "%") {
-
                 var map_obj = this.kag.getStack("macro");
                 //最新のコールスタックを取得
 
@@ -364,9 +350,7 @@ tyrano.plugin.kag.ftag = {
 
                 //もし、スタックが溜まっている状態なら、
                 if (map_obj) {
-
                     pm[key] = map_obj.pm[val.substr(1, val.length)];
-
                 }
 
                 //代替変数の代入処理
@@ -374,31 +358,30 @@ tyrano.plugin.kag.ftag = {
 
                 if (d.length == 2) {
                     //%〇〇の値が渡ってきているか調査
-                    if (map_obj.pm[$.trim(d[0]).substr(1, $.trim(d[0]).length)]) {
-                        pm[key] = map_obj.pm[$.trim(d[0]).substr(1, $.trim(d[0]).length)];
+                    if (
+                        map_obj.pm[$.trim(d[0]).substr(1, $.trim(d[0]).length)]
+                    ) {
+                        pm[key] =
+                            map_obj.pm[
+                                $.trim(d[0]).substr(1, $.trim(d[0]).length)
+                            ];
                     } else {
                         pm[key] = $.trim(d[1]);
-
                     }
-
                 }
             }
-
         }
 
         return pm;
-
     },
 
     //必須チェック
-    checkVital: function(tag) {
-
+    checkVital: function (tag) {
         var master_tag = this.master_tag[tag.name];
 
         var err_str = "";
 
         if (master_tag.vital) {
-
         } else {
             return "";
         }
@@ -407,24 +390,31 @@ tyrano.plugin.kag.ftag = {
 
         for (var i = 0; i < array_vital.length; i++) {
             if (tag.pm[array_vital[i]]) {
-
                 //値が入っていなかった場合
                 if (tag.pm[array_vital[i]] == "") {
-                    err_str += "タグ「" + tag.name + "」にパラメーター「" + array_vital[i] + "」は必須です　\n";
+                    err_str +=
+                        "タグ「" +
+                        tag.name +
+                        "」にパラメーター「" +
+                        array_vital[i] +
+                        "」は必須です　\n";
                 }
-
             } else {
-                err_str += "タグ「" + tag.name + "」にパラメーター「" + array_vital[i] + "」は必須です　\n";
+                err_str +=
+                    "タグ「" +
+                    tag.name +
+                    "」にパラメーター「" +
+                    array_vital[i] +
+                    "」は必須です　\n";
             }
         }
 
         return err_str;
-
     },
 
     //cond条件のチェック
     //条件が真の時だけ実行する
-    checkCond: function(tag) {
+    checkCond: function (tag) {
         var pm = tag.pm;
 
         //cond属性が存在して、なおかつ、条件
@@ -435,39 +425,38 @@ tyrano.plugin.kag.ftag = {
         } else {
             return true;
         }
-
     },
 
     //タグを指定して直接実行
-    startTag: function(name, pm) {
-
+    startTag: function (name, pm) {
         if (typeof pm == "undefined") {
             pm = {};
         }
 
         pm["_tag"] = name;
-        this.master_tag[name].start($.extend(true, $.cloneObject(this.master_tag[name].pm), pm));
-
+        this.master_tag[name].start(
+            $.extend(true, $.cloneObject(this.master_tag[name].pm), pm),
+        );
     },
 
     //indexを指定して、その命令を実行
     //シナリオファイルが異なる場合
-    nextOrderWithLabel: function(label_name, scenario_file) {
-
+    nextOrderWithLabel: function (label_name, scenario_file) {
         this.kag.stat.is_strong_stop = false;
 
         //Jump ラベル記録が必要な場合に記録しておく
         if (label_name) {
-
             if (label_name.indexOf("*") != -1) {
                 label_name = label_name.substr(1, label_name.length);
             }
-            this.kag.ftag.startTag("label", { "label_name": label_name, "nextorder": "false" });
+            this.kag.ftag.startTag("label", {
+                label_name: label_name,
+                nextorder: "false",
+            });
         }
 
         //セーブスナップが指定された場合
         if (label_name == "*savesnap") {
-
             var tmpsnap = this.kag.menu.snap;
 
             var co = tmpsnap.current_order_index;
@@ -477,7 +466,6 @@ tyrano.plugin.kag.ftag = {
             //snap は noかつ、スナップで上書きする
 
             return;
-
         }
 
         var that = this;
@@ -490,44 +478,47 @@ tyrano.plugin.kag.ftag = {
         label_name = label_name.replace("*", "");
 
         //シナリオファイルが変わる場合は、全く違う動きをする
-        if (scenario_file != this.kag.stat.current_scenario && original_scenario != null) {
-
+        if (
+            scenario_file != this.kag.stat.current_scenario &&
+            original_scenario != null
+        ) {
             this.kag.layer.hideEventLayer();
 
-            this.kag.loadScenario(scenario_file, function(array_tag) {
+            this.kag.loadScenario(scenario_file, function (array_tag) {
                 that.kag.layer.showEventLayer();
                 that.kag.ftag.buildTag(array_tag, label_name);
-
             });
-
         } else {
-
             //ラベル名が指定されてない場合は最初から
             if (label_name == "") {
-
                 this.current_order_index = -1;
                 this.nextOrder();
-
             } else if (this.kag.stat.map_label[label_name]) {
-
                 var label_obj = this.kag.stat.map_label[label_name];
                 this.current_order_index = label_obj.index;
                 this.nextOrder();
-
             } else {
-
-                $.error_message($.lang("label") + "：'" + label_name + "'" + $.lang("not_exists"));
+                $.error_message(
+                    $.lang("label") +
+                        "：'" +
+                        label_name +
+                        "'" +
+                        $.lang("not_exists"),
+                );
 
                 this.nextOrder();
-
             }
         }
-
     },
 
     //次の命令へ移動　index とストレージ名を指定する
-    nextOrderWithIndex: function(index, scenario_file, flag, insert, auto_next) {
-
+    nextOrderWithIndex: function (
+        index,
+        scenario_file,
+        flag,
+        insert,
+        auto_next,
+    ) {
         this.kag.stat.is_strong_stop = false;
         this.kag.layer.showEventLayer();
 
@@ -542,24 +533,18 @@ tyrano.plugin.kag.ftag = {
 
         //シナリオファイルが変わる場合は、全く違う動きをする
         if (scenario_file != this.kag.stat.current_scenario || flag == true) {
-
             this.kag.layer.hideEventLayer();
 
-            this.kag.loadScenario(scenario_file, function(tmp_array_tag) {
+            this.kag.loadScenario(scenario_file, function (tmp_array_tag) {
                 var array_tag = $.extend(true, [], tmp_array_tag);
                 if (typeof insert == "object") {
-
                     array_tag.splice(index + 1, 0, insert);
-
                 }
 
                 that.kag.layer.showEventLayer();
                 that.kag.ftag.buildTagIndex(array_tag, index, auto_next);
-
             });
-
         } else {
-
             //index更新
             this.current_order_index = index;
 
@@ -567,62 +552,53 @@ tyrano.plugin.kag.ftag = {
                 this.nextOrder();
             } else if (auto_next == "snap") {
                 //ストロングの場合、すすめないように
-                this.kag.stat.is_strong_stop = this.kag.menu.snap.stat.is_strong_stop;
+                this.kag.stat.is_strong_stop =
+                    this.kag.menu.snap.stat.is_strong_stop;
 
                 //スキップフラグが立っている場合は進めてくださいね。
-                if (this.kag.stat.is_skip == true && this.kag.stat.is_strong_stop == false) {
+                if (
+                    this.kag.stat.is_skip == true &&
+                    this.kag.stat.is_strong_stop == false
+                ) {
                     this.kag.ftag.nextOrder();
                 }
-
             } else if (auto_next == "stop") {
-
                 //[s]タグで終わった人が登場してきた時
                 //this.kag.stat.is_strong_stop = true;
                 //レイヤイベントレイヤ非表示。
                 //this.current_order_index--;
-                this.kag.ftag.startTag("s", { "val": {} });
-
+                this.kag.ftag.startTag("s", { val: {} });
             }
-
         }
-
-    }
+    },
 };
 
 //タグを記述していく
 tyrano.plugin.kag.tag.text = {
-
     //vital:["val"], //必須のタグ
 
     cw: true,
 
     //初期値
     pm: {
-
-        "val": "",
-        "backlog": "add" /*バックログ用の文字列。改行するかどうか。add join */
-
+        val: "",
+        backlog: "add" /*バックログ用の文字列。改行するかどうか。add join */,
     },
 
     //実行
-    start: function(pm) {
-
+    start: function (pm) {
         //スクリプト解析状態の場合は、その扱いをする
         if (this.kag.stat.is_script == true) {
-
             this.kag.stat.buff_script += pm.val + "\n";
             this.kag.ftag.nextOrder();
             return;
-
         }
 
         //HTML解析状態の場合
         if (this.kag.stat.is_html == true) {
-
             this.kag.stat.map_html.buff_html += pm.val;
             this.kag.ftag.nextOrder();
             return;
-
         }
 
         var j_inner_message = this.kag.getMessageInnerLayer();
@@ -630,8 +606,11 @@ tyrano.plugin.kag.tag.text = {
         //文字ステータスの設定
         j_inner_message.css({
             "letter-spacing": this.kag.config.defaultPitch + "px",
-            "line-height": parseInt(this.kag.config.defaultFontSize) + parseInt(this.kag.config.defaultLineSpacing) + "px",
-            "font-family": this.kag.config.userFace
+            "line-height":
+                parseInt(this.kag.config.defaultFontSize) +
+                parseInt(this.kag.config.defaultLineSpacing) +
+                "px",
+            "font-family": this.kag.config.userFace,
         });
 
         //現在表示中のテキストを格納
@@ -639,63 +618,54 @@ tyrano.plugin.kag.tag.text = {
 
         //縦書き指定の場合
         if (this.kag.stat.vertical == "true") {
-
             //自動改ページ無効の場合
             if (this.kag.config.defaultAutoReturn != "false") {
-
                 //テキストエリアの横幅が、一定以上いっていたばあい、テキストをクリアします
                 var j_outer_message = this.kag.getMessageOuterLayer();
 
                 var limit_width = parseInt(j_outer_message.css("width")) * 0.8;
-                var current_width = parseInt(j_inner_message.find("p").css("width"));
+                var current_width = parseInt(
+                    j_inner_message.find("p").css("width"),
+                );
 
                 if (current_width > limit_width) {
-
                     if (this.kag.stat.vchat.is_active) {
                         this.kag.ftag.startTag("vchat_in", {});
                     } else {
                         this.kag.getMessageInnerLayer().html("");
                     }
-
                 }
-
             }
 
             this.showMessage(pm.val, pm, true);
-
         } else {
-
             if (this.kag.config.defaultAutoReturn != "false") {
-
                 //テキストエリアの高さが、一定以上いっていたばあい、テキストをクリアします
                 var j_outer_message = this.kag.getMessageOuterLayer();
 
-                var limit_height = parseInt(j_outer_message.css("height")) * 0.8;
-                var current_height = parseInt(j_inner_message.find("p").css("height"));
+                var limit_height =
+                    parseInt(j_outer_message.css("height")) * 0.8;
+                var current_height = parseInt(
+                    j_inner_message.find("p").css("height"),
+                );
 
                 if (current_height > limit_height) {
-
                     //画面クリア
                     if (this.kag.stat.vchat.is_active) {
                         this.kag.ftag.startTag("vchat_in", {});
                     } else {
                         this.kag.getMessageInnerLayer().html("");
                     }
-
                 }
-
             }
 
-
             this.showMessage(pm.val, pm, false);
-
         }
 
         //this.kag.ftag.nextOrder();
-
     },
 
-    showMessage: function(message_str, pm, isVertical) {
+    showMessage: function (message_str, pm, isVertical) {
         var that = this;
 
         //特定のタグが直前にあった場合、ログの作り方に気をつける
@@ -708,24 +678,39 @@ tyrano.plugin.kag.tag.text = {
             chara_name = $.isNull($("." + this.kag.stat.chara_ptext).html());
         }
 
-        if ((chara_name != "" && pm.backlog != "join") || (chara_name != "" && this.kag.stat.f_chara_ptext == "true")) {
-
-            this.kag.pushBackLog("<b class='backlog_chara_name " + chara_name + "'>" + chara_name + "</b>：<span class='backlog_text " + chara_name + "'>" + message_str + "</span>", "add");
+        if (
+            (chara_name != "" && pm.backlog != "join") ||
+            (chara_name != "" && this.kag.stat.f_chara_ptext == "true")
+        ) {
+            this.kag.pushBackLog(
+                "<b class='backlog_chara_name " +
+                    chara_name +
+                    "'>" +
+                    chara_name +
+                    "</b>：<span class='backlog_text " +
+                    chara_name +
+                    "'>" +
+                    message_str +
+                    "</span>",
+                "add",
+            );
 
             if (this.kag.stat.f_chara_ptext == "true") {
                 this.kag.stat.f_chara_ptext = "false";
                 this.kag.stat.log_join = "true";
             }
-
         } else {
-
-            var log_str = "<span class='backlog_text " + chara_name + "'>" + message_str + "</span>";
+            var log_str =
+                "<span class='backlog_text " +
+                chara_name +
+                "'>" +
+                message_str +
+                "</span>";
 
             if (pm.backlog == "join") {
                 this.kag.pushBackLog(log_str, "join");
             } else {
                 this.kag.pushBackLog(log_str, "add");
-
             }
         }
 
@@ -733,7 +718,6 @@ tyrano.plugin.kag.tag.text = {
         if (that.kag.stat.play_speak == true) {
             speechSynthesis.speak(new SpeechSynthesisUtterance(message_str));
         }
-
 
         //テキスト表示時に、まず、画面上の次へボタンアイコンを抹消
         that.kag.ftag.hideNextImg();
@@ -747,9 +731,7 @@ tyrano.plugin.kag.tag.text = {
             j_msg_inner.show();
         }
 
-
-        (function(jtext) {
-
+        (function (jtext) {
             if (jtext.html() == "") {
                 //タグ作成
                 if (isVertical) {
@@ -772,16 +754,14 @@ tyrano.plugin.kag.tag.text = {
             var current_str = "";
 
             if (jtext.find("p").find(".current_span").length != 0) {
-
                 //アニメーションは強制停止させる。
                 jtext.find("p").find(".current_span").find("span").css({
-                    "opacity": 1,
-                    "visibility": "visible",
-                    "animation": ""
+                    opacity: 1,
+                    visibility: "visible",
+                    animation: "",
                 });
 
                 current_str = jtext.find("p").find(".current_span").html();
-
             }
 
             that.kag.checkMessage(jtext);
@@ -790,36 +770,40 @@ tyrano.plugin.kag.tag.text = {
             var j_span = {};
 
             if (that.kag.stat.vchat.is_active) {
-
                 j_span = jtext.find(".current_span");
                 if (chara_name == "") {
                     $(".current_vchat").find(".vchat_chara_name").remove();
-                    $(".current_vchat").find(".vchat-text-inner").css("margin-top", "0.2em");
+                    $(".current_vchat")
+                        .find(".vchat-text-inner")
+                        .css("margin-top", "0.2em");
                 } else {
-                    $(".current_vchat").find(".vchat_chara_name").html(chara_name);
+                    $(".current_vchat")
+                        .find(".vchat_chara_name")
+                        .html(chara_name);
 
                     //キャラ名欄の色
-                    var vchat_name_color = $.convertColor(that.kag.stat.vchat.chara_name_color);
+                    var vchat_name_color = $.convertColor(
+                        that.kag.stat.vchat.chara_name_color,
+                    );
 
                     var cpm = that.kag.stat.vchat.charas[chara_name];
 
                     if (cpm) {
-
                         //色指定がある場合は、その色を指定する。
                         if (cpm.color != "") {
                             vchat_name_color = $.convertColor(cpm.color);
                         }
-
                     }
 
+                    $(".current_vchat")
+                        .find(".vchat_chara_name")
+                        .css("background-color", vchat_name_color);
 
-                    $(".current_vchat").find(".vchat_chara_name").css("background-color", vchat_name_color);
-
-                    $(".current_vchat").find(".vchat-text-inner").css("margin-top", "1.5em");
+                    $(".current_vchat")
+                        .find(".vchat-text-inner")
+                        .css("margin-top", "1.5em");
                 }
-
             } else {
-
                 j_span = that.kag.getMessageCurrentSpan();
 
                 j_span.css({
@@ -827,37 +811,50 @@ tyrano.plugin.kag.tag.text = {
                     "font-weight": that.kag.stat.font.bold,
                     "font-size": that.kag.stat.font.size + "px",
                     "font-family": that.kag.stat.font.face,
-                    "font-style": that.kag.stat.font.italic
+                    "font-style": that.kag.stat.font.italic,
                 });
 
                 if (that.kag.stat.font.edge != "") {
                     var edge_color = that.kag.stat.font.edge;
-                    j_span.css("text-shadow", "1px 1px 0 " + edge_color + ", -1px 1px 0 " + edge_color + ",1px -1px 0 " + edge_color + ",-1px -1px 0 " + edge_color + "");
-
+                    j_span.css(
+                        "text-shadow",
+                        "1px 1px 0 " +
+                            edge_color +
+                            ", -1px 1px 0 " +
+                            edge_color +
+                            ",1px -1px 0 " +
+                            edge_color +
+                            ",-1px -1px 0 " +
+                            edge_color +
+                            "",
+                    );
                 } else if (that.kag.stat.font.shadow != "") {
                     //j_span.css()
-                    j_span.css("text-shadow", "2px 2px 2px " + that.kag.stat.font.shadow);
+                    j_span.css(
+                        "text-shadow",
+                        "2px 2px 2px " + that.kag.stat.font.shadow,
+                    );
                 }
-
             }
-
 
             //既読管理中の場合、現在の場所が既読済みなら、色を変える
             if (that.kag.config.autoRecordLabel == "true") {
-
                 if (that.kag.stat.already_read == true) {
                     //テキストの色調整
                     if (that.kag.config.alreadyReadTextColor != "default") {
-                        j_span.css("color", $.convertColor(that.kag.config.alreadyReadTextColor));
+                        j_span.css(
+                            "color",
+                            $.convertColor(
+                                that.kag.config.alreadyReadTextColor,
+                            ),
+                        );
                     }
-
                 } else {
                     //未読スキップがfalseの場合は、スキップ停止
                     if (that.kag.config.unReadTextSkip == "false") {
                         that.kag.stat.is_skip = false;
                     }
                 }
-
             }
 
             var ch_speed = 30;
@@ -869,13 +866,19 @@ tyrano.plugin.kag.tag.text = {
             }
 
             //アニメーション設定。無効な場合がある
-            if (typeof that.kag.stat.font.effect == "undefined" || that.kag.stat.font.effect == "none") {
+            if (
+                typeof that.kag.stat.font.effect == "undefined" ||
+                that.kag.stat.font.effect == "none"
+            ) {
                 that.kag.stat.font.effect = "";
             }
 
             //禁則処理を有効にするための処置。エフェクトによっては有効にできないようにする
             var flag_in_block = true;
-            if (that.kag.stat.font.effect == "" || that.kag.stat.font.effect == "fadeIn") {
+            if (
+                that.kag.stat.font.effect == "" ||
+                that.kag.stat.font.effect == "fadeIn"
+            ) {
                 flag_in_block = false;
             }
 
@@ -884,43 +887,44 @@ tyrano.plugin.kag.tag.text = {
                 var c = message_str.charAt(i);
                 //ルビ指定がされている場合
                 if (that.kag.stat.ruby_str != "") {
-                    c = "<ruby><rb>" + c + "</rb><rt>" + that.kag.stat.ruby_str + "</rt></ruby>";
+                    c =
+                        "<ruby><rb>" +
+                        c +
+                        "</rb><rt>" +
+                        that.kag.stat.ruby_str +
+                        "</rt></ruby>";
                     that.kag.stat.ruby_str = "";
                 }
-
 
                 if (c == " ") {
                     append_str += "<span style='opacity:0'>" + c + "</span>";
                 } else {
-
                     if (that.kag.stat.mark == 1) {
-
                         var mark_style = that.kag.stat.style_mark;
                         c = "<mark style='" + mark_style + "'>" + c + "</mark>";
-
                     } else if (that.kag.stat.mark == 2) {
                         that.kag.stat.mark = 0;
                     }
 
                     if (flag_in_block) {
-                        append_str += "<span style='display:inline-block;opacity:0'>" + c + "</span>";
+                        append_str +=
+                            "<span style='display:inline-block;opacity:0'>" +
+                            c +
+                            "</span>";
                     } else {
-                        append_str += "<span style='opacity:0'>" + c + "</span>";
+                        append_str +=
+                            "<span style='opacity:0'>" + c + "</span>";
                     }
-
                 }
             }
 
             current_str += "<span>" + append_str + "</span>";
 
-
             // hidden状態で全部追加する
             that.kag.appendMessage(jtext, current_str);
 
-
             //吹き出しが有効な場合は位置を自動調整
             if (that.kag.stat.fuki.active) {
-
                 //メッセージレイヤの表示
                 that.kag.layer.showMessageLayers();
                 that.kag.stat.is_hide_message = false;
@@ -932,9 +936,7 @@ tyrano.plugin.kag.tag.text = {
 
                 if (chara_name == "") {
                     is_chara_show = false;
-
                 } else {
-
                     let original_name = chara_name;
 
                     if (that.kag.stat.jcharas[chara_name]) {
@@ -950,38 +952,50 @@ tyrano.plugin.kag.tag.text = {
                         chara_obj = undefined;
                     }
 
-                    if ((typeof chara_obj != "undefined" && chara_obj.get(0)) && that.kag.stat.charas[original_name]["fuki"]["enable"] == "true") {
-
+                    if (
+                        typeof chara_obj != "undefined" &&
+                        chara_obj.get(0) &&
+                        that.kag.stat.charas[original_name]["fuki"]["enable"] ==
+                            "true"
+                    ) {
                         is_chara_show = true;
 
                         //chara_p_textを排除
                         $(".tyrano_base").find(".chara_name_area").hide();
 
-                        chara_fuki = that.kag.stat.charas[original_name]["fuki"];
+                        chara_fuki =
+                            that.kag.stat.charas[original_name]["fuki"];
 
                         if (chara_fuki["fix_width"] != "") {
                             j_msg_inner.css("max-width", "");
-                            j_msg_inner.css("width", parseInt(chara_fuki["fix_width"]));
+                            j_msg_inner.css(
+                                "width",
+                                parseInt(chara_fuki["fix_width"]),
+                            );
                         } else {
                             j_msg_inner.css("width", "");
-                            j_msg_inner.css("max-width", parseInt(chara_fuki["max_width"]));
+                            j_msg_inner.css(
+                                "max-width",
+                                parseInt(chara_fuki["max_width"]),
+                            );
                         }
 
                         //縦書きの場合はheightだけ無視で。
                         if (that.kag.stat.vertical == "true") {
                             //safariでも表示させるための処置
-                            let w = j_msg_inner.find(".vertical_text").css("width");
+                            let w = j_msg_inner
+                                .find(".vertical_text")
+                                .css("width");
                             j_msg_inner.css("width", w);
                             j_msg_inner.css("height", "");
-                            j_msg_inner.css("max-height", parseInt(chara_fuki["max_width"]));
-
+                            j_msg_inner.css(
+                                "max-height",
+                                parseInt(chara_fuki["max_width"]),
+                            );
                         } else {
-
                             if (chara_fuki["fix_width"] == "") {
-
                                 j_msg_inner.css("width", "");
                                 j_msg_inner.css("height", "");
-
                             }
                         }
 
@@ -990,18 +1004,24 @@ tyrano.plugin.kag.tag.text = {
                         let height = j_msg_inner.css("height");
 
                         //20 はアイコンの文
-                        width = parseInt(width) + parseInt(j_msg_inner.css("padding-left")) + that.kag.stat.fuki.marginr + 20;
-                        height = parseInt(height) + parseInt(j_msg_inner.css("padding-top")) + that.kag.stat.fuki.marginb + 20;
+                        width =
+                            parseInt(width) +
+                            parseInt(j_msg_inner.css("padding-left")) +
+                            that.kag.stat.fuki.marginr +
+                            20;
+                        height =
+                            parseInt(height) +
+                            parseInt(j_msg_inner.css("padding-top")) +
+                            that.kag.stat.fuki.marginb +
+                            20;
 
                         var j_outer_message = that.kag.getMessageOuterLayer();
 
                         j_outer_message.css("width", width);
                         j_outer_message.css("height", height);
 
-
                         chara_left = parseInt(chara_obj.css("left"));
                         chara_top = parseInt(chara_obj.css("top"));
-
 
                         let fuki_left = chara_fuki["left"];
                         let fuki_top = chara_fuki["top"];
@@ -1009,11 +1029,19 @@ tyrano.plugin.kag.tag.text = {
                         let fuki_sippo_left = chara_fuki["sippo_left"];
                         let fuki_sippo_top = chara_fuki["sippo_top"];
 
-                        let chara_width = parseInt(chara_obj.find("img").css("width"));
-                        let chara_height = parseInt(chara_obj.find("img").css("height"));
+                        let chara_width = parseInt(
+                            chara_obj.find("img").css("width"),
+                        );
+                        let chara_height = parseInt(
+                            chara_obj.find("img").css("height"),
+                        );
 
-                        let origin_width = that.kag.stat.charas[original_name]["origin_width"];
-                        let origin_height = that.kag.stat.charas[original_name]["origin_height"];
+                        let origin_width =
+                            that.kag.stat.charas[original_name]["origin_width"];
+                        let origin_height =
+                            that.kag.stat.charas[original_name][
+                                "origin_height"
+                            ];
 
                         //相対位置はキャラのサイズによって座標を調整する
                         let per_width = chara_width / origin_width;
@@ -1025,15 +1053,20 @@ tyrano.plugin.kag.tag.text = {
                         fuki_left2 = chara_left + fuki_left;
                         fuki_top2 = chara_top + fuki_top;
 
-                        let outer_width = parseInt(j_outer_message.css("width"));
-                        let outer_height = parseInt(j_outer_message.css("height"));
+                        let outer_width = parseInt(
+                            j_outer_message.css("width"),
+                        );
+                        let outer_height = parseInt(
+                            j_outer_message.css("height"),
+                        );
 
                         //吹き出し位置によって位置を変更
                         let sippo = chara_fuki["sippo"];
                         if (sippo == "bottom") {
                             fuki_top2 = fuki_top2 - outer_height;
                         } else if (sippo == "left") {
-                            fuki_left2 = fuki_left2 + parseInt(chara_fuki["sippo_left"]);
+                            fuki_left2 =
+                                fuki_left2 + parseInt(chara_fuki["sippo_left"]);
                         } else if (sippo == "right") {
                             fuki_left2 = fuki_left2 - outer_width;
                         }
@@ -1051,31 +1084,26 @@ tyrano.plugin.kag.tag.text = {
                         //右端に飛び出ていたら
 
                         if (fuki_right >= sc_width) {
-
-                            fuki_left2 = fuki_left2 - (fuki_right - sc_width) - 10;
-                            sippo_left = (fuki_right - sc_width) + 10; //はみ出たぶんだけプラス
+                            fuki_left2 =
+                                fuki_left2 - (fuki_right - sc_width) - 10;
+                            sippo_left = fuki_right - sc_width + 10; //はみ出たぶんだけプラス
                         }
 
                         if (fuki_bottom >= sc_height) {
-                            fuki_top2 = fuki_top2 - (fuki_bottom - sc_height) - 10;
+                            fuki_top2 =
+                                fuki_top2 - (fuki_bottom - sc_height) - 10;
                             //sippo_left = (fuki_bottom - -50;
-
                         }
 
                         if (fuki_left2 <= 0) {
-
                             //しっぽの位置はマイナスさせる
-                            sippo_left = (fuki_left2) - 10;
+                            sippo_left = fuki_left2 - 10;
                             fuki_left2 = 10;
-
                         }
 
                         if (fuki_top2 <= 0) {
-
                             fuki_top2 = 10;
-
                         }
-
 
                         //alert(fuki_left);
                         j_outer_message.css("left", fuki_left2);
@@ -1083,8 +1111,8 @@ tyrano.plugin.kag.tag.text = {
 
                         //innerの情報
                         j_msg_inner.css({
-                            "left": parseInt(j_outer_message.css("left")) + 10,
-                            "top": parseInt(j_outer_message.css("top")) + 10
+                            left: parseInt(j_outer_message.css("left")) + 10,
+                            top: parseInt(j_outer_message.css("top")) + 10,
                         });
 
                         //調整値。はみ出し多分
@@ -1092,20 +1120,16 @@ tyrano.plugin.kag.tag.text = {
                         that.setFukiStyle(j_outer_message, chara_fuki);
 
                         //ふきだしの位置を調整//////////////
-                        that.kag.updateFuki(original_name, { "sippo_left": sippo_left });
-
-
+                        that.kag.updateFuki(original_name, {
+                            sippo_left: sippo_left,
+                        });
                     } else {
-
                         is_chara_show = false;
-
                     }
-
                 }
 
                 //othersのポジションに戻す。
                 if (is_chara_show == false) {
-
                     //chara_p_textを排除
                     $(".tyrano_base").find(".chara_name_area").hide();
 
@@ -1116,10 +1140,12 @@ tyrano.plugin.kag.tag.text = {
                     let nleft = others_style.left || def_style.left;
                     let ntop = others_style.top || def_style.top;
 
-
                     if (others_style["fix_width"] != "") {
                         j_msg_inner.css("max-width", "");
-                        j_msg_inner.css("width", parseInt(others_style["fix_width"]));
+                        j_msg_inner.css(
+                            "width",
+                            parseInt(others_style["fix_width"]),
+                        );
                     } else {
                         j_msg_inner.css("width", "");
                         j_msg_inner.css("max-width", parseInt(nwidth));
@@ -1129,10 +1155,17 @@ tyrano.plugin.kag.tag.text = {
                     width = j_msg_inner.css("width");
                     height = j_msg_inner.css("height");
 
-
                     //20 はアイコンの文
-                    width = parseInt(width) + parseInt(j_msg_inner.css("padding-left")) + that.kag.stat.fuki.marginr + 20;
-                    height = parseInt(height) + parseInt(j_msg_inner.css("padding-top")) + that.kag.stat.fuki.marginb + 20;
+                    width =
+                        parseInt(width) +
+                        parseInt(j_msg_inner.css("padding-left")) +
+                        that.kag.stat.fuki.marginr +
+                        20;
+                    height =
+                        parseInt(height) +
+                        parseInt(j_msg_inner.css("padding-top")) +
+                        that.kag.stat.fuki.marginb +
+                        20;
 
                     var j_outer_message = that.kag.getMessageOuterLayer();
 
@@ -1144,8 +1177,8 @@ tyrano.plugin.kag.tag.text = {
 
                     //通常のポジションに戻す
                     j_msg_inner.css({
-                        "left": parseInt(j_outer_message.css("left")) + 10,
-                        "top": parseInt(j_outer_message.css("top")) + 10
+                        left: parseInt(j_outer_message.css("left")) + 10,
+                        top: parseInt(j_outer_message.css("top")) + 10,
                     });
 
                     chara_fuki = that.kag.stat.fuki.others_style;
@@ -1153,163 +1186,188 @@ tyrano.plugin.kag.tag.text = {
                     that.setFukiStyle(j_outer_message, chara_fuki);
 
                     //ふきだしを消す
-                    that.kag.updateFuki("others", { "sippo": "none" });
-
+                    that.kag.updateFuki("others", { sippo: "none" });
                 }
-
-
             }
 
-
-            var append_span = j_span.children('span:last-child');
-            var makeVisible = function(index) {
-
+            var append_span = j_span.children("span:last-child");
+            var makeVisible = function (index) {
                 //append_span.children("span:eq(" + index + ")").addClass("fadeIn");
                 //append_span.children("span:eq(" + index + ")").css('animation','rollIn 0.2s ease 0s 1 normal forwards');
 
                 if (that.kag.stat.font.effect != "") {
-
-                    append_span.children("span:eq(" + index + ")").on("animationend", function(e) {
-
-                        $(e.target).css({
-                            "opacity": 1,
-                            "visibility": "visible",
-                            "animation": ""
+                    append_span
+                        .children("span:eq(" + index + ")")
+                        .on("animationend", function (e) {
+                            $(e.target).css({
+                                opacity: 1,
+                                visibility: "visible",
+                                animation: "",
+                            });
                         });
 
-                    });
-
-                    append_span.children("span:eq(" + index + ")").css('animation', "t" + that.kag.stat.font.effect + ' ' + that.kag.stat.font.effect_speed + ' ease 0s 1 normal forwards');
-
+                    append_span
+                        .children("span:eq(" + index + ")")
+                        .css(
+                            "animation",
+                            "t" +
+                                that.kag.stat.font.effect +
+                                " " +
+                                that.kag.stat.font.effect_speed +
+                                " ease 0s 1 normal forwards",
+                        );
                 } else {
-                    append_span.children("span:eq(" + index + ")").css({ 'visibility': 'visible', 'opacity': '1' });
+                    append_span
+                        .children("span:eq(" + index + ")")
+                        .css({ visibility: "visible", opacity: "1" });
                 }
-
             };
-            var makeVisibleAll = function() {
-                append_span.children("span").css({ 'visibility': 'visible', 'opacity': '1' });
+            var makeVisibleAll = function () {
+                append_span
+                    .children("span")
+                    .css({ visibility: "visible", opacity: "1" });
             };
 
-            var pchar = function(index) {
+            var pchar = function (index) {
                 // 一文字ずつ表示するか？
-                var isOneByOne = (
-                    that.kag.stat.is_skip != true
-                    && that.kag.stat.is_nowait != true
-                    && ch_speed >= 3
-                );
+                var isOneByOne =
+                    that.kag.stat.is_skip != true &&
+                    that.kag.stat.is_nowait != true &&
+                    ch_speed >= 3;
 
                 if (isOneByOne) {
                     makeVisible(index);
                 }
 
                 if (index <= message_str.length) {
-
                     that.kag.stat.is_adding_text = true;
 
                     //再生途中にクリックされて、残りを一瞬で表示する
-                    if (that.kag.stat.is_click_text == true || that.kag.stat.is_skip == true || that.kag.stat.is_nowait == true) {
+                    if (
+                        that.kag.stat.is_click_text == true ||
+                        that.kag.stat.is_skip == true ||
+                        that.kag.stat.is_nowait == true
+                    ) {
                         pchar(++index);
                     } else {
-                        setTimeout(function() {
+                        setTimeout(function () {
                             pchar(++index);
                         }, ch_speed);
                     }
                 } else {
-
                     that.kag.stat.is_adding_text = false;
                     that.kag.stat.is_click_text = false;
-
 
                     //すべて表示完了 ここまではイベント残ってたな
 
                     if (that.kag.stat.is_stop != "true") {
                         if (!isOneByOne) {
                             makeVisibleAll();
-                            setTimeout(function() {
-                                if (!that.kag.stat.is_hide_message) that.kag.ftag.nextOrder();
+                            setTimeout(function () {
+                                if (!that.kag.stat.is_hide_message)
+                                    that.kag.ftag.nextOrder();
                             }, parseInt(that.kag.config.skipSpeed));
-
                         } else {
-                            if (!that.kag.stat.is_hide_message) that.kag.ftag.nextOrder();
+                            if (!that.kag.stat.is_hide_message)
+                                that.kag.ftag.nextOrder();
                         }
                     }
                 }
             };
 
             pchar(0);
-
         })(j_msg_inner);
     },
 
-    nextOrder: function() {
+    nextOrder: function () {},
 
-    },
-
-    setFukiStyle: function(j_outer_message, chara_fuki) {
-
+    setFukiStyle: function (j_outer_message, chara_fuki) {
         //見た目の指定がある場合は設定する
         if (typeof chara_fuki["color"] != "undefined") {
-            j_outer_message.css("background-color", $.convertColor(chara_fuki["color"]));
+            j_outer_message.css(
+                "background-color",
+                $.convertColor(chara_fuki["color"]),
+            );
         }
 
         if (typeof chara_fuki["opacity"] != "undefined") {
-            j_outer_message.css("opacity", $.convertOpacity(chara_fuki["opacity"]));
+            j_outer_message.css(
+                "opacity",
+                $.convertOpacity(chara_fuki["opacity"]),
+            );
         }
 
         if (typeof chara_fuki["border_size"] != "undefined") {
-            j_outer_message.css("border-width", parseInt(chara_fuki["border_size"]));
+            j_outer_message.css(
+                "border-width",
+                parseInt(chara_fuki["border_size"]),
+            );
             j_outer_message.css("border-style", "solid");
         }
 
         if (typeof chara_fuki["border_color"] != "undefined") {
-            j_outer_message.css("border-color", $.convertColor(chara_fuki["border_color"]));
+            j_outer_message.css(
+                "border-color",
+                $.convertColor(chara_fuki["border_color"]),
+            );
         }
 
         if (typeof chara_fuki["radius"] != "undefined") {
-            j_outer_message.css("border-radius", parseInt(chara_fuki["radius"]));
+            j_outer_message.css(
+                "border-radius",
+                parseInt(chara_fuki["radius"]),
+            );
         }
 
         //内部設定
         if (typeof chara_fuki["font_color"] != "undefined") {
-            j_outer_message.parent().find(".message_inner").find(".current_span").css("color", $.convertColor(chara_fuki["font_color"]));
+            j_outer_message
+                .parent()
+                .find(".message_inner")
+                .find(".current_span")
+                .css("color", $.convertColor(chara_fuki["font_color"]));
         }
 
         if (typeof chara_fuki["font_size"] != "undefined") {
-            j_outer_message.parent().find(".message_inner").find(".current_span").css("font-size", parseInt(chara_fuki["font_size"]));
+            j_outer_message
+                .parent()
+                .find(".message_inner")
+                .find(".current_span")
+                .css("font-size", parseInt(chara_fuki["font_size"]));
         }
-
-    }
+    },
 };
 
 tyrano.plugin.kag.tag.label = {
-
     pm: {
-        nextorder: "true"
+        nextorder: "true",
     },
 
-    start: function(pm) {
+    start: function (pm) {
         //ラベル通過したよ。
 
         //ラベル記録
         if (this.kag.config.autoRecordLabel == "true") {
-
-            var sf_tmp = "trail_" + this.kag.stat.current_scenario.replace(".ks", "").replace(/\u002f/g, "").replace(/:/g, "").replace(/\./g, "");
+            var sf_tmp =
+                "trail_" +
+                this.kag.stat.current_scenario
+                    .replace(".ks", "")
+                    .replace(/\u002f/g, "")
+                    .replace(/:/g, "")
+                    .replace(/\./g, "");
             var sf_buff = this.kag.stat.buff_label_name;
             var sf_label = sf_tmp + "_" + pm.label_name;
 
             if (this.kag.stat.buff_label_name != "") {
-
                 if (!this.kag.variable.sf.record) {
                     this.kag.variable.sf.record = {};
                 }
 
                 var sf_str = "sf.record." + sf_buff;
 
-                var scr_str = ""
-                    + sf_str + " = " + sf_str + "  || 0;"
-                    + sf_str + "++;";
+                var scr_str =
+                    "" + sf_str + " = " + sf_str + "  || 0;" + sf_str + "++;";
                 this.kag.evalScript(scr_str);
-
             }
 
             if (this.kag.variable.sf.record) {
@@ -1329,11 +1387,8 @@ tyrano.plugin.kag.tag.label = {
         if (pm.nextorder == "true") {
             this.kag.ftag.nextOrder();
         }
-
-    }
-
+    },
 };
-
 
 /*
 #[config_record_label]
@@ -1355,19 +1410,19 @@ skip=未読スキップをの有効(true)、無効(false)を指定します。�
 */
 
 tyrano.plugin.kag.tag.config_record_label = {
-
     pm: {
         color: "",
-        skip: ""
+        skip: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         if (pm.color != "") {
             this.kag.config.alreadyReadTextColor = pm.color;
-            this.kag.ftag.startTag("eval", { "exp": "sf._system_config_already_read_text_color = " + pm.color });
+            this.kag.ftag.startTag("eval", {
+                exp: "sf._system_config_already_read_text_color = " + pm.color,
+            });
         }
 
         if (pm.skip != "") {
@@ -1377,14 +1432,14 @@ tyrano.plugin.kag.tag.config_record_label = {
                 this.kag.config.unReadTextSkip = "false";
             }
 
-            this.kag.ftag.startTag("eval", { "exp": "sf._system_config_unread_text_skip = '" + pm.skip + "'" });
+            this.kag.ftag.startTag("eval", {
+                exp: "sf._system_config_unread_text_skip = '" + pm.skip + "'",
+            });
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
 
 /*
 #[l]
@@ -1411,11 +1466,9 @@ tyrano.plugin.kag.tag.config_record_label = {
 
 //[l] クリック待ち
 tyrano.plugin.kag.tag.l = {
-
     cw: true,
 
-    start: function() {
-
+    start: function () {
         var that = this;
 
         this.kag.ftag.showNextImg();
@@ -1424,19 +1477,18 @@ tyrano.plugin.kag.tag.l = {
         if (this.kag.stat.is_skip == true) {
             //スキップ中の場合は、nextorder
             this.kag.ftag.nextOrder();
-
         } else if (this.kag.stat.is_auto == true) {
-
             this.kag.stat.is_wait_auto = true;
 
             var auto_speed = that.kag.config.autoSpeed;
             if (that.kag.config.autoSpeedWithText != "0") {
                 var cnt_text = this.kag.stat.current_message_str.length;
-                auto_speed = parseInt(auto_speed) + (parseInt(that.kag.config.autoSpeedWithText) * cnt_text);
+                auto_speed =
+                    parseInt(auto_speed) +
+                    parseInt(that.kag.config.autoSpeedWithText) * cnt_text;
             }
 
-            setTimeout(function() {
-
+            setTimeout(function () {
                 if (that.kag.stat.is_wait_auto == true) {
                     //ボイス再生中の場合は、オートで次に行かない。効果音再生終了後に進めるためのフラグを立てる
 
@@ -1446,12 +1498,9 @@ tyrano.plugin.kag.tag.l = {
                         that.kag.ftag.nextOrder();
                     }
                 }
-
             }, auto_speed);
-
         }
-
-    }
+    },
 };
 
 /*
@@ -1480,11 +1529,9 @@ tyrano.plugin.kag.tag.l = {
 
 //[p] 改ページクリック待ち
 tyrano.plugin.kag.tag.p = {
-
     cw: true,
 
-    start: function() {
-
+    start: function () {
         var that = this;
         //改ページ
         this.kag.stat.flag_ref_page = true;
@@ -1495,18 +1542,18 @@ tyrano.plugin.kag.tag.p = {
             //スキップ中の場合は、nextorder
             this.kag.ftag.nextOrder();
         } else if (this.kag.stat.is_auto == true) {
-
             this.kag.stat.is_wait_auto = true;
 
             var auto_speed = that.kag.config.autoSpeed;
             if (that.kag.config.autoSpeedWithText != "0") {
                 var cnt_text = this.kag.stat.current_message_str.length;
-                auto_speed = parseInt(auto_speed) + (parseInt(that.kag.config.autoSpeedWithText) * cnt_text);
+                auto_speed =
+                    parseInt(auto_speed) +
+                    parseInt(that.kag.config.autoSpeedWithText) * cnt_text;
             }
 
-            setTimeout(function() {
+            setTimeout(function () {
                 if (that.kag.stat.is_wait_auto == true) {
-
                     //ボイス再生中の場合は、オートで次に行かない。効果音再生終了後に進めるためのフラグを立てる
                     if (that.kag.tmp.is_vo_play == true) {
                         that.kag.tmp.is_vo_play_wait = true;
@@ -1515,9 +1562,8 @@ tyrano.plugin.kag.tag.p = {
                     }
                 }
             }, auto_speed);
-
         }
-    }
+    },
 };
 
 /*
@@ -1550,16 +1596,14 @@ tyrano.plugin.kag.tag.p = {
  */
 
 tyrano.plugin.kag.tag.graph = {
-
     vital: ["storage"],
 
     pm: {
-        storage: null
+        storage: null,
     },
 
     //開始
-    start: function(pm) {
-
+    start: function (pm) {
         var jtext = this.kag.getMessageInnerLayer();
 
         var current_str = "";
@@ -1577,11 +1621,13 @@ tyrano.plugin.kag.tag.graph = {
         }
 
         //テキストエリアに画像を追加して、次のメッセージへ晋
-        this.kag.appendMessage(jtext, current_str + "<img src='" + storage_url + "' >");
+        this.kag.appendMessage(
+            jtext,
+            current_str + "<img src='" + storage_url + "' >",
+        );
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -1611,22 +1657,19 @@ target=ジャンプ先のラベル名を指定します。省略すると先頭�
 
 //ジャンプ命令
 tyrano.plugin.kag.tag.jump = {
-
     pm: {
         storage: null,
         target: null, //ラベル名
-        countpage: true
+        countpage: true,
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
         //ジャンプ直後のwt などでフラグがおかしくなる対策
-        setTimeout(function() {
+        setTimeout(function () {
             that.kag.ftag.nextOrderWithLabel(pm.target, pm.storage);
         }, 1);
-
-    }
+    },
 };
 
 /*
@@ -1652,22 +1695,21 @@ tyrano.plugin.kag.tag.jump = {
 
 //改行を挿入
 tyrano.plugin.kag.tag.r = {
-
     log_join: "true",
 
-    start: function() {
-
+    start: function () {
         var that = this;
         //クリックするまで、次へすすまないようにする
         var j_inner_message = this.kag.getMessageInnerLayer();
 
-        var txt = j_inner_message.find("p").find(".current_span").html() + "<br />";
+        var txt =
+            j_inner_message.find("p").find(".current_span").html() + "<br />";
         j_inner_message.find("p").find(".current_span").html(txt);
 
-        setTimeout(function() {
+        setTimeout(function () {
             that.kag.ftag.nextOrder();
         }, 5);
-    }
+    },
 };
 
 /*
@@ -1692,9 +1734,7 @@ tyrano.plugin.kag.tag.r = {
  */
 
 tyrano.plugin.kag.tag.er = {
-
-    start: function() {
-
+    start: function () {
         this.kag.ftag.hideNextImg();
         //フォントのリセット
         //カレントレイヤのみ削除
@@ -1703,8 +1743,7 @@ tyrano.plugin.kag.tag.er = {
         this.kag.ftag.startTag("resetfont");
 
         //this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -1734,9 +1773,7 @@ tyrano.plugin.kag.tag.er = {
 
 //画面クリア
 tyrano.plugin.kag.tag.cm = {
-
-    start: function() {
-
+    start: function () {
         this.kag.ftag.hideNextImg();
         //フォントのリセット
         //カレントレイヤだけじゃなくて、全てもメッセージレイヤを消去する必要がある
@@ -1753,8 +1790,7 @@ tyrano.plugin.kag.tag.cm = {
         this.kag.layer.getFreeLayer().html("").hide();
 
         this.kag.ftag.startTag("resetfont");
-
-    }
+    },
 };
 
 /*
@@ -1783,9 +1819,7 @@ tyrano.plugin.kag.tag.cm = {
  */
 
 tyrano.plugin.kag.tag.ct = {
-
-    start: function() {
-
+    start: function () {
         this.kag.ftag.hideNextImg();
 
         //フォントのリセット
@@ -1799,8 +1833,7 @@ tyrano.plugin.kag.tag.ct = {
         this.kag.stat.current_page = "fore";
 
         this.kag.ftag.startTag("resetfont");
-
-    }
+    },
 };
 
 /*
@@ -1830,14 +1863,12 @@ page=表画面を対象とするか、裏画面を対象とするかを指定し
 
 //メッセージレイヤの指定
 tyrano.plugin.kag.tag.current = {
-
     pm: {
         layer: "",
-        page: "fore"
+        page: "fore",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         //layer指定がない場合は、現在のレイヤを採用
         if (pm.layer == "") {
             pm.layer = this.kag.stat.current_layer;
@@ -1847,8 +1878,7 @@ tyrano.plugin.kag.tag.current = {
         this.kag.stat.current_page = pm.page;
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 //メッセージレイヤの属性を変更します
@@ -1892,9 +1922,7 @@ tyrano.plugin.kag.tag.current = {
  #[end]
  */
 tyrano.plugin.kag.tag.position = {
-
     pm: {
-
         layer: "message0",
         page: "fore",
         left: "",
@@ -1914,24 +1942,20 @@ tyrano.plugin.kag.tag.position = {
         marginb: "0", //下余白
 
         next: "true",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         //指定のレイヤを取得
-        var target_layer = this.kag.layer.getLayer(pm.layer, pm.page).find(".message_outer");
+        var target_layer = this.kag.layer
+            .getLayer(pm.layer, pm.page)
+            .find(".message_outer");
 
         var new_style = {};
 
-        if (pm.left != "")
-            new_style["left"] = pm.left + "px";
-        if (pm.top != "")
-            new_style["top"] = pm.top + "px";
-        if (pm.width != "")
-            new_style["width"] = pm.width + "px";
-        if (pm.height != "")
-            new_style["height"] = pm.height + "px";
+        if (pm.left != "") new_style["left"] = pm.left + "px";
+        if (pm.top != "") new_style["top"] = pm.top + "px";
+        if (pm.width != "") new_style["width"] = pm.width + "px";
+        if (pm.height != "") new_style["height"] = pm.height + "px";
         if (pm.color != "")
             new_style["background-color"] = $.convertColor(pm.color);
 
@@ -1940,7 +1964,6 @@ tyrano.plugin.kag.tag.position = {
         }
 
         if (pm.border_size != "") {
-
             new_style["border-width"] = parseInt(pm.border_size) + "px";
             target_layer.css("border-style", "solid");
         }
@@ -1952,13 +1975,16 @@ tyrano.plugin.kag.tag.position = {
         //背景フレーム画像の設定 透明度も自分で設定する
 
         if (pm.frame == "none") {
-
-            target_layer.css("opacity", $.convertOpacity(this.kag.config.frameOpacity));
+            target_layer.css(
+                "opacity",
+                $.convertOpacity(this.kag.config.frameOpacity),
+            );
             target_layer.css("background-image", "");
-            target_layer.css("background-color", $.convertColor(this.kag.config.frameColor));
-
+            target_layer.css(
+                "background-color",
+                $.convertColor(this.kag.config.frameColor),
+            );
         } else if (pm.frame != "") {
-
             var storage_url = "";
 
             if ($.isHTTP(pm.frame)) {
@@ -1971,7 +1997,6 @@ tyrano.plugin.kag.tag.position = {
             target_layer.css("background-repeat", "no-repeat");
             target_layer.css("opacity", 1);
             target_layer.css("background-color", "");
-
         }
 
         if (pm.opacity != "") {
@@ -1982,14 +2007,20 @@ tyrano.plugin.kag.tag.position = {
         this.kag.setStyles(target_layer, new_style);
 
         //outerレイヤを保存
-        this.kag.stat.fuki.def_style = $.extend(true, this.kag.stat.fuki.def_style, new_style);
+        this.kag.stat.fuki.def_style = $.extend(
+            true,
+            this.kag.stat.fuki.def_style,
+            new_style,
+        );
 
         //複数のレイヤに影響がでないように。
         this.kag.layer.refMessageLayer(pm.layer);
 
         //message_inner のスタイルを変更する必要もある
 
-        var layer_inner = this.kag.layer.getLayer(pm.layer, pm.page).find(".message_inner");
+        var layer_inner = this.kag.layer
+            .getLayer(pm.layer, pm.page)
+            .find(".message_inner");
 
         //縦書き指定
         if (pm.vertical != "") {
@@ -2002,7 +2033,6 @@ tyrano.plugin.kag.tag.position = {
             }
         }
 
-
         var new_style_inner = {};
 
         if (pm.marginl != "0")
@@ -2011,27 +2041,38 @@ tyrano.plugin.kag.tag.position = {
             new_style_inner["padding-top"] = parseInt(pm.margint) + "px";
 
         if (pm.marginr != "0") {
-            new_style_inner["width"] = (parseInt(layer_inner.css("width")) - parseInt(pm.marginr) - parseInt(pm.marginl)) + "px";
+            new_style_inner["width"] =
+                parseInt(layer_inner.css("width")) -
+                parseInt(pm.marginr) -
+                parseInt(pm.marginl) +
+                "px";
             this.kag.stat.fuki.marginr = parseInt(pm.marginr);
         }
 
         if (pm.marginb != "0") {
-            new_style_inner["height"] = (parseInt(layer_inner.css("height")) - parseInt(pm.marginb)) - parseInt(pm.margint) + "px";
+            new_style_inner["height"] =
+                parseInt(layer_inner.css("height")) -
+                parseInt(pm.marginb) -
+                parseInt(pm.margint) +
+                "px";
             this.kag.stat.fuki.marginb = parseInt(pm.marginb);
         }
 
         this.kag.setStyles(layer_inner, new_style_inner);
 
         //innerレイヤを保存
-        this.kag.stat.fuki.def_style_inner = $.extend(true, this.kag.stat.fuki.def_style_inner, new_style_inner);
-
+        this.kag.stat.fuki.def_style_inner = $.extend(
+            true,
+            this.kag.stat.fuki.def_style_inner,
+            new_style_inner,
+        );
 
         //レイヤーをリフレッシュする
 
         if (pm.next == "true") {
             this.kag.ftag.nextOrder();
         }
-    }
+    },
 };
 
 /*
@@ -2076,32 +2117,30 @@ othersで設定した位置にふきだしを表示[p]
  #[end]
  */
 tyrano.plugin.kag.tag.fuki_start = {
-
     pm: {
-
         layer: "message0",
         page: "fore",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.fuki.active = true;
 
         //どこに表示するか
         //指定のレイヤを取得
-        var target_layer = this.kag.layer.getLayer(pm.layer, pm.page).find(".message_outer");
+        var target_layer = this.kag.layer
+            .getLayer(pm.layer, pm.page)
+            .find(".message_outer");
         target_layer.addClass("fuki_box");
 
-        var j_msg_inner = this.kag.layer.getLayer(pm.layer, pm.page).find(".message_inner");
+        var j_msg_inner = this.kag.layer
+            .getLayer(pm.layer, pm.page)
+            .find(".message_inner");
         j_msg_inner.css("width", "");
         j_msg_inner.css("height", "");
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
 
 /*
  #[fuki_stop]
@@ -2118,13 +2157,9 @@ tyrano.plugin.kag.tag.fuki_start = {
  #[end]
  */
 tyrano.plugin.kag.tag.fuki_stop = {
+    pm: {},
 
-    pm: {
-
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.fuki.active = false;
 
         var j_outer_layer = this.kag.getMessageOuterLayer();
@@ -2151,8 +2186,7 @@ tyrano.plugin.kag.tag.fuki_stop = {
         $(".tyrano_base").find(".chara_name_area").show();
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -2197,11 +2231,9 @@ tyrano.plugin.kag.tag.fuki_stop = {
  */
 
 tyrano.plugin.kag.tag.fuki_chara = {
-
     vital: ["name"],
 
     pm: {
-
         name: "",
 
         //left:"",
@@ -2228,11 +2260,9 @@ tyrano.plugin.kag.tag.fuki_chara = {
         border_size: "",
         border_color: "",
         radius: "",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var storage_url = "";
 
         //見た目は継承させない
@@ -2246,13 +2276,19 @@ tyrano.plugin.kag.tag.fuki_chara = {
         if (pm.font_color == "") delete pm.font_color;
 
         if (pm.name == "others") {
-            this.kag.stat.fuki.others_style = $.extend(this.kag.stat.fuki.others_style, pm);
+            this.kag.stat.fuki.others_style = $.extend(
+                this.kag.stat.fuki.others_style,
+                pm,
+            );
         } else {
-
             var cpm = this.kag.stat.charas[pm.name];
 
             if (cpm == null) {
-                this.kag.error("指定されたキャラクター「" + pm.name + "」は定義されていません。[chara_new]で定義してください");
+                this.kag.error(
+                    "指定されたキャラクター「" +
+                        pm.name +
+                        "」は定義されていません。[chara_new]で定義してください",
+                );
                 return;
             }
 
@@ -2260,15 +2296,11 @@ tyrano.plugin.kag.tag.fuki_chara = {
 
             //パラメータ更新
             this.kag.stat.charas[pm.name]["fuki"] = $.extend(_cpm, pm);
-
         }
 
         this.kag.ftag.nextOrder();
-
-
-    }
+    },
 };
-
 
 /*
 #[image]
@@ -2318,38 +2350,33 @@ pos=レイヤ位置を自動的に決定します。前景レイヤに対して�
 //タグを記述していく
 //[image layer=base page=fore storage=haikei.jpg visible=true]
 tyrano.plugin.kag.tag.image = {
-
     pm: {
-
-        "layer": "base",
-        "page": "fore",
-        "visible": "",
-        "top": "",
-        "left": "",
-        "x": "",
-        "y": "",
-        "width": "",
-        "height": "",
-        "pos": "",
-        "name": "",
-        "folder": "", //画像フォルダを明示できる
-        "time": "",
-        "wait": "true",
-        "depth": "front",
-        "reflect": "",
-        "zindex": "1"
+        layer: "base",
+        page: "fore",
+        visible: "",
+        top: "",
+        left: "",
+        x: "",
+        y: "",
+        width: "",
+        height: "",
+        pos: "",
+        name: "",
+        folder: "", //画像フォルダを明示できる
+        time: "",
+        wait: "true",
+        depth: "front",
+        reflect: "",
+        zindex: "1",
         //"visible":"true"
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var strage_url = "";
         var folder = "";
         var that = this;
 
         if (pm.layer != "base") {
-
             //visible true が指定されている場合は表示状態に持っていけ
             //これはレイヤのスタイル
             var layer_new_style = {};
@@ -2359,13 +2386,14 @@ tyrano.plugin.kag.tag.image = {
                 layer_new_style.display = "block";
             }
 
-            this.kag.setStyles(this.kag.layer.getLayer(pm.layer, pm.page), layer_new_style);
+            this.kag.setStyles(
+                this.kag.layer.getLayer(pm.layer, pm.page),
+                layer_new_style,
+            );
 
             //ポジションの指定
             if (pm.pos != "") {
-
                 switch (pm.pos) {
-
                     case "left":
                     case "l":
                         pm.left = this.kag.config["scPositionX.left"];
@@ -2390,9 +2418,7 @@ tyrano.plugin.kag.tag.image = {
                     case "r":
                         pm.left = this.kag.config["scPositionX.right"];
                         break;
-
                 }
-
             }
 
             if (pm.folder != "") {
@@ -2410,12 +2436,12 @@ tyrano.plugin.kag.tag.image = {
 
             var img_obj = $("<img />");
 
-
-            if ($.getExt(pm.storage) == "svg" || $.getExt(pm.storage) == "SVG") {
-
+            if (
+                $.getExt(pm.storage) == "svg" ||
+                $.getExt(pm.storage) == "SVG"
+            ) {
                 img_obj = $("<object type='image/svg+xml' />");
                 img_obj.attr("data", strage_url);
-
             }
 
             img_obj.attr("src", strage_url);
@@ -2455,7 +2481,6 @@ tyrano.plugin.kag.tag.image = {
 
             if (pm.time == 0 || pm.time == "0") pm.time = ""; // integer 0 and string "0" are equal to ""
             if (pm.time != "") {
-
                 img_obj.css("opacity", 0);
 
                 if (pm.depth == "back") {
@@ -2464,24 +2489,18 @@ tyrano.plugin.kag.tag.image = {
                     this.kag.layer.getLayer(pm.layer, pm.page).append(img_obj);
                 }
 
-
-                img_obj.stop(true, true).animate(
-                    { "opacity": 1 },
-                    parseInt(pm.time),
-                    function() {
+                img_obj
+                    .stop(true, true)
+                    .animate({ opacity: 1 }, parseInt(pm.time), function () {
                         if (pm.wait == "true") {
                             that.kag.ftag.nextOrder();
                         }
-                    }
-                );
+                    });
 
                 if (pm.wait != "true") {
                     that.kag.ftag.nextOrder();
                 }
-
-
             } else {
-
                 if (pm.depth == "back") {
                     this.kag.layer.getLayer(pm.layer, pm.page).prepend(img_obj);
                 } else {
@@ -2489,11 +2508,8 @@ tyrano.plugin.kag.tag.image = {
                 }
 
                 this.kag.ftag.nextOrder();
-
             }
-
         } else {
-
             //base レイヤの場合
 
             if (pm.folder != "") {
@@ -2513,19 +2529,20 @@ tyrano.plugin.kag.tag.image = {
 
             var new_style = {
                 "background-image": "url(" + strage_url + ")",
-                "display": "none"
+                "display": "none",
             };
 
             if (pm.page === "fore") {
                 new_style.display = "block";
             }
 
-            this.kag.setStyles(this.kag.layer.getLayer(pm.layer, pm.page), new_style);
+            this.kag.setStyles(
+                this.kag.layer.getLayer(pm.layer, pm.page),
+                new_style,
+            );
             this.kag.ftag.nextOrder();
-
         }
-
-    }
+    },
 };
 
 /*
@@ -2564,29 +2581,27 @@ wait=完了を待つかどうかを指定できます。trueを指定すると�
 
 //イメージ情報消去背景とか
 tyrano.plugin.kag.tag.freeimage = {
-
     vital: ["layer"],
 
     pm: {
         layer: "",
         page: "fore",
         time: "", //徐々に非表示にする
-        wait: "true"
+        wait: "true",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         if (pm.layer != "base") {
-
             //前景レイヤの場合、全部削除だよ
 
             //非表示にした後、削除する
             if (pm.time == 0) pm.time = ""; // integer 0 and string "0" are equal to ""
             if (pm.time != "") {
-
-                var j_obj = this.kag.layer.getLayer(pm.layer, pm.page).children();
+                var j_obj = this.kag.layer
+                    .getLayer(pm.layer, pm.page)
+                    .children();
 
                 //存在しない場合は即next
                 if (!j_obj.get(0)) {
@@ -2599,32 +2614,27 @@ tyrano.plugin.kag.tag.freeimage = {
                 var cnt = 0;
                 var s_cnt = j_obj.length;
 
-                j_obj.stop(true, true).animate(
-                    { "opacity": 0 },
-                    parseInt(pm.time),
-                    function() {
+                j_obj
+                    .stop(true, true)
+                    .animate({ opacity: 0 }, parseInt(pm.time), function () {
                         that.kag.layer.getLayer(pm.layer, pm.page).empty();
                         //次へ移動ですがな
                         cnt++;
                         if (s_cnt == cnt) {
-
                             if (pm.wait == "true") {
                                 that.kag.ftag.nextOrder();
                             }
-
                         }
-                    }
-                );
-
+                    });
             } else {
                 that.kag.layer.getLayer(pm.layer, pm.page).empty();
                 //次へ移動ですがな
                 that.kag.ftag.nextOrder();
             }
-
         } else {
-
-            this.kag.layer.getLayer(pm.layer, pm.page).css("background-image", "");
+            this.kag.layer
+                .getLayer(pm.layer, pm.page)
+                .css("background-image", "");
             //次へ移動ですがな
             this.kag.ftag.nextOrder();
         }
@@ -2632,15 +2642,11 @@ tyrano.plugin.kag.tag.freeimage = {
         if (pm.wait == "false") {
             this.kag.ftag.nextOrder();
         }
-
-
-    }
+    },
 };
-
 
 //freeimageという名前がわかりにくい。freelayerという名前でもつかえるようにした。
 tyrano.plugin.kag.tag.freelayer = tyrano.plugin.kag.tag.freeimage;
-
 
 /*
 #[free]
@@ -2672,11 +2678,8 @@ wait=削除の完了を待つかどうかを指定できます。trueを指定�
 #[end]
 */
 
-
-
 //イメージ情報消去背景とか
 tyrano.plugin.kag.tag.free = {
-
     vital: ["layer", "name"],
 
     pm: {
@@ -2684,24 +2687,20 @@ tyrano.plugin.kag.tag.free = {
         page: "fore",
         name: "",
         wait: "true",
-        time: "" //徐々に非表示にする
+        time: "", //徐々に非表示にする
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         if (pm.layer != "base") {
-
             //前景レイヤの場合、全部削除だよ
 
             //非表示にした後、削除する
             if (pm.time == 0) pm.time = ""; // integer 0 and string "0" are equal to ""
             if (pm.time != "") {
-
                 var j_obj = this.kag.layer.getLayer(pm.layer, pm.page);
                 j_obj = j_obj.find("." + pm.name);
-
 
                 //存在しない場合は即next
                 if (!j_obj.get(0)) {
@@ -2714,10 +2713,9 @@ tyrano.plugin.kag.tag.free = {
                 var cnt = 0;
                 var s_cnt = j_obj.length;
 
-                j_obj.stop(true, true).animate(
-                    { "opacity": 0 },
-                    parseInt(pm.time),
-                    function() {
+                j_obj
+                    .stop(true, true)
+                    .animate({ opacity: 0 }, parseInt(pm.time), function () {
                         j_obj.remove();
                         //次へ移動ですがな
                         cnt++;
@@ -2726,16 +2724,13 @@ tyrano.plugin.kag.tag.free = {
                                 that.kag.ftag.nextOrder();
                             }
                         }
-                    }
-                );
+                    });
 
                 //falseの時は即次へ
                 if (pm.wait == "false") {
                     that.kag.ftag.nextOrder();
                 }
-
             } else {
-
                 var j_obj = this.kag.layer.getLayer(pm.layer, pm.page);
                 j_obj = j_obj.find("." + pm.name);
                 j_obj.remove();
@@ -2743,9 +2738,7 @@ tyrano.plugin.kag.tag.free = {
                 //次へ移動ですがな
                 that.kag.ftag.nextOrder();
             }
-
         } else {
-
             var j_obj = this.kag.layer.getLayer(pm.layer, pm.page);
             j_obj = j_obj.find("." + pm.name);
             j_obj.remove();
@@ -2753,12 +2746,8 @@ tyrano.plugin.kag.tag.free = {
             //次へ移動ですがな
             this.kag.ftag.nextOrder();
         }
-
-
-    }
+    },
 };
-
-
 
 /*
 #[ptext]
@@ -2806,37 +2795,33 @@ overwrite=true か false を指定します。同時にnameを指定している
 
 //タグを記述していく
 tyrano.plugin.kag.tag.ptext = {
-
     vital: ["layer", "x", "y"],
 
     pm: {
-
-        "layer": "0",
-        "page": "fore",
-        "x": 0,
-        "y": 0,
-        "vertical": "false",
-        "text": "", //テキスト領域のデフォルト値を指定するためですが、、、
-        "size": "",
-        "face": "",
-        "color": "",
-        "italic": "",
-        "bold": "",
-        "align": "left",
-        "edge": "",
-        "shadow": "",
-        "name": "",
-        "time": "",
-        "width": "",
-        "zindex": "9999",
-        "overwrite": "false" //要素を上書きするかどうか
+        layer: "0",
+        page: "fore",
+        x: 0,
+        y: 0,
+        vertical: "false",
+        text: "", //テキスト領域のデフォルト値を指定するためですが、、、
+        size: "",
+        face: "",
+        color: "",
+        italic: "",
+        bold: "",
+        align: "left",
+        edge: "",
+        shadow: "",
+        name: "",
+        time: "",
+        width: "",
+        zindex: "9999",
+        overwrite: "false", //要素を上書きするかどうか
 
         //"visible":"true"
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         //visible true が指定されている場合は表示状態に持っていけ
@@ -2880,29 +2865,34 @@ tyrano.plugin.kag.tag.ptext = {
             pm.color = $.convertColor(pm.color);
         }
 
-
         var font_new_style = {
-
             "color": pm.color,
             "font-weight": pm.bold,
             "font-style": pm.fontstyle,
             "font-size": pm.size + "px",
             "font-family": pm.face,
             "z-index": "999",
-            "text": ""
-
+            "text": "",
         };
 
         if (pm.edge != "") {
             var edge_color = $.convertColor(pm.edge);
-            font_new_style["text-shadow"] = "1px 1px 0 " + edge_color + ", -1px 1px 0 " + edge_color + ",1px -1px 0 " + edge_color + ",-1px -1px 0 " + edge_color + "";
+            font_new_style["text-shadow"] =
+                "1px 1px 0 " +
+                edge_color +
+                ", -1px 1px 0 " +
+                edge_color +
+                ",1px -1px 0 " +
+                edge_color +
+                ",-1px -1px 0 " +
+                edge_color +
+                "";
         } else if (pm.shadow != "") {
-            font_new_style["text-shadow"] = "2px 2px 2px " + $.convertColor(pm.shadow);
+            font_new_style["text-shadow"] =
+                "2px 2px 2px " + $.convertColor(pm.shadow);
         }
 
         var target_layer = this.kag.layer.getLayer(pm.layer, pm.page);
-
-
 
         var tobj = $("<p></p>");
 
@@ -2912,7 +2902,6 @@ tyrano.plugin.kag.tag.ptext = {
         tobj.css("width", pm.width);
 
         tobj.css("text-align", pm.align);
-
 
         if (pm.vertical == "true") {
             tobj.addClass("vertical_text");
@@ -2934,22 +2923,18 @@ tyrano.plugin.kag.tag.ptext = {
             tobj.css("opacity", 0);
             target_layer.append(tobj);
             tobj.stop(true, true).animate(
-                { "opacity": 1 },
+                { opacity: 1 },
                 parseInt(pm.time),
-                function() {
+                function () {
                     that.kag.ftag.nextOrder();
-                }
+                },
             );
         } else {
             target_layer.append(tobj);
             this.kag.ftag.nextOrder();
-
         }
-
-
-    }
+    },
 };
-
 
 /*
 #[mtext]
@@ -3011,53 +2996,49 @@ out_reverse=trueを指定すると、文字が後ろから消えていきます�
 
 //タグを記述していく
 tyrano.plugin.kag.tag.mtext = {
-
     vital: ["x", "y"],
 
     pm: {
+        layer: "0",
+        page: "fore",
+        x: 0,
+        y: 0,
+        vertical: "false",
+        text: "", //テキスト領域のデフォルト値を指定するためですが、、、
+        size: "",
+        face: "",
+        color: "",
+        italic: "",
+        bold: "",
+        shadow: "",
+        edge: "",
+        name: "",
+        zindex: "9999",
+        width: "",
+        align: "left",
 
-        "layer": "0",
-        "page": "fore",
-        "x": 0,
-        "y": 0,
-        "vertical": "false",
-        "text": "", //テキスト領域のデフォルト値を指定するためですが、、、
-        "size": "",
-        "face": "",
-        "color": "",
-        "italic": "",
-        "bold": "",
-        "shadow": "",
-        "edge": "",
-        "name": "",
-        "zindex": "9999",
-        "width": "",
-        "align": "left",
+        fadeout: "true", //テキストを残すかどうか
+        time: "2000", //テキストを表示時間しておく時間
 
-        "fadeout": "true", //テキストを残すかどうか
-        "time": "2000", //テキストを表示時間しておく時間
+        in_effect: "fadeIn",
+        in_delay: "50",
+        in_delay_scale: "1.5",
+        in_sync: "false",
+        in_shuffle: "false",
+        in_reverse: "false",
 
-        "in_effect": "fadeIn",
-        "in_delay": "50",
-        "in_delay_scale": "1.5",
-        "in_sync": "false",
-        "in_shuffle": "false",
-        "in_reverse": "false",
+        wait: "true", //テキストの表示完了を待つ
 
-        "wait": "true",  //テキストの表示完了を待つ
-
-        "out_effect": "fadeOut",
-        "out_delay": "50", //次の１文字が消えるタイミングへ移動する時間をミリ秒で指定します
-        "out_scale_delay": "", //１文字が消えるのにかかる時間をミリ秒で指定します
-        "out_sync": "false",
-        "out_shuffle": "false",
-        "out_reverse": "false"
+        out_effect: "fadeOut",
+        out_delay: "50", //次の１文字が消えるタイミングへ移動する時間をミリ秒で指定します
+        out_scale_delay: "", //１文字が消えるのにかかる時間をミリ秒で指定します
+        out_sync: "false",
+        out_shuffle: "false",
+        out_reverse: "false",
         //"visible":"true"
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         //指定がない場合はデフォルトフォントを適応する
@@ -3073,22 +3054,30 @@ tyrano.plugin.kag.tag.mtext = {
         }
 
         var font_new_style = {
-
             "color": pm.color,
             "font-weight": pm.bold,
             "font-style": pm.fontstyle,
             "font-size": pm.size + "px",
             "font-family": pm.face,
             "z-index": "999",
-            "text": ""
-
+            "text": "",
         };
 
         if (pm.edge != "") {
             var edge_color = $.convertColor(pm.edge);
-            font_new_style["text-shadow"] = "1px 1px 0 " + edge_color + ", -1px 1px 0 " + edge_color + ",1px -1px 0 " + edge_color + ",-1px -1px 0 " + edge_color + "";
+            font_new_style["text-shadow"] =
+                "1px 1px 0 " +
+                edge_color +
+                ", -1px 1px 0 " +
+                edge_color +
+                ",1px -1px 0 " +
+                edge_color +
+                ",-1px -1px 0 " +
+                edge_color +
+                "";
         } else if (pm.shadow != "") {
-            font_new_style["text-shadow"] = "2px 2px 2px " + $.convertColor(pm.shadow);
+            font_new_style["text-shadow"] =
+                "2px 2px 2px " + $.convertColor(pm.shadow);
         }
 
         var target_layer = this.kag.layer.getLayer(pm.layer, pm.page);
@@ -3130,45 +3119,43 @@ tyrano.plugin.kag.tag.mtext = {
 
         //tobj をアニメーションさせる
         tobj.textillate({
+            loop: pm["fadeout"],
+            minDisplayTime: pm["time"],
 
-            "loop": pm["fadeout"],
-            "minDisplayTime": pm["time"],
-
-            "in": {
-                "effect": pm["in_effect"],
-                "delayScale": pm["in_delay_scale"],
-                "delay": pm["in_delay"],
-                "sync": pm["in_sync"],
-                "shuffle": pm["in_shuffle"],
-                "reverse": pm["in_reverse"],
-                "callback": function() {
+            in: {
+                effect: pm["in_effect"],
+                delayScale: pm["in_delay_scale"],
+                delay: pm["in_delay"],
+                sync: pm["in_sync"],
+                shuffle: pm["in_shuffle"],
+                reverse: pm["in_reverse"],
+                callback: function () {
                     if (pm.fadeout == false && pm.wait == true) {
                         that.kag.ftag.nextOrder();
                     }
-                }
+                },
             },
 
-            "out": {
-                "effect": pm["out_effect"],
-                "delayScale": pm["out_delay_scale"],
-                "delay": pm["out_delay"],
-                "sync": pm["out_sync"],
-                "shuffle": pm["out_shuffle"],
-                "reverse": pm["out_reverse"],
-                "callback": function() {
+            out: {
+                effect: pm["out_effect"],
+                delayScale: pm["out_delay_scale"],
+                delay: pm["out_delay"],
+                sync: pm["out_sync"],
+                shuffle: pm["out_shuffle"],
+                reverse: pm["out_reverse"],
+                callback: function () {
                     tobj.remove();
                     if (pm.wait == true) {
                         that.kag.ftag.nextOrder();
                     }
-                }
-            }
-
+                },
+            },
         });
 
         if (pm.wait != true) {
             this.kag.ftag.nextOrder();
         }
-    }
+    },
 };
 
 /*
@@ -3204,15 +3191,14 @@ message0 または message1 を指定するとメッセージレイヤにな り
 
 //前景レイヤを背景レイヤにコピー
 tyrano.plugin.kag.tag.backlay = {
-
     pm: {
-        layer: ""
+        layer: "",
     },
 
-    start: function(pm) {
+    start: function (pm) {
         this.kag.layer.backlay(pm.layer);
         this.kag.ftag.nextOrder();
-    }
+    },
 };
 
 /*
@@ -3240,23 +3226,21 @@ tyrano.plugin.kag.tag.backlay = {
 
 //トランジション完了を待つ
 tyrano.plugin.kag.tag.wt = {
-    start: function(pm) {
-
+    start: function (pm) {
         if (this.kag.stat.is_trans == false) {
             this.kag.layer.showEventLayer();
             this.kag.ftag.nextOrder();
         } else {
             this.kag.layer.hideEventLayer();
         }
-
-    }
+    },
 };
 
 //音楽のフェードインを待つ
 tyrano.plugin.kag.tag.wb = {
-    start: function(pm) {
+    start: function (pm) {
         this.kag.layer.hideEventLayer();
-    }
+    },
 };
 
 //フェードインを待つ
@@ -3314,14 +3298,12 @@ target=ジャンプ先のラベルを指定します。省略すると、ファ�
 
 //リンクターゲット
 tyrano.plugin.kag.tag.link = {
-
     pm: {
         target: null,
-        storage: null
+        storage: null,
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         //即時にスパンを設定しないとダメね
@@ -3331,35 +3313,30 @@ tyrano.plugin.kag.tag.link = {
 
         j_span.css("cursor", "pointer");
 
-        (function() {
-
+        (function () {
             var _target = pm.target;
             var _storage = pm.storage;
 
             //クラスとイベントを登録する
             that.kag.event.addEventElement({
-                "tag": "link",
-                "j_target": j_span, //イベント登録先の
-                "pm": pm
+                tag: "link",
+                j_target: j_span, //イベント登録先の
+                pm: pm,
             });
 
             //イベントを設定する
             that.setEvent(j_span, pm);
-
         })();
 
         this.kag.ftag.nextOrder();
-
     },
 
-    setEvent: function(j_span, pm) {
-
+    setEvent: function (j_span, pm) {
         var _target = pm.target;
         var _storage = pm.storage;
         var that = TYRANO;
 
-        j_span.bind('click touchstart', function(e) {
-
+        j_span.bind("click touchstart", function (e) {
             that.kag.stat.display_link = false;
 
             //ここから書き始める。イベントがあった場合の処理ですね　ジャンプで飛び出す
@@ -3372,13 +3349,10 @@ tyrano.plugin.kag.tag.link = {
             } else {
                 that.kag.stat.is_skip = false;
             }
-
         });
 
         j_span.css("cursor", "pointer");
-
-    }
-
+    },
 };
 
 /*
@@ -3402,15 +3376,12 @@ tyrano.plugin.kag.tag.link = {
  */
 
 tyrano.plugin.kag.tag.endlink = {
-
-    start: function(pm) {
-
+    start: function (pm) {
         var j_span = this.kag.setMessageCurrentSpan();
 
         //新しいspanをつくるの
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -3431,31 +3402,25 @@ tyrano.plugin.kag.tag.endlink = {
  */
 
 tyrano.plugin.kag.tag.s = {
-
-    start: function() {
-
+    start: function () {
         this.kag.stat.is_strong_stop = true;
         this.kag.layer.hideEventLayer();
-
-    }
+    },
 };
 
 //使用禁止
 //処理停止、事前準備
 tyrano.plugin.kag.tag._s = {
-
     vital: [],
 
-    pm: {
+    pm: {},
 
-    },
-
-    start: function(pm) {
+    start: function (pm) {
         //現在のIndexを指定する。保存時に戻る場所だ
-        this.kag.stat.strong_stop_recover_index = this.kag.ftag.current_order_index;
+        this.kag.stat.strong_stop_recover_index =
+            this.kag.ftag.current_order_index;
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -3476,17 +3441,13 @@ time=ウェイトをミリ秒で指定します。
 
 //ウェイト
 tyrano.plugin.kag.tag.wait = {
-
     vital: ["time"],
 
     pm: {
-
-        time: 0
-
+        time: 0,
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         //クリック無効
@@ -3494,19 +3455,14 @@ tyrano.plugin.kag.tag.wait = {
         this.kag.stat.is_wait = true;
         this.kag.layer.hideEventLayer();
 
-
-        that.kag.tmp.wait_id = setTimeout(function() {
+        that.kag.tmp.wait_id = setTimeout(function () {
             that.kag.stat.is_strong_stop = false;
             that.kag.stat.is_wait = false;
             that.kag.layer.showEventLayer();
             that.kag.ftag.nextOrder();
         }, pm.time);
-
-
-
-    }
+    },
 };
-
 
 /*
 #[wait_cancel]
@@ -3527,14 +3483,11 @@ tyrano.plugin.kag.tag.wait = {
 
 //ウェイト
 tyrano.plugin.kag.tag.wait_cancel = {
-
     vital: [],
 
-    pm: {
-    },
+    pm: {},
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         //[wait]キャンセル
@@ -3545,10 +3498,8 @@ tyrano.plugin.kag.tag.wait_cancel = {
         this.kag.layer.showEventLayer();
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
 
 /*
  #[hidemessage]
@@ -3565,9 +3516,7 @@ tyrano.plugin.kag.tag.wait_cancel = {
  */
 
 tyrano.plugin.kag.tag.hidemessage = {
-
-    start: function() {
-
+    start: function () {
         this.kag.stat.is_hide_message = true;
         //メッセージレイヤを全て削除する //テキスト表示時に復活
         this.kag.layer.hideMessageLayers();
@@ -3576,8 +3525,7 @@ tyrano.plugin.kag.tag.hidemessage = {
         this.kag.layer.layer_event.show();
 
         //this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -3606,7 +3554,6 @@ vmax=揺れの縦方向への最大振幅を指定します。省略すると 10
 
 //画面を揺らします
 tyrano.plugin.kag.tag.quake = {
-
     vital: ["time"],
 
     pm: {
@@ -3615,46 +3562,48 @@ tyrano.plugin.kag.tag.quake = {
         timemode: "",
         hmax: "0",
         vmax: "10",
-        wait: "true"
+        wait: "true",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         if (pm.hmax != "0") {
-
-            $("." + this.kag.define.BASE_DIV_NAME).effect('shake', {
-                times: parseInt(pm.count),
-                distance: parseInt(pm.hmax),
-                direction: "left"
-            }, parseInt(pm.time), function() {
-
-                if (pm.wait == "true") {
-                    that.kag.ftag.nextOrder();
-                }
-            });
-
+            $("." + this.kag.define.BASE_DIV_NAME).effect(
+                "shake",
+                {
+                    times: parseInt(pm.count),
+                    distance: parseInt(pm.hmax),
+                    direction: "left",
+                },
+                parseInt(pm.time),
+                function () {
+                    if (pm.wait == "true") {
+                        that.kag.ftag.nextOrder();
+                    }
+                },
+            );
         } else if (pm.vmax != "0") {
-
-            $("." + this.kag.define.BASE_DIV_NAME).effect('shake', {
-                times: parseInt(pm.count),
-                distance: parseInt(pm.vmax),
-                direction: "up"
-            }, parseInt(pm.time), function() {
-
-                if (pm.wait == "true") {
-                    that.kag.ftag.nextOrder();
-                }
-            });
-
+            $("." + this.kag.define.BASE_DIV_NAME).effect(
+                "shake",
+                {
+                    times: parseInt(pm.count),
+                    distance: parseInt(pm.vmax),
+                    direction: "up",
+                },
+                parseInt(pm.time),
+                function () {
+                    if (pm.wait == "true") {
+                        that.kag.ftag.nextOrder();
+                    }
+                },
+            );
         }
 
         if (pm.wait == "false") {
             that.kag.ftag.nextOrder();
         }
-
-    }
+    },
 };
 
 /*
@@ -3693,15 +3642,11 @@ fadeIn/fadeInDown/fadeInLeft/fadeInRight/fadeInUp/rotateIn<br />/zoomIn/slideIn/
  */
 
 tyrano.plugin.kag.tag.font = {
-
-    pm: {
-
-    },
+    pm: {},
 
     log_join: "true",
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.setMessageCurrentSpan();
 
         var new_font = {};
@@ -3727,19 +3672,16 @@ tyrano.plugin.kag.tag.font = {
         }
 
         if (pm.effect) {
-
             if (pm.effect == "none") {
                 this.kag.stat.font["effect"] = "";
             } else {
                 this.kag.stat.font["effect"] = pm.effect;
             }
-
         }
 
         if (pm.effect_speed) {
             this.kag.stat.font["effect_speed"] = pm.effect_speed;
         }
-
 
         if (pm.edge) {
             if (pm.edge == "none" || pm.edge == "") {
@@ -3759,8 +3701,7 @@ tyrano.plugin.kag.tag.font = {
 
         this.kag.ftag.nextOrder();
         ///////////////////
-
-    }
+    },
 };
 
 /*
@@ -3794,13 +3735,9 @@ effect_speed=effectパラメータがnone以外の場合に、表示されるま
 
 //デフォルトフォント設定
 tyrano.plugin.kag.tag.deffont = {
+    pm: {},
 
-    pm: {
-
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         var new_font = {};
 
         if (pm.size) {
@@ -3824,20 +3761,16 @@ tyrano.plugin.kag.tag.deffont = {
         }
 
         if (pm.effect) {
-
             if (pm.effect == "none") {
                 this.kag.stat.default_font["effect"] = "";
             } else {
                 this.kag.stat.default_font["effect"] = pm.effect;
             }
-
         }
 
         if (pm.effect_speed) {
             this.kag.stat.default_font["effect_speed"] = pm.effect_speed;
         }
-
-
 
         if (pm.edge) {
             if (pm.edge == "none" || pm.edge == "") {
@@ -3855,12 +3788,9 @@ tyrano.plugin.kag.tag.deffont = {
             }
         }
 
-
-
         this.kag.ftag.nextOrder();
         ///////////////////
-
-    }
+    },
 };
 
 /*
@@ -3884,21 +3814,19 @@ speed=文字の表示速度を指定します
 
 //文字の表示速度変更
 tyrano.plugin.kag.tag.delay = {
-
     pm: {
-        speed: ""
+        speed: "",
     },
 
     log_join: "true",
 
-    start: function(pm) {
+    start: function (pm) {
         if (pm.speed != "") {
             this.kag.stat.ch_speed = parseInt(pm.speed);
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -3916,22 +3844,17 @@ tyrano.plugin.kag.tag.delay = {
 
 //文字の表示速度変更
 tyrano.plugin.kag.tag.resetdelay = {
-
     pm: {
-        speed: ""
+        speed: "",
     },
 
     log_join: "true",
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.ch_speed = "";
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
-
 
 /*
 #[configdelay]
@@ -3951,21 +3874,21 @@ speed=文字の表示速度を指定します
 
 //文字の表示速度変更
 tyrano.plugin.kag.tag.configdelay = {
-
     pm: {
-        speed: ""
+        speed: "",
     },
 
-    start: function(pm) {
+    start: function (pm) {
         if (pm.speed != "") {
             this.kag.stat.ch_speed = "";
             this.kag.config.chSpeed = pm.speed;
-            this.kag.ftag.startTag("eval", { "exp": "sf._config_ch_speed = " + pm.speed });
+            this.kag.ftag.startTag("eval", {
+                exp: "sf._config_ch_speed = " + pm.speed,
+            });
         } else {
             this.kag.ftag.nextOrder();
         }
-
-    }
+    },
 };
 
 /*
@@ -3982,16 +3905,13 @@ tyrano.plugin.kag.tag.configdelay = {
  */
 
 tyrano.plugin.kag.tag.nowait = {
-
     pm: {},
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.is_nowait = true;
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -4008,16 +3928,13 @@ tyrano.plugin.kag.tag.nowait = {
  */
 
 tyrano.plugin.kag.tag.endnowait = {
-
     pm: {},
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.is_nowait = false;
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -4035,17 +3952,14 @@ tyrano.plugin.kag.tag.endnowait = {
  */
 
 tyrano.plugin.kag.tag.resetfont = {
-
     log_join: "true",
 
-    start: function() {
-
+    start: function () {
         var j_span = this.kag.setMessageCurrentSpan();
 
         this.kag.stat.font = $.extend(true, {}, this.kag.stat.default_font);
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -4082,7 +3996,6 @@ opacity=レイヤの不透明度を指定します。０～２５５の範囲で
 
 //レイヤーオプション変更
 tyrano.plugin.kag.tag.layopt = {
-
     vital: ["layer"],
 
     pm: {
@@ -4093,18 +4006,15 @@ tyrano.plugin.kag.tag.layopt = {
         top: "",
         opacity: "",
         autohide: false,
-        index: 10
+        index: 10,
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         if (pm.layer == "message") {
-
             pm.layer = this.kag.stat.current_layer;
             pm.page = this.kag.stat.current_page;
-
         }
 
         var j_layer = this.kag.layer.getLayer(pm.layer, pm.page);
@@ -4115,23 +4025,17 @@ tyrano.plugin.kag.tag.layopt = {
 
         //表示部分の変更
         if (pm.visible != "") {
-
             if (pm.visible == "true") {
-
                 //バックの場合は、その場では表示してはダメ
                 if (pm.page == "fore") {
                     j_layer.css("display", "");
                 }
 
                 j_layer.attr("l_visible", "true");
-
             } else {
-
                 j_layer.css("display", "none");
                 j_layer.attr("l_visible", "false");
-
             }
-
         }
 
         //レイヤのポジション指定
@@ -4149,8 +4053,7 @@ tyrano.plugin.kag.tag.layopt = {
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -4176,28 +4079,23 @@ text=ルビとして表示させる文字を指定します
 
 //ルビ指定
 tyrano.plugin.kag.tag["ruby"] = {
-
     vital: ["text"],
 
     pm: {
-        text: ""
+        text: "",
     },
 
     log_join: "true",
 
-    start: function(pm) {
-
+    start: function (pm) {
         var str = pm.text;
 
         //ここに文字が入っている場合、ルビを設定してから、テキスト表示する
         this.kag.stat.ruby_str = str;
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
-
 
 /*
 #[mark]
@@ -4225,7 +4123,6 @@ size=マーカーのサイズを指定できます。0〜100の間で指定し�
 
 //ルビ指定
 tyrano.plugin.kag.tag["mark"] = {
-
     vital: [],
 
     pm: {
@@ -4234,9 +4131,7 @@ tyrano.plugin.kag.tag["mark"] = {
         size: "",
     },
 
-
-    start: function(pm) {
-
+    start: function (pm) {
         var str = pm.text;
 
         this.kag.stat.mark = 1;
@@ -4248,11 +4143,15 @@ tyrano.plugin.kag.tag["mark"] = {
             style_mark += "color:" + $.convertColor(pm.font_color) + ";";
         } else {
             style_mark += "color:" + this.kag.stat.font.color + ";";
-
         }
 
         if (pm.size != "") {
-            style_mark += "background: linear-gradient(transparent " + (100 - parseInt(pm.size)) + "%, " + $.convertColor(pm.color) + " 0%);";
+            style_mark +=
+                "background: linear-gradient(transparent " +
+                (100 - parseInt(pm.size)) +
+                "%, " +
+                $.convertColor(pm.color) +
+                " 0%);";
         }
 
         style_mark += "padding-top:4px;padding-bottom:4px;";
@@ -4260,10 +4159,8 @@ tyrano.plugin.kag.tag["mark"] = {
         this.kag.stat.style_mark = style_mark;
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
 
 /*
 #[endmark]
@@ -4288,15 +4185,11 @@ tyrano.plugin.kag.tag["mark"] = {
 
 //ルビ指定
 tyrano.plugin.kag.tag["endmark"] = {
-
     vital: [],
 
-    pm: {
-    },
+    pm: {},
 
-
-    start: function(pm) {
-
+    start: function (pm) {
         var str = pm.text;
 
         //ここに文字が入っている場合、ルビを設定してから、テキスト表示する
@@ -4305,10 +4198,8 @@ tyrano.plugin.kag.tag["endmark"] = {
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
 
 /*
  #[cancelskip]
@@ -4325,12 +4216,10 @@ tyrano.plugin.kag.tag["endmark"] = {
  */
 
 tyrano.plugin.kag.tag.cancelskip = {
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.is_skip = false;
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -4357,14 +4246,12 @@ y=縦方向位置指定
 
 //グラフィックボタン表示位置調整、テキストはできない
 tyrano.plugin.kag.tag.locate = {
-
     pm: {
         x: null,
-        y: null
+        y: null,
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         if (pm.x != null) {
             this.kag.stat.locate.x = pm.x;
         }
@@ -4374,8 +4261,7 @@ tyrano.plugin.kag.tag.locate = {
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -4432,7 +4318,6 @@ role=ボタンに特別な機能を割り当てることができます。この
 
 //指定した位置にグラフィックボタンを配置する
 tyrano.plugin.kag.tag.button = {
-
     pm: {
         graphic: "",
         storage: null,
@@ -4443,7 +4328,7 @@ tyrano.plugin.kag.tag.button = {
         y: "",
         width: "",
         height: "",
-        fix: "false", /*ここがtrueの場合、システムボタンになりますね*/
+        fix: "false" /*ここがtrueの場合、システムボタンになりますね*/,
         savesnap: "false",
         folder: "image",
         exp: "",
@@ -4458,14 +4343,12 @@ tyrano.plugin.kag.tag.button = {
 
         auto_next: "yes",
 
-        role: ""
-
+        role: "",
     },
 
     //イメージ表示レイヤ。メッセージレイヤのように扱われますね。。
     //cmで抹消しよう
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         var target_layer = null;
@@ -4530,8 +4413,8 @@ tyrano.plugin.kag.tag.button = {
         //ツールチップの設定
         if (pm.hint != "") {
             j_button.attr({
-                "title": pm.hint,
-                "alt": pm.hint
+                title: pm.hint,
+                alt: pm.hint,
             });
         }
 
@@ -4540,9 +4423,9 @@ tyrano.plugin.kag.tag.button = {
 
         //クラスとイベントを登録する
         that.kag.event.addEventElement({
-            "tag": "button",
-            "j_target": j_button, //イベント登録先の
-            "pm": pm
+            tag: "button",
+            j_target: j_button, //イベント登録先の
+            pm: pm,
         });
         that.setEvent(j_button, pm);
 
@@ -4553,15 +4436,12 @@ tyrano.plugin.kag.tag.button = {
         }
 
         this.kag.ftag.nextOrder();
-
     },
 
-    setEvent: function(j_button, pm) {
-
+    setEvent: function (j_button, pm) {
         var that = TYRANO;
 
-        (function() {
-
+        (function () {
             var _target = pm.target;
             var _storage = pm.storage;
             var _pm = pm;
@@ -4569,67 +4449,64 @@ tyrano.plugin.kag.tag.button = {
             var preexp = that.kag.embScript(pm.preexp);
             var button_clicked = false;
 
-            j_button.hover(function() {
-                //マウスが乗った時
-                if (_pm.enterse != "") {
-                    that.kag.ftag.startTag("playse", {
-                        "storage": _pm.enterse,
-                        "stop": true
-                    });
-                }
-
-                if (_pm.enterimg != "") {
-                    var enter_img_url = "";
-                    if ($.isHTTP(_pm.enterimg)) {
-                        enter_img_url = _pm.enterimg;
-                    } else {
-                        enter_img_url = "./data/" + _pm.folder + "/" + _pm.enterimg;
+            j_button.hover(
+                function () {
+                    //マウスが乗った時
+                    if (_pm.enterse != "") {
+                        that.kag.ftag.startTag("playse", {
+                            storage: _pm.enterse,
+                            stop: true,
+                        });
                     }
 
-                    $(this).attr("src", enter_img_url);
+                    if (_pm.enterimg != "") {
+                        var enter_img_url = "";
+                        if ($.isHTTP(_pm.enterimg)) {
+                            enter_img_url = _pm.enterimg;
+                        } else {
+                            enter_img_url =
+                                "./data/" + _pm.folder + "/" + _pm.enterimg;
+                        }
 
-                }
-
-            }, function() {
-                //マウスが外れた時
-                if (_pm.leavese != "") {
-                    that.kag.ftag.startTag("playse", {
-                        "storage": _pm.leavese,
-                        "stop": true
-                    });
-                }
-
-                //元に戻す
-                if (_pm.enterimg != "") {
-
-                    var enter_img_url = "";
-                    if ($.isHTTP(_pm.graphic)) {
-                        enter_img_url = _pm.graphic;
-                    } else {
-                        enter_img_url = "./data/" + _pm.folder + "/" + _pm.graphic;
+                        $(this).attr("src", enter_img_url);
+                    }
+                },
+                function () {
+                    //マウスが外れた時
+                    if (_pm.leavese != "") {
+                        that.kag.ftag.startTag("playse", {
+                            storage: _pm.leavese,
+                            stop: true,
+                        });
                     }
 
-                    $(this).attr("src", enter_img_url);
+                    //元に戻す
+                    if (_pm.enterimg != "") {
+                        var enter_img_url = "";
+                        if ($.isHTTP(_pm.graphic)) {
+                            enter_img_url = _pm.graphic;
+                        } else {
+                            enter_img_url =
+                                "./data/" + _pm.folder + "/" + _pm.graphic;
+                        }
 
-                }
+                        $(this).attr("src", enter_img_url);
+                    }
+                },
+            );
 
-            });
-
-            j_button.click(function(event) {
-
+            j_button.click(function (event) {
                 if (_pm.clickimg != "") {
-
                     var click_img_url = "";
                     if ($.isHTTP(_pm.clickimg)) {
                         click_img_url = _pm.clickimg;
                     } else {
-                        click_img_url = "./data/" + _pm.folder + "/" + _pm.clickimg;
+                        click_img_url =
+                            "./data/" + _pm.folder + "/" + _pm.clickimg;
                     }
 
                     j_button.attr("src", click_img_url);
-
                 }
-
 
                 //fix指定のボタンは、繰り返し実行できるようにする
                 if (button_clicked == true && _pm.fix == "false") {
@@ -4637,7 +4514,10 @@ tyrano.plugin.kag.tag.button = {
                 }
 
                 //Sタグに到達していないとクリッカブルが有効にならない fixの時は実行される必要がある
-                if (that.kag.stat.is_strong_stop != true && _pm.fix == "false") {
+                if (
+                    that.kag.stat.is_strong_stop != true &&
+                    _pm.fix == "false"
+                ) {
                     return false;
                 }
 
@@ -4649,7 +4529,6 @@ tyrano.plugin.kag.tag.button = {
                 }
 
                 if (_pm.savesnap == "true") {
-
                     //セーブスナップを取る場合、アニメーション中やトランジションはNG
                     if (that.kag.stat.is_stop == true) {
                         return false;
@@ -4657,20 +4536,19 @@ tyrano.plugin.kag.tag.button = {
 
                     //ここは、現在のセーブ用のメッセージを取得しよう
                     that.kag.menu.snapSave(that.kag.stat.current_save_str);
-
                 }
-
 
                 //画面効果中は実行できないようにする
-                if (that.kag.layer.layer_event.css("display") == "none" && that.kag.stat.is_strong_stop != true) {
+                if (
+                    that.kag.layer.layer_event.css("display") == "none" &&
+                    that.kag.stat.is_strong_stop != true
+                ) {
                     return false;
                 }
-
 
                 //roleが設定されている場合は対応する処理を実行
                 //指定できる文字列はsave(セーブ画面を表示します)。load(ロード画面を表示します)。title(タイトル画面に戻ります)。menu(メニュー画面を表示します)。message(メッセージウィンドウを非表示にします)。skip(スキップの実行)
                 if (_pm.role != "") {
-
                     //roleがクリックされたら、skip停止
                     that.kag.stat.is_skip = false;
 
@@ -4680,20 +4558,22 @@ tyrano.plugin.kag.tag.button = {
                     }
 
                     //文字が流れているときは、セーブ出来ないようにする。
-                    if (_pm.role == "save" ||
+                    if (
+                        _pm.role == "save" ||
                         _pm.role == "menu" ||
                         _pm.role == "quicksave" ||
-                        _pm.role == "sleepgame") {
-
+                        _pm.role == "sleepgame"
+                    ) {
                         //テキストが流れているときとwait中は実行しない
-                        if (that.kag.stat.is_adding_text == true || that.kag.stat.is_wait == true) {
+                        if (
+                            that.kag.stat.is_adding_text == true ||
+                            that.kag.stat.is_wait == true
+                        ) {
                             return false;
                         }
-
                     }
 
                     switch (_pm.role) {
-
                         case "save":
                             that.kag.menu.displaySave();
                             break;
@@ -4728,16 +4608,16 @@ tyrano.plugin.kag.tag.button = {
                             that.kag.menu.loadQuickSave();
                             break;
                         case "auto":
-
                             if (that.kag.stat.is_auto == true) {
-                                that.kag.ftag.startTag("autostop", { next: "false" });
+                                that.kag.ftag.startTag("autostop", {
+                                    next: "false",
+                                });
                             } else {
                                 that.kag.ftag.startTag("autostart", {});
                             }
                             break;
 
                         case "sleepgame":
-
                             //押されたオブジェクトのマウスオーバーをsleepgame前に解除
                             j_button.trigger("mouseout");
 
@@ -4752,14 +4632,13 @@ tyrano.plugin.kag.tag.button = {
 
                             that.kag.ftag.startTag("sleepgame", _pm);
                             break;
-
                     }
 
                     //クリックされた時に音が指定されていたら
                     if (_pm.clickse != "") {
                         that.kag.ftag.startTag("playse", {
-                            "storage": _pm.clickse,
-                            "stop": true
+                            storage: _pm.clickse,
+                            stop: true,
                         });
                     }
 
@@ -4773,8 +4652,8 @@ tyrano.plugin.kag.tag.button = {
                 //クリックされた時に音が指定されていたら
                 if (_pm.clickse != "") {
                     that.kag.ftag.startTag("playse", {
-                        "storage": _pm.clickse,
-                        "stop": true
+                        storage: _pm.clickse,
+                        stop: true,
                     });
                 }
 
@@ -4782,7 +4661,6 @@ tyrano.plugin.kag.tag.button = {
 
                 //fixレイヤの場合はcallでスタックが積まれる
                 if (_pm.role == "" && _pm.fix == "true") {
-
                     //コールスタックが帰ってきてない場合は、実行しないようにする必要がある
                     //fixの場合はコールスタックに残る。
                     var stack_pm = that.kag.getStack("call"); //最新のコールスタックを取得
@@ -4804,24 +4682,20 @@ tyrano.plugin.kag.tag.button = {
                         that.kag.ftag.startTag("call", {
                             storage: _storage,
                             target: _target,
-                            auto_next: _auto_next
+                            auto_next: _auto_next,
                         });
-
                     } else {
-
                         //スタックで残された
-                        that.kag.log("callスタックが残っている場合、fixボタンは反応しません");
+                        that.kag.log(
+                            "callスタックが残っている場合、fixボタンは反応しません",
+                        );
                         that.kag.log(stack_pm);
-
 
                         return false;
                     }
-
                 } else {
-
                     //jumpを実行する
                     that.kag.ftag.startTag("jump", _pm);
-
                 }
 
                 //選択肢の後、スキップを継続するか否か
@@ -4830,16 +4704,9 @@ tyrano.plugin.kag.tag.button = {
                 } else {
                     that.kag.stat.is_skip = false;
                 }
-
             });
-
         })();
-
-
-    }
-
-
-
+    },
 };
 
 /*
@@ -4899,7 +4766,6 @@ cm=デフォルトはtrue。glinkは通常、ボタンをクリック後、自�
 
 //グラフィカルな選択肢を表示する　CSSボタン
 tyrano.plugin.kag.tag.glink = {
-
     pm: {
         color: "black", //クラス名でいいよ
         font_color: "",
@@ -4918,13 +4784,12 @@ tyrano.plugin.kag.tag.glink = {
         clickse: "",
         enterse: "",
         leavese: "",
-        face: ""
+        face: "",
     },
 
     //イメージ表示レイヤ。メッセージレイヤのように扱われますね。。
     //cmで抹消しよう
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
         var target_layer = null;
         target_layer = this.kag.layer.getFreeLayer();
@@ -4950,7 +4815,6 @@ tyrano.plugin.kag.tag.glink = {
 
         //graphic 背景画像を指定できます。
         if (pm.graphic != "") {
-
             //画像の読み込み
 
             j_button.removeClass("glink_button").addClass("button_graphic");
@@ -4959,7 +4823,6 @@ tyrano.plugin.kag.tag.glink = {
             j_button.css("background-repeat", "no-repeat");
             j_button.css("background-position", "center center");
             j_button.css("background-size", "100% 100%");
-
         } else {
             j_button.addClass(pm.color);
         }
@@ -4976,7 +4839,6 @@ tyrano.plugin.kag.tag.glink = {
             var base = Math.floor(sc_width / 2);
             var first_left = base - center;
             j_button.css("left", first_left + "px");
-
         } else if (pm.x == "") {
             j_button.css("left", this.kag.stat.locate.x + "px");
         } else {
@@ -4993,37 +4855,33 @@ tyrano.plugin.kag.tag.glink = {
         $.setName(j_button, pm.name);
 
         that.kag.event.addEventElement({
-            "tag": "glink",
-            "j_target": j_button, //イベント登録先の
-            "pm": pm
+            tag: "glink",
+            j_target: j_button, //イベント登録先の
+            pm: pm,
         });
         this.setEvent(j_button, pm);
 
         target_layer.append(j_button);
         target_layer.show();
         this.kag.ftag.nextOrder();
-
     },
 
-    setEvent: function(j_button, pm) {
-
+    setEvent: function (j_button, pm) {
         var that = TYRANO;
 
-        (function() {
-
+        (function () {
             var _target = pm.target;
             var _storage = pm.storage;
             var _pm = pm;
             var preexp = that.kag.embScript(pm.preexp);
             var button_clicked = false;
 
-            j_button.click(function(e) {
-
+            j_button.click(function (e) {
                 //クリックされた時に音が指定されていたら
                 if (_pm.clickse != "") {
                     that.kag.ftag.startTag("playse", {
-                        "storage": _pm.clickse,
-                        "stop": true
+                        storage: _pm.clickse,
+                        stop: true,
                     });
                 }
 
@@ -5054,46 +4912,45 @@ tyrano.plugin.kag.tag.glink = {
                 } else {
                     that.kag.stat.is_skip = false;
                 }
-
             });
 
-            j_button.hover(function() {
+            j_button.hover(
+                function () {
+                    if (_pm.enterimg != "") {
+                        var enterimg_url = "./data/image/" + _pm.enterimg;
+                        j_button.css(
+                            "background-image",
+                            "url(" + enterimg_url + ")",
+                        );
+                    }
 
-                if (_pm.enterimg != "") {
-                    var enterimg_url = "./data/image/" + _pm.enterimg;
-                    j_button.css("background-image", "url(" + enterimg_url + ")");
-                }
-
-                //マウスが乗った時
-                if (_pm.enterse != "") {
-                    that.kag.ftag.startTag("playse", {
-                        "storage": _pm.enterse,
-                        "stop": true
-                    });
-                }
-
-            },
-                function() {
-
+                    //マウスが乗った時
+                    if (_pm.enterse != "") {
+                        that.kag.ftag.startTag("playse", {
+                            storage: _pm.enterse,
+                            stop: true,
+                        });
+                    }
+                },
+                function () {
                     if (_pm.enterimg != "") {
                         var img_url = "./data/image/" + _pm.graphic;
-                        j_button.css("background-image", "url(" + img_url + ")");
+                        j_button.css(
+                            "background-image",
+                            "url(" + img_url + ")",
+                        );
                     }
                     //マウスが乗った時
                     if (_pm.leavese != "") {
                         that.kag.ftag.startTag("playse", {
-                            "storage": _pm.leavese,
-                            "stop": true
+                            storage: _pm.leavese,
+                            stop: true,
                         });
                     }
-                });
-
-
-
+                },
+            );
         })();
-
-
-    }
+    },
 };
 
 /*
@@ -5137,7 +4994,6 @@ target=クリックされた際のジャンプ先のラベルを指定します�
 
 //指定した位置にグラフィックボタンを配置する
 tyrano.plugin.kag.tag.clickable = {
-
     vital: ["width", "height"],
 
     pm: {
@@ -5151,13 +5007,12 @@ tyrano.plugin.kag.tag.clickable = {
         opacity: "140",
         storage: null,
         target: null,
-        name: ""
+        name: "",
     },
 
     //イメージ表示レイヤ。メッセージレイヤのように扱われますね。。
     //cmで抹消しよう
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         //this.kag.stat.locate.x
@@ -5176,7 +5031,6 @@ tyrano.plugin.kag.tag.clickable = {
         j_button.css("background-color", $.convertColor(pm.color));
         j_button.css("border", $.replaceAll(pm.border, ":", " "));
 
-
         //alert($.replaceAll(pm.border,":"," "));
 
         //x,y 座標が指定されている場合は、そっちを採用
@@ -5190,9 +5044,9 @@ tyrano.plugin.kag.tag.clickable = {
 
         //クラスとイベントを登録する
         that.kag.event.addEventElement({
-            "tag": "clickable",
-            "j_target": j_button, //イベント登録先の
-            "pm": pm
+            tag: "clickable",
+            j_target: j_button, //イベント登録先の
+            pm: pm,
         });
 
         that.setEvent(j_button, pm);
@@ -5201,43 +5055,35 @@ tyrano.plugin.kag.tag.clickable = {
         layer_free.show();
 
         this.kag.ftag.nextOrder();
-
     },
 
-    setEvent: function(j_button, pm) {
-
+    setEvent: function (j_button, pm) {
         var that = TYRANO;
 
-        (function() {
-
+        (function () {
             var _target = pm.target;
             var _storage = pm.storage;
             var _pm = pm;
 
             if (_pm.mouseopacity != "") {
-
-                j_button.bind("mouseover", function() {
+                j_button.bind("mouseover", function () {
                     j_button.css("opacity", $.convertOpacity(_pm.mouseopacity));
-
                 });
 
-                j_button.bind("mouseout", function() {
+                j_button.bind("mouseout", function () {
                     j_button.css("opacity", $.convertOpacity(_pm.opacity));
                 });
-
             }
 
-            j_button.click(function() {
-
+            j_button.click(function () {
                 //Sタグに到達していないとクリッカブルが有効にならない
 
-                var is_s = (function(obj) {
+                var is_s = (function (obj) {
                     if (obj.kag.stat.is_strong_stop != true) {
                         return false;
                     }
 
                     return true;
-
                 })(that);
 
                 if (is_s == false) {
@@ -5248,15 +5094,9 @@ tyrano.plugin.kag.tag.clickable = {
                 //コールを実行する
                 that.kag.layer.showEventLayer();
                 that.kag.ftag.startTag("jump", _pm);
-
-
             });
-
         })();
-
-
-    }
-
+    },
 };
 
 /*
@@ -5285,25 +5125,22 @@ top=fix 属性を true にしたときに記号を表示する位置のうち、
 
 //指定した位置にグラフィックボタンを配置する
 tyrano.plugin.kag.tag.glyph = {
-
     pm: {
         line: "nextpage.gif",
         layer: "message0",
         fix: "false",
         left: 0,
-        top: 0
+        top: 0,
     },
 
     //イメージ表示レイヤ。メッセージレイヤのように扱われますね。。
     //cmで抹消しよう
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         $(".glyph_image").remove();
 
         if (pm.fix == "true") {
-
             var j_layer = this.kag.layer.getLayer(pm.layer);
 
             var j_next = $("<img class='glyph_image' />");
@@ -5317,19 +5154,13 @@ tyrano.plugin.kag.tag.glyph = {
             j_layer.append(j_next);
 
             this.kag.stat.flag_glyph = "true";
-
         } else {
-
             this.kag.stat.flag_glyph = "false";
             this.kag.stat.path_glyph = pm.line;
-
-
-
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 //スタイル変更は未サポート
@@ -5411,18 +5242,16 @@ rollIn
 
 //トランジション
 tyrano.plugin.kag.tag.trans = {
-
     vital: ["time", "layer"],
 
     pm: {
         layer: "base",
         method: "fadeIn",
         children: false,
-        time: 1500
+        time: 1500,
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.ftag.hideNextImg();
         this.kag.stat.is_trans = true;
         var that = this;
@@ -5443,14 +5272,10 @@ tyrano.plugin.kag.tag.trans = {
         var map_layer_fore = $.cloneObject(this.kag.layer.map_layer_fore);
         var map_layer_back = $.cloneObject(this.kag.layer.map_layer_back);
 
-
         for (key in map_layer_fore) {
-
             //指定条件のレイヤのみ実施
             if (pm.children == true || key === pm.layer) {
-
-                (function() {
-
+                (function () {
                     var _key = key;
 
                     var layer_fore = map_layer_fore[_key];
@@ -5459,41 +5284,41 @@ tyrano.plugin.kag.tag.trans = {
                     //メッセージレイヤの場合、カレント以外はトランスしない。むしろ非表示
                     //if((_key.indexOf("message")!=-1 && _key !== that.kag.stat.current_layer) || (_key.indexOf("message")!=-1 && layer_back.attr("l_visible") == "false") ){
 
-                    if ((_key.indexOf("message") != -1 && layer_back.attr("l_visible") == "false")) {
-
+                    if (
+                        _key.indexOf("message") != -1 &&
+                        layer_back.attr("l_visible") == "false"
+                    ) {
                         comp_num++;
                         that.kag.layer.forelay(_key);
-
                     } else {
-
                         /*
                         $.trans_old(pm.method, layer_fore, parseInt(pm.time), "hide", function() {
                         });
                         layer_back.css("display", "none");
                         */
 
-                        $.trans(pm.method, layer_back, parseInt(pm.time), "show", function() {
-                            comp_num++;
-                            that.kag.layer.forelay(_key);
+                        $.trans(
+                            pm.method,
+                            layer_back,
+                            parseInt(pm.time),
+                            "show",
+                            function () {
+                                comp_num++;
+                                that.kag.layer.forelay(_key);
 
-                            that.kag.ftag.completeTrans();
+                                that.kag.ftag.completeTrans();
 
-                            that.kag.ftag.hideNextImg();
-
-                        });
-
+                                that.kag.ftag.hideNextImg();
+                            },
+                        );
                     }
-
                 })();
             }
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
-
 
 /*
 #[bg]
@@ -5554,7 +5379,6 @@ puffIn
 
 //背景変更
 tyrano.plugin.kag.tag.bg = {
-
     vital: ["storage"],
 
     pm: {
@@ -5564,11 +5388,9 @@ tyrano.plugin.kag.tag.bg = {
         time: 3000,
         cross: "false",
         position: "",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.ftag.hideNextImg();
 
         var that = this;
@@ -5587,8 +5409,7 @@ tyrano.plugin.kag.tag.bg = {
         }
 
         //jqyeru で一つを削除して、もう一方を復活させる
-        this.kag.preload(storage_url, function() {
-
+        this.kag.preload(storage_url, function () {
             var j_old_bg = that.kag.layer.getLayer("base", "fore");
             var j_new_bg = j_old_bg.clone(false);
 
@@ -5609,46 +5430,50 @@ tyrano.plugin.kag.tag.bg = {
                 that.kag.layer.hideEventLayer();
             }
 
-
             //スキップ中は時間を短くする
             pm.time = that.kag.cutTimeWithSkip(pm.time);
 
-            if (pm.cross == "true") {   //crossがfalseの場合は、古い背景はtransしない。
-                $.trans(pm.method, j_old_bg, parseInt(pm.time), "hide", function() {
-                    j_old_bg.remove();
-                });
+            if (pm.cross == "true") {
+                //crossがfalseの場合は、古い背景はtransしない。
+                $.trans(
+                    pm.method,
+                    j_old_bg,
+                    parseInt(pm.time),
+                    "hide",
+                    function () {
+                        j_old_bg.remove();
+                    },
+                );
             }
 
-            $.trans(pm.method, j_new_bg, parseInt(pm.time), "show", function() {
+            $.trans(
+                pm.method,
+                j_new_bg,
+                parseInt(pm.time),
+                "show",
+                function () {
+                    j_new_bg.css("opacity", 1);
 
-                j_new_bg.css("opacity", 1);
+                    //crossがfalseの場合は、古い背景画像を削除
+                    if (pm.cross == "false") {
+                        j_old_bg.remove();
+                    }
 
-                //crossがfalseの場合は、古い背景画像を削除
-                if (pm.cross == "false") {
-                    j_old_bg.remove();
-                }
-
-                if (pm.wait == "true") {
-                    that.kag.layer.showEventLayer();
-                    that.kag.ftag.nextOrder();
-                }
-
-            });
+                    if (pm.wait == "true") {
+                        that.kag.layer.showEventLayer();
+                        that.kag.ftag.nextOrder();
+                    }
+                },
+            );
 
             //レイヤの中で、画像を取得する
-
         });
 
         if (pm.wait == "false") {
             this.kag.ftag.nextOrder();
         }
-    }
+    },
 };
-
-
-
-
-
 
 /*
 #[bg2]
@@ -5708,7 +5533,6 @@ puffIn
 
 //背景変更
 tyrano.plugin.kag.tag.bg2 = {
-
     vital: ["storage"],
 
     pm: {
@@ -5723,11 +5547,10 @@ tyrano.plugin.kag.tag.bg2 = {
         left: "",
         top: "",
 
-        cross: "false"
+        cross: "false",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.ftag.hideNextImg();
 
         var that = this;
@@ -5745,8 +5568,7 @@ tyrano.plugin.kag.tag.bg2 = {
         }
 
         //jquery で一つを削除して、もう一方を復活させる
-        this.kag.preload(storage_url, function() {
-
+        this.kag.preload(storage_url, function () {
             var j_old_bg = that.kag.layer.getLayer("base", "fore");
             var j_new_bg = j_old_bg.clone(false);
 
@@ -5779,7 +5601,7 @@ tyrano.plugin.kag.tag.bg2 = {
                 width: scWidth,
                 height: scHeight,
                 left: left,
-                top: top
+                top: top,
             });
 
             j_bg_img.attr("src", storage_url);
@@ -5788,7 +5610,6 @@ tyrano.plugin.kag.tag.bg2 = {
 
             j_new_bg.find("img").remove();
             j_new_bg.append(j_bg_img);
-
 
             ////ここまで
             j_new_bg.css("display", "none");
@@ -5805,39 +5626,47 @@ tyrano.plugin.kag.tag.bg2 = {
             //スキップ中は時間を短くする
             pm.time = that.kag.cutTimeWithSkip(pm.time);
 
-            if (pm.cross == "true") {   //crossがfalseの場合は、古い背景はtransしない。
-                $.trans(pm.method, j_old_bg, parseInt(pm.time), "hide", function() {
-                    j_old_bg.remove();
-                });
+            if (pm.cross == "true") {
+                //crossがfalseの場合は、古い背景はtransしない。
+                $.trans(
+                    pm.method,
+                    j_old_bg,
+                    parseInt(pm.time),
+                    "hide",
+                    function () {
+                        j_old_bg.remove();
+                    },
+                );
             }
 
-            $.trans(pm.method, j_new_bg, parseInt(pm.time), "show", function() {
+            $.trans(
+                pm.method,
+                j_new_bg,
+                parseInt(pm.time),
+                "show",
+                function () {
+                    j_new_bg.css("opacity", 1);
 
-                j_new_bg.css("opacity", 1);
+                    //crossがfalseの場合は、古い背景画像を削除
+                    if (pm.cross == "false") {
+                        j_old_bg.remove();
+                    }
 
-                //crossがfalseの場合は、古い背景画像を削除
-                if (pm.cross == "false") {
-                    j_old_bg.remove();
-                }
-
-                if (pm.wait == "true") {
-                    that.kag.layer.showEventLayer();
-                    that.kag.ftag.nextOrder();
-                }
-
-            });
+                    if (pm.wait == "true") {
+                        that.kag.layer.showEventLayer();
+                        that.kag.ftag.nextOrder();
+                    }
+                },
+            );
 
             //レイヤの中で、画像を取得する
-
         });
 
         if (pm.wait == "false") {
             this.kag.ftag.nextOrder();
         }
-    }
+    },
 };
-
-
 
 /*
 #[layermode]
@@ -5869,7 +5698,6 @@ wait=合成の完了を待つか否かを指定できます。trueかfalseを指
 
 //背景変更
 tyrano.plugin.kag.tag.layermode = {
-
     vital: [],
 
     pm: {
@@ -5880,20 +5708,19 @@ tyrano.plugin.kag.tag.layermode = {
         folder: "",
         opacity: "", //opacity=メッセージレイヤの不透明度を 0 ～ 255 の数値で指定しま す(文字の不透明度や、レイヤ自体の不透明度ではありません)。0 で完全 に透明です。,
         time: "500", //時間,
-        wait: "true" //演出の終わりを待つかどうか
-
+        wait: "true", //演出の終わりを待つかどうか
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.ftag.hideNextImg();
 
         var that = this;
 
         var blend_layer = null;
 
-        blend_layer = $("<div class='layer_blend_mode blendlayer' style='display:none;position:absolute;width:100%;height:100%;z-index:99'></div>");
-
+        blend_layer = $(
+            "<div class='layer_blend_mode blendlayer' style='display:none;position:absolute;width:100%;height:100%;z-index:99'></div>",
+        );
 
         if (pm.name != "") {
             blend_layer.addClass("layer_blend_" + pm.name);
@@ -5906,7 +5733,6 @@ tyrano.plugin.kag.tag.layermode = {
         if (pm.opacity != "") {
             blend_layer.css("opacity", $.convertOpacity(pm.opacity));
         }
-
 
         if (pm.folder != "") {
             folder = pm.folder;
@@ -5923,48 +5749,36 @@ tyrano.plugin.kag.tag.layermode = {
 
         blend_layer.css("mix-blend-mode", pm.mode);
 
-
         $("#tyrano_base").append(blend_layer);
 
-
         //j_new_bg.css("background-image","url("+storage_url+")");
-
 
         //background: #0bd url(beach-footprint.jpg) no-repeat;
         //background-blend-mode: screen;
 
         if (pm.graphic != "") {
-
-            this.kag.preload(storage_url, function() {
-
-                blend_layer.stop(true, true).fadeIn(parseInt(pm.time), function() {
-
-                    if (pm.wait == "true") {
-                        that.kag.ftag.nextOrder();
-                    }
-
-                });
+            this.kag.preload(storage_url, function () {
+                blend_layer
+                    .stop(true, true)
+                    .fadeIn(parseInt(pm.time), function () {
+                        if (pm.wait == "true") {
+                            that.kag.ftag.nextOrder();
+                        }
+                    });
             });
-
         } else {
-
-            blend_layer.stop(true, true).fadeIn(parseInt(pm.time), function() {
-
+            blend_layer.stop(true, true).fadeIn(parseInt(pm.time), function () {
                 if (pm.wait == "true") {
                     that.kag.ftag.nextOrder();
                 }
-
             });
-
         }
 
         if (pm.wait == "false") {
             this.kag.ftag.nextOrder();
         }
-
-    }
+    },
 };
-
 
 /*
 #[layermode_movie]
@@ -6008,7 +5822,6 @@ wait=動作効果の再生完了を待つか否かをtrueかfalseで指定でき
 
 //背景変更
 tyrano.plugin.kag.tag.layermode_movie = {
-
     vital: ["video"],
 
     pm: {
@@ -6030,18 +5843,21 @@ tyrano.plugin.kag.tag.layermode_movie = {
         top: "",
         left: "",
 
-        stop: "false" //trueでnextorderを無効化。ロード復帰の時用
+        stop: "false", //trueでnextorderを無効化。ロード復帰の時用
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.ftag.hideNextImg();
 
         var that = this;
 
         var blend_layer = null;
 
-        blend_layer = $("<video class='layer_blend_mode blendlayer blendvideo' data-video-name='" + pm.name + "' data-video-pm='' style='display:none;position:absolute;width:100%;height:100%;z-index:99' ></video>");
+        blend_layer = $(
+            "<video class='layer_blend_mode blendlayer blendvideo' data-video-name='" +
+                pm.name +
+                "' data-video-pm='' style='display:none;position:absolute;width:100%;height:100%;z-index:99' ></video>",
+        );
         var video = blend_layer.get(0);
         var url = "./data/video/" + pm.video;
 
@@ -6091,14 +5907,12 @@ tyrano.plugin.kag.tag.layermode_movie = {
             video.style.top = pm.top + "px";
         }
 
-
         video.style.minHeight = "100%";
         video.style.minWidth = "100%";
         video.style.backgroundSize = "cover";
 
         video.autoplay = true;
         video.autobuffer = true;
-
 
         video.setAttribute("playsinline", "1");
 
@@ -6115,8 +5929,7 @@ tyrano.plugin.kag.tag.layermode_movie = {
         var j_video = $(video);
 
         //ビデオ再生完了時
-        video.addEventListener("ended", function(e) {
-
+        video.addEventListener("ended", function (e) {
             if (pm.loop == "false") {
                 j_video.remove();
             }
@@ -6135,7 +5948,6 @@ tyrano.plugin.kag.tag.layermode_movie = {
 
         blend_layer = j_video;
 
-
         if (pm.name != "") {
             blend_layer.addClass("layer_blend_" + pm.name);
         }
@@ -6146,17 +5958,14 @@ tyrano.plugin.kag.tag.layermode_movie = {
 
         blend_layer.css("mix-blend-mode", pm.mode);
 
-
         $("#tyrano_base").append(blend_layer);
 
-        blend_layer.stop(true, true).fadeIn(parseInt(pm.time), function() {
-
+        blend_layer.stop(true, true).fadeIn(parseInt(pm.time), function () {
             if (pm.wait == "true" && pm.loop == "true") {
                 if (pm.stop != "true") {
                     that.kag.ftag.nextOrder();
                 }
             }
-
         });
 
         if (pm.wait == "false") {
@@ -6164,12 +5973,8 @@ tyrano.plugin.kag.tag.layermode_movie = {
                 this.kag.ftag.nextOrder();
             }
         }
-
-    }
+    },
 };
-
-
-
 
 /*
 #[free_layermode]
@@ -6194,17 +5999,15 @@ wait=フェードアウトの完了を待つか否かをtrueかfalseで指定で
 
 //背景変更
 tyrano.plugin.kag.tag.free_layermode = {
-
     vital: [],
 
     pm: {
         name: "", //レイヤーモードに名前をつけることができます。
         time: "500", //時間,
-        wait: "true" //演出の完了を待つかどうか
+        wait: "true", //演出の完了を待つかどうか
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.ftag.hideNextImg();
 
         var that = this;
@@ -6226,9 +6029,9 @@ tyrano.plugin.kag.tag.free_layermode = {
             return;
         }
 
-        blend_layer.each(function() {
+        blend_layer.each(function () {
             var blend_obj = $(this);
-            blend_obj.stop(true, true).fadeOut(parseInt(pm.time), function() {
+            blend_obj.stop(true, true).fadeOut(parseInt(pm.time), function () {
                 blend_obj.remove();
                 n++;
                 if (pm.wait == "true") {
@@ -6237,13 +6040,10 @@ tyrano.plugin.kag.tag.free_layermode = {
                     }
                 }
             });
-
         });
-
 
         if (pm.wait == "false") {
             this.kag.ftag.nextOrder();
         }
-
-    }
+    },
 };

--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -4304,7 +4304,8 @@ hint=マウスカーソルを静止させたときに表示されるツールチ
 clickse=ボタンをクリックした時に再生される効果音を設定できます。効果音ファイルはsoundフォルダに配置してください,
 enterse=ボタンの上にマウスカーソルが乗った時に再生する効果音を設定できます。効果音ファイルはsoundフォルダに配置してください,
 leavese=ボタンの上からマウスカーソルが外れた時に再生する効果音を設定できます。効果音ファイルはsoundフォルダに配置してください。,
-clickimg=ボタンをクリックした時に切り替える画像ファイルを指定できます。ファイルはimageフォルダに配置してください,
+activeimg=ボタンの上でマウスボタンを押している間に切り替える画像ファイルを指定できます。ファイルはimageフォルダに配置してください。,
+clickimg=ボタンをクリックしたあとに切り替える画像ファイルを指定できます。ファイルはimageフォルダに配置してください。,
 enterimg=ボタンの上にマウスカーソルが乗った時に切り替える画像ファイルを指定できます。ファイルはimageフォルダに配置してください。,
 visible=初期状態で表示か非表示を選択できます。trueで表示falseで非表示の初期状態となります,
 auto_next=true or false を指定します。falseを指定すると、fixの場合、[return]で戻った時に次のタグへ進ませません。,
@@ -4338,6 +4339,7 @@ tyrano.plugin.kag.tag.button = {
         clickse: "",
         enterse: "",
         leavese: "",
+        activeimg: "",
         clickimg: "",
         enterimg: "",
 
@@ -4449,63 +4451,66 @@ tyrano.plugin.kag.tag.button = {
             var preexp = that.kag.embScript(pm.preexp);
             var button_clicked = false;
 
+            var parse_img_url = function (src) {
+                if ($.isHTTP(src)) {
+                    return src;
+                } else {
+                    return "./data/" + _pm.folder + "/" + src;
+                }
+            };
+
             j_button.hover(
+                //マウスが乗った時
                 function () {
-                    //マウスが乗った時
+                    //音を鳴らす
                     if (_pm.enterse != "") {
                         that.kag.ftag.startTag("playse", {
                             storage: _pm.enterse,
                             stop: true,
                         });
                     }
-
+                    //画像を変更する
                     if (_pm.enterimg != "") {
-                        var enter_img_url = "";
-                        if ($.isHTTP(_pm.enterimg)) {
-                            enter_img_url = _pm.enterimg;
-                        } else {
-                            enter_img_url =
-                                "./data/" + _pm.folder + "/" + _pm.enterimg;
-                        }
-
+                        var enter_img_url = parse_img_url(_pm.enterimg);
                         $(this).attr("src", enter_img_url);
                     }
                 },
+                //マウスが外れた時
                 function () {
-                    //マウスが外れた時
+                    //音を鳴らす
                     if (_pm.leavese != "") {
                         that.kag.ftag.startTag("playse", {
                             storage: _pm.leavese,
                             stop: true,
                         });
                     }
-
-                    //元に戻す
+                    //画像を元に戻す
                     if (_pm.enterimg != "") {
-                        var enter_img_url = "";
-                        if ($.isHTTP(_pm.graphic)) {
-                            enter_img_url = _pm.graphic;
-                        } else {
-                            enter_img_url =
-                                "./data/" + _pm.folder + "/" + _pm.graphic;
-                        }
-
-                        $(this).attr("src", enter_img_url);
+                        var initial_img_url = parse_img_url(_pm.graphic);
+                        $(this).attr("src", initial_img_url);
                     }
                 },
             );
 
+            //マウスを押したとき
+            j_button.on("mousedown touchstart", function (event) {
+                if (_pm.activeimg != "") {
+                    var active_img_url = parse_img_url(_pm.activeimg);
+                    j_button.attr("src", active_img_url);
+                }
+            });
+
+            //クリックが確定したとき
             j_button.click(function (event) {
                 if (_pm.clickimg != "") {
-                    var click_img_url = "";
-                    if ($.isHTTP(_pm.clickimg)) {
-                        click_img_url = _pm.clickimg;
-                    } else {
-                        click_img_url =
-                            "./data/" + _pm.folder + "/" + _pm.clickimg;
-                    }
-
+                    //クリック画像が設定されているなら画像を変える
+                    var click_img_url = parse_img_url(_pm.clickimg);
                     j_button.attr("src", click_img_url);
+                } else if (_pm.activeimg != "") {
+                    //クリック画像は設定されていないが、アクティブ画像が設定されている場合
+                    //いままさにアクティブ画像になっているはずなので、もとに戻す
+                    var initial_img_url = parse_img_url(_pm.graphic);
+                    $(this).attr("src", initial_img_url);
                 }
 
                 //fix指定のボタンは、繰り返し実行できるようにする

--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -1395,18 +1395,20 @@ tyrano.plugin.kag.tag.label = {
 
 :group
 システム操作
+
 :title
 既読管理の設定
 
 :exp
-既読管理に関する設定を変更できます
+既読管理の設定を変更できます。
 
 :sample
-:param
-color=既読時のテキスト色を0x000000形式で指定してください,
-skip=未読スキップをの有効(true)、無効(false)を指定します。つまりfalseを指定すると、未読文章で止まります。
-#[end]
 
+:param
+color=既読テキスト色を`0xRRGGBB`形式で指定します。,
+skip=プレイヤーが未読テキストをスキップできるかどうか。`true`または`false`で指定します。`false`を指定すると、プレイヤーが未読テキストに到達したときにスキップが解除されます。
+
+#[end]
 */
 
 tyrano.plugin.kag.tag.config_record_label = {
@@ -1446,22 +1448,23 @@ tyrano.plugin.kag.tag.config_record_label = {
 
 :group
 メッセージ関連
+
 :title
 クリック待ち
 
 :exp
-このタグの位置でクリック待ちを行います。
+このタグの位置でプレイヤーのクリックを待ちます。
 
 :sample
 テキスト表示[l]
 テキスト表示[l][r]
+
 :param
 
 :demo
 1,kaisetsu/01_text
 
 #[end]
-
 */
 
 //[l] クリック待ち
@@ -1508,23 +1511,24 @@ tyrano.plugin.kag.tag.l = {
 
 :group
 メッセージ関連
+
 :title
-改ページクリック待ち
+クリック待ち＋改ページ
 
 :exp
-改ページをともなうクリック待ちで使用できます
+プレイヤーのクリックを待ちます。
+プレイヤーがクリックすると改ページされます。
 
 :sample
 テキスト表示[p]
 テキスト表示[p][r]
+
 :param
 
 :demo
 1,kaisetsu/01_text
 
-
 #[end]
-
 */
 
 //[p] 改ページクリック待ち
@@ -1567,33 +1571,36 @@ tyrano.plugin.kag.tag.p = {
 };
 
 /*
- #[graph]
- :group
- メッセージ関連
- :title
- インライン画像表示
- :exp
- 任意の画像をメッセージ中に表示します。
- 絵文字や特殊文字などに活用できます。
- 表示させる画像はimageフォルダに配置して下さい
+#[graph]
 
- また、よく使う記号については、マクロを組んでおくと楽です。
+:group
+メッセージ関連
 
- :sample
- ; heart にはハートマークの画像
- [macro name="heart"][graph storage="heart.png"][endmacro]
+:title
+インライン画像表示
 
- ; 以後、[heart] タグでハートマークを使用可能
- 大好き[heart]
- :param
- storage=表示する画像ファイル名を指定します
+:exp
+任意の画像をメッセージ中に表示します。絵文字や特殊文字などに活用できます。
+表示する画像はdata/imageフォルダに配置して下さい。
+よく使う記号についてはマクロを組んでおくと楽です。
 
- :demo
- 1,kaisetsu/02_decotext
+:sample
+;heart.png はハートマークの画像
+[macro name="heart"]
+[graph storage="heart.png"]
+[endmacro]
 
- #[end]
+;以後、[heart] タグでハートマークを使用可能
+大好き[heart][p]
 
- */
+:param
+storage=表示する画像ファイル名を指定します。
+
+:demo
+1,kaisetsu/02_decotext
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.graph = {
     vital: ["storage"],
@@ -1631,28 +1638,30 @@ tyrano.plugin.kag.tag.graph = {
 };
 
 /*
-
 #[jump]
+
 :group
 ラベル・ジャンプ操作
+
 :title
 シナリオのジャンプ
-:exp
-指定されたファイルの指定されたラベルに移動します
-callとの違いは、jumpはコールスタックに残りません。つまり、一方通行です。ラベルの指定は必須です。
-:sample
 
-; second.ks というシナリオファイルの　*start　ラベルへ移動する
+:exp
+指定シナリオファイルの指定ラベルに移動します。
+
+`[call]`タグとは異なり、`[jump]`タグの移動はコールスタックに残りません。つまり一方通行であり、`[return]`で戻ってくることはできません。
+
+:sample
+;second.ks というシナリオファイルの *start ラベルへ移動する
 [jump storage=second.ks target=*start]
 
 :param
-storage=移動するシナリオファイル名を指定します。省略された場合は現在のシナリオファイルと見なされます,
-target=ジャンプ先のラベル名を指定します。省略すると先頭から実行されます
+storage=ジャンプ先のシナリオファイル名を指定します。省略すると、現在のシナリオファイルとみなされます。,
+target=ジャンプ先のラベル名を指定します。省略すると、シナリオファイルの先頭にジャンプします。
 
 :demo
 
 #[end]
-
 */
 
 //ジャンプ命令
@@ -1674,21 +1683,25 @@ tyrano.plugin.kag.tag.jump = {
 
 /*
 #[r]
+
 :group
 メッセージ関連
+
 :title
-改行する
+改行
+
 :exp
-改行します
+改行します。
+
 :sample
 テキスト表示[l]
 改行します[l][r]
 改行します[l][r]
+
 :param
 
 :demo
  1,kaisetsu/01_text
-
 
 #[end]
 */
@@ -1713,25 +1726,30 @@ tyrano.plugin.kag.tag.r = {
 };
 
 /*
- #[er]
- :group
- メッセージ関連
- :title
- メッセージレイヤの文字の消去
- :exp
- 現在の操作対象メッセージレイヤ(current指定)の文字を消去します。
- :sample
- テキスト表示[l]
- メッセージをクリアします[l][er]
- 改行します[l][r]
- :param
+#[er]
 
- :demo
- 1,kaisetsu/01_text
+:group
+メッセージ関連
 
+:title
+メッセージレイヤの文字の消去
 
- #[end]
- */
+:exp
+現在の操作対象のメッセージレイヤの文字を消去します。
+
+操作対象のメッセージレイヤを切り替えるには`[current]`タグを使います。
+
+:sample
+クリックするとメッセージがクリアされます[l][er]
+クリアされました[l]
+
+:param
+
+:demo
+1,kaisetsu/01_text
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.er = {
     start: function () {
@@ -1748,25 +1766,29 @@ tyrano.plugin.kag.tag.er = {
 
 /*
 #[cm]
+
 :group
 メッセージ関連
+
 :title
-すべてのメッセージレイヤをクリア
+すべてのメッセージレイヤのクリア
+
 :exp
-すべてのメッセージレイヤをクリアします。
-また、フォントスタイルなどもデフォルトの設定に戻ります。
-ただし、positionやlayoptで指定した値は引き継がれます
-[ct]タグのように 操作対象のメッセージレイヤが表ページの message0 に指定されるようなことはありません。 このタグを実行後も操作対象のレイヤは同じです。
+すべてのメッセージレイヤの文字を消去します。`[button]`タグ、`[glink]`タグ、`[html]`タグなどで表示した要素も消去されます。
+
+フォントスタイルがデフォルトの設定に戻ります。
+
+`[ct]`タグとは異なり、操作対象のメッセージレイヤが`message0`に変更されるようなことはありません。このタグを実行したあとも操作対象のメッセージレイヤは同じままです。
 
 :sample
 テキスト表示[l]
 画面クリアする[l][cm]
 もう一度画面クリアする[l][cm]
+
 :param
 
 :demo
 1,kaisetsu/01_text
-
 
 #[end]
 */
@@ -1794,29 +1816,31 @@ tyrano.plugin.kag.tag.cm = {
 };
 
 /*
- #[ct]
- :group
- メッセージ関連
- :title
- すべてのメッセージレイヤをリセット
- :exp
+#[ct]
 
- メッセージレイヤをリセットします。
- すべてのメッセージレイヤの文字は消去され、操作対象のメッセージレイヤは 表ページの message0 に指定されます。
- font タグで指定した文字の属性、style タグ で指定したスタイルはすべて標準状態に戻ります。ただ し、position タグ や layopt タグで指定した属性は引き継が れます。
+:group
+メッセージ関連
 
- :sample
- テキスト表示[l]
- 画面クリアする[l][ct]
- もう一度画面クリアする[l][ct]
- :param
+:title
+メッセージレイヤにのリセット
 
- :demo
- 1,kaisetsu/01_text
+:exp
+すべてのメッセージレイヤの文字が消去されます。
 
+フォントスタイルがデフォルトの設定に戻り、操作対象のメッセージレイヤが`message0`の表ページに変更されます。
 
- #[end]
- */
+:sample
+テキスト表示[l]
+画面リセットする[l][ct]
+もう一度画面リセットする[l][ct]
+
+:param
+
+:demo
+1,kaisetsu/01_text
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.ct = {
     start: function () {
@@ -1838,25 +1862,30 @@ tyrano.plugin.kag.tag.ct = {
 
 /*
 #[current]
+
 :group
 メッセージ関連
+
 :title
 操作対象のメッセージレイヤの指定
+
 :exp
-操作対象とするメッセージレイヤを指定します。以後、文章や font タグでの文字属性の指定、l タグ等のクリック待ちなどは、このレイヤに対して行われます。
-message0はデフォルトで可視の状態で すが、message1 は layopt タグ 等で visible=true としないと表示されないので注意してください。
+操作対象とするメッセージレイヤを指定します。以後、文章や`[font]`タグでの文字属性の指定、`[l]`タグ等のクリック待ちなどは、このレイヤに対して行われます。
+
+`message0`はデフォルトで可視の状態ですが、`message1`は`[layopt]`タグを使用しないと表示されないので注意してください。
+
 :sample
 [current layer="message0"]
 message0レイヤに表示されています[l]
 [current layer="message1"]
 message1レイヤに表示されています[l]
+
 :param
-layer=操作対象のメッセージレイヤを指定します。指定がない場合、現在のメッセージレイヤとみなされます,
-page=表画面を対象とするか、裏画面を対象とするかを指定します。省略すると表ページとみなされます
+layer=操作対象のメッセージレイヤを指定します。省略すると、現在のメッセージレイヤとみなされます。,
+page=表ページを対象とするか、裏ページを対象とするかを指定します。省略すると、表ページとみなされます。
 
 :demo
 1,kaisetsu/18_window_2
-
 
 #[end]
 */
@@ -1884,43 +1913,50 @@ tyrano.plugin.kag.tag.current = {
 //メッセージレイヤの属性を変更します
 
 /*
- #[position]
- :group
- レイヤ関連
- :title
- メッセージレイヤの属性変更
- :exp
- メッセージレイヤに対する様々な属性を指定します。<br />
- いずれの属性も、省略すれば設定は変更されません。
- :sample
- ;メッセージレイヤの位置とサイズを変更
- [position width=400 height=300 top=100 left=20]
- ;メッセージレイヤの色と透明度を変更
- [position color=blue opacity=100]
- :param
- layer=対象とするメッセージレイヤを指定します。<br/>省略するとcurrentタグで指定されたレイヤが選択されます,
- page=対象とするページを指定します。"fore"か"back"を指定して下さい。<br>この属性を省略するとcurrentタグで指定された、現在のページが選択されます。,
- left=メッセージレイヤの左端位置を指定します。（ピクセル）,
- top=メッセージレイヤの上端位置を指定します。（ピクセル）,
- width=メッセージレイヤの幅を指定します。（ピクセル）,
- height=メッセージレイヤの高さを指定します。（ピクセル）,
- frame=メッセージレイヤのフレーム画像として表示させる画像を指定します。<br>メッセージエリアをカスタマイズしたい場合に利用できます。<br />画像サイズはwidthとheight属性に準じて調整して下さい。<br />さらに、margin属性で実際にメッセージが表示される箇所の調整も行いましょう<br />また、"none"と指定することで標準枠に戻すこともできます。違う枠画像をしていすると切り替えることもできます,
- color=メッセージレイヤの表示色を 0xRRGGBB 形式で指定します。 ,
- border_color=外枠の線が有効な場合の色を 0xRRGGBB 形式で指定します。border_sizeの指定が同時に必要です,
- border_size=外枠の線が有効な場合の太さを指定します。0を指定すると外枠は表示されません。デフォルトは0です。,
- opacity=メッセージレイヤの不透明度を 0 ～ 255 の数値で指定しま す(文字の不透明度や、レイヤ自体の不透明度ではありません)。0 で完全に透明です。,
- marginl=メッセージレイヤの左余白を指定します。,
- margint=メッセージレイヤの上余白を指定します。,
- marginr=メッセージレイヤの右余白を指定します。,
- marginb=メッセージレイヤの下余白を指定します。,
- radius=角の丸みを設定できます。数字で指定します。参考として 10（控えめな角丸）30（普通の角丸）100（巨大な角丸）くらいになります,
- vertical=メッセージレイヤを縦書きにモードにするには "true" を指定します。 横書きにするには "false" を指定してください。,
- visible=true に設定すると、メッセージレイヤが可視(表示状態)になります。<br >false に設定すると、メッセージレイヤは不可視(非表示状態)になります。
+#[position]
+
+:group
+レイヤ関連
+
+:title
+メッセージレイヤの属性変更
+
+:exp
+メッセージレイヤに対する様々な属性を指定します。
+いずれの属性も、省略すれば設定は変更されません。
+
+:sample
+;メッセージレイヤの位置とサイズを変更
+[position width=400 height=300 top=100 left=20]
+;メッセージレイヤの色と透明度を変更
+[position color=blue opacity=100]
+
+:param
+layer=対象とするメッセージレイヤを指定します。
+page=対象とするページを指定します。"fore"か"back"を指定して下さい。,
+left=メッセージレイヤの左端位置を指定します。（ピクセル）,
+top=メッセージレイヤの上端位置を指定します。（ピクセル）,
+width=メッセージレイヤの幅を指定します。（ピクセル）,
+height=メッセージレイヤの高さを指定します。（ピクセル）,
+frame=メッセージレイヤのフレーム画像として表示させる画像を指定します。<br>メッセージエリアをカスタマイズしたい場合に利用できます。<br />画像サイズはwidthとheight属性に準じて調整して下さい。<br />さらに、margin属性で実際にメッセージが表示される箇所の調整も行いましょう<br />また、"none"と指定することで標準枠に戻すこともできます。違う枠画像をしていすると切り替えることもできます,
+color=メッセージレイヤの表示色を`0xRRGGBB`形式で指定します。 ,
+border_color=外枠の線が有効な場合の色を`0xRRGGBB`形式で指定します。`border_size`属性の指定が同時に必要です,
+border_size=外枠の線が有効な場合の太さを指定します。0を指定すると外枠は表示されません。デフォルトは0です。,
+opacity=メッセージレイヤの不透明度を 0 ～ 255 の数値で指定しま す(文字の不透明度や、レイヤ自体の不透明度ではありません)。0 で完全に透明です。,
+marginl=メッセージレイヤの左余白を指定します。,
+margint=メッセージレイヤの上余白を指定します。,
+marginr=メッセージレイヤの右余白を指定します。,
+marginb=メッセージレイヤの下余白を指定します。,
+radius=角の丸みを設定できます。数字で指定します。参考として 10（控えめな角丸）30（普通の角丸）100（巨大な角丸）くらいになります,
+vertical=メッセージレイヤを縦書きにモードにするには "true" を指定します。 横書きにするには "false" を指定します。,
+visible=true に設定すると、メッセージレイヤが可視(表示状態)になります。<br >false に設定すると、メッセージレイヤは不可視(非表示状態)になります。
+
 :demo
 1,kaisetsu/17_window_1
 
- #[end]
- */
+#[end]
+*/
+
 tyrano.plugin.kag.tag.position = {
     pm: {
         layer: "message0",
@@ -2076,16 +2112,22 @@ tyrano.plugin.kag.tag.position = {
 };
 
 /*
- #[fuki_start]
- :group
- メッセージ関連
- :title
- メッセージレイヤをふきだし化する
- :exp
- メッセージレイヤを漫画のふきだし風に表現できます。<br />
- このタグでふきだし表示を有効にする前に[fuki_chara]タグで個別に設定が必要です。
- ふきだしのデザインは[position]タグの設定が引き継がれますが、[fuki_chara]タグでデザインを個別に設定することも可能です。
- :sample
+#[fuki_start]
+
+:group
+メッセージ関連
+
+:title
+メッセージレイヤをふきだし化する
+
+:exp
+メッセージレイヤを漫画のふきだし風に表現できます。
+
+このタグでふきだし表示を有効にする前に`[fuki_chara]`タグで設定が必要です。
+
+ふきだしのデザインは`[position]`タグの設定が引き継がれますが、`[fuki_chara]`タグで個別に設定することも可能です。
+
+:sample
 
 ;通常のメッセージレイヤに対して、ふきだしに適応したいデザインを設定する
 [font color="black"]
@@ -2110,12 +2152,12 @@ tyrano.plugin.kag.tag.position = {
 #
 othersで設定した位置にふきだしを表示[p]
 
+:param
+layer=対象とするメッセージレイヤを指定します。デフォルトはmessage0
 
- :param
- layer=対象とするメッセージレイヤを指定します。デフォルトはmessage0
+#[end]
+*/
 
- #[end]
- */
 tyrano.plugin.kag.tag.fuki_start = {
     pm: {
         layer: "message0",
@@ -2143,19 +2185,25 @@ tyrano.plugin.kag.tag.fuki_start = {
 };
 
 /*
- #[fuki_stop]
- :group
- メッセージ関連
- :title
- メッセージレイヤのふきだし化を無効にする
- :exp
- ふきだし表示を停止します。
- メッセージレイヤのスタイルは[fuki_start]前の状態に戻ります。
- :sample
- :param
+#[fuki_stop]
 
- #[end]
- */
+:group
+メッセージ関連
+
+:title
+メッセージレイヤのふきだし化を無効にする
+
+:exp
+ふきだし表示を停止します。
+メッセージレイヤのスタイルは[fuki_start]前の状態に戻ります。
+
+:sample
+
+:param
+
+#[end]
+*/
+
 tyrano.plugin.kag.tag.fuki_stop = {
     pm: {},
 
@@ -2190,15 +2238,20 @@ tyrano.plugin.kag.tag.fuki_stop = {
 };
 
 /*
- #[fuki_chara ]
- :group
- メッセージ関連
- :title
- ふきだしのキャラクター登録
- :exp
- ふきだしを有効にしたとき、表示形式をキャラクター毎に設定できます。
- nameに「others」指定すると画面上にキャラクターが登場していない場合のスタイルを設定することができます。
- :sample
+#[fuki_chara]
+
+:group
+メッセージ関連
+
+:title
+ふきだしのキャラクター登録
+
+:exp
+ふきだしのデザインをキャラクターごとに設定できます。
+
+`name`属性に`others`を指定すると、画面上にキャラクターがいない場合のデザインを設定できます。
+
+:sample
 
 ;ふきだしの表示位置をキャラごとに設定する
 [fuki_chara name="akane" left=200 top=270 sippo_left=30 sippo_top=30 sippo="top" max_width=300 radius=15]
@@ -2207,28 +2260,27 @@ tyrano.plugin.kag.tag.fuki_stop = {
 ;キャラクターが画面上に存在しない場合に適応するふきだし設定 name=others
 [fuki_chara name="others" left=250 top=500 max_width=700 fix_width=700 radius=0 ]
 
- :param
- name=キャラクター名を指定。othersを指定するとキャラクターが見つからなかったときの位置を指定できる,
- left=ふきだし機能が有効な場合、どの位置にふきだしを表示するか指定します。画像ファイルの左端からの相対位置となります。,
- top=ふきだし機能が有効な場合、どの位置にふきだしを表示するか指定します。画像ファイルの上端からの相対位置となります。,
- sippo=しっぽをどの場所に表示するかを指定するtop（上） bottom（下） left（左） right（右） ,
- sippo_left=ふきだし機能が有効な場合かつ、ふきだしの位置がtopかbottomの場合、しっぽを表示する左端からの位置を指定できます。デフォルトは40,
- sippo_top=ふきだし機能が有効な場合かつ、ふきだしの位置がleftかrightの場合、しっぽを表示する上端からの位置を指定できます。デフォルトは40,
- sippo_width=しっぽの幅を指定できます。デフォルトは12,
- sippo_top=しっぽの高さを指定できます。デフォルトは20,
- max_width=ふきだしのサイズは自動的に調整されますが、横幅の上限サイズを指定することができます。デフォルトは300,
- fix_width=デフォルトのふきだし横幅は自動的に調整されますが、fix_widthパラメータを指定することで固定の幅を確保することができます。この値が指定されている場合はふきだしサイズの自動調整は行われません。,
- color=メッセージレイヤの表示色を 0xRRGGBB 形式で指定します。 ,
- border_color=外枠の線が有効な場合の色を 0xRRGGBB 形式で指定します。border_sizeの指定が同時に必要です,
- border_size=外枠の線が有効な場合の太さを指定します。0を指定すると外枠は表示されません。デフォルトは0です。,
- opacity=メッセージレイヤの不透明度を 0 ～ 255 の数値で指定しま す(文字の不透明度や、レイヤ自体の不透明度ではありません)。0 で完全に透明です。,
- radius=角の丸みを設定できます。数字で指定します。参考として 10（控えめな角丸）30（普通の角丸）100（巨大な角丸）くらいになります,
- font_color=フォントの色を指定できます。0xRRGGBB 形式で指定してください。 ,
- font_size=フォントサイズを指定できます。
+:param
+name         = キャラクター名を指定します。キャラクターがいないときデザインを設定するにはothersを指定します。,
+left         = どの位置にふきだしを表示するかを指定します。（キャラクター画像左端からの相対位置）,
+top          = どの位置にふきだしを表示するかを指定します。（キャラクター画像上端からの相対位置）,
+sippo        = しっぽをどの方向に表示するかを指定します。top（上）/ bottom（下）/ left（左）/ right（右）,
+sippo_left   = ふきだしの位置がtopかbottomの場合、しっぽを表示する左端からの位置を指定できます。デフォルトは40。,
+sippo_top    = ふきだしの位置がleftかrightの場合、しっぽを表示する上端からの位置を指定できます。デフォルトは40。,
+sippo_width  = しっぽの幅を指定できます。デフォルトは12。,
+sippo_top    = しっぽの高さを指定できます。デフォルトは20。,
+max_width    = ふきだしのサイズは自動的に調整されますが、横幅の上限サイズを指定できます。デフォルトは300。,
+fix_width    = ふきだし横幅は自動的に調整されますが、これを指定することで横幅を固定にできます。これが指定されている場合、ふきだしサイズの自動調整は行われません。,
+color        = メッセージレイヤの表示色を`0xRRGGBB`形式で指定します。 ,
+border_color = 外枠の線が有効な場合の色を`0xRRGGBB`形式で指定します。border_sizeの指定が同時に必要です。,
+border_size  = 外枠の線が有効な場合の太さを指定します。0を指定すると外枠は表示されません。デフォルトは0。,
+opacity      = ふきだしの不透明度を0～255の数値で指定します。0で完全に透明。（文字の不透明度や、レイヤ自体の不透明度ではありません）,
+radius       = ふきだしの角の丸みを数値で指定します。例：10（控えめな角丸）/ 30（普通の角丸）/ 100（巨大な角丸）,
+font_color   = フォントの色を0xRRGGBB形式で指定します。,
+font_size    = フォントサイズを指定します。
 
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.fuki_chara = {
     vital: ["name"],
@@ -2304,42 +2356,50 @@ tyrano.plugin.kag.tag.fuki_chara = {
 
 /*
 #[image]
+
 :group
 レイヤ関連
+
 :title
 画像を表示
+
 :exp
-レイヤに画像を表示します。キャラクター表示や背景切り替えなどに使用できます。前景レイヤは初期状態では非表示なのでvisible=trueとすることで表示されます
+指定したレイヤに画像を追加します。キャラクター表示や背景切り替えなどに使用できます。
+
+初期状態ではレイヤ自体が非表示になっているため、そのままでは`[image]`タグで画像を追加しても画面に表示されません。その場合、`[layopt]`タグでレイヤ自体を表示状態にする必要があります。
+
 :sample
-;画像ファイルを表示
-[layopt layer=1 visible=true]
-[image layer="1" x="150" y="150" storage="myimage.png"]
+;レイヤ1を表示状態に
+[layopt layer="1" visible="true"]
+;レイヤ1にcat.pngを追加
+[image layer="1" x="150" y="150" storage="cat.png"]
+[l]
 
 ;画像を削除
 [freeimage layer="1"]
 
 :param
-storage=画像ファイル名を指定します。ファイルは背景レイヤならプロジェクトフォルダのbgimage、前景レイヤならfgimageに入れてください,
-layer=対象とするメレイヤを指定します。<br/>"base"を指定すると背景レイヤ。0以上の整数を指定すると対応する前景レイヤに画像を表示します,
-page=対象とするページを指定します。"fore"か"back"を指定して下さい。<br>この属性を省略すると"fore"であるとみなされます,
-visible=true or false を指定。imageは通常、非表示で始まるが、trueを指定すると最初から表示状態にできる。,
+storage=画像ファイル名を指定します。ファイルは背景レイヤならプロジェクトフォルダのbgimage、前景レイヤならfgimageに入れてください。,
+layer=画像を追加するレイヤを指定します。<br>`base`を指定すると背景レイヤ。0以上の整数を指定すると対応する前景レイヤに画像を表示します。,
+page=対象とするページを`fore`か`back`で指定します。デフォルトは`fore`。,
+visible=`true`または`false`を指定します。`true`を指定すると、画像を追加したレイヤ自体を表示状態にできます。つまり、`[layopt visible="true"]`を省略できます。,
 left=画像の左端位置を指定します。（ピクセル）,
 top=画像の上端位置を指定します。（ピクセル）,
-x=画像の左端位置を指定します。leftと同様。こちらが優先度高（ピクセル）,
-y=画像の上端位置を指定します。topと同様。こちらが優先度高（ピクセル）,
+x=画像の左端位置を指定します。leftと同様。こちらが優先度高。（ピクセル）,
+y=画像の上端位置を指定します。topと同様。こちらが優先度高。（ピクセル）,
 width=画像の横幅を指定します。（ピクセル）,
-height=画像の高さ位置を指定します。（ピクセル）,
-folder=好きな画像フォルダから、画像を選択できます。通常前景レイヤはfgimage　背景レイヤはbgimageと決まっていますが、ここで記述したフォルダ以下の画像ファイルを使用することができるようになります。,
-name=ティラノスクリプトのみ。animタグなどからこの名前でアニメーションさせることができます。でまた名前を指定しておくとクラス属性としてJSから操作できます。カンマで区切ることで複数指定することもできます,
-time=ミリ秒を指定することで、徐々にイメージを表示させることができます。,
-wait=falseを指定すると、画像が表示されるのを待たずに、処理を進め明日。デフォルトはtrue,
-zindex=画像同士の重なりを指定できます。数値が大きい方が前に表示されます,
-depth="zindexが同一な場合の重なりを指定できます。front（最前面）/back（最後面）で指定します。デフォルトはfront",
-reflect="trueを指定すると左右反転します",
-pos=レイヤ位置を自動的に決定します。前景レイヤに対して使います。横方向の位置は、この属性で指定した left ( 左端 ) 、left_center ( 左より )、center ( 中央 )、 right_center ( 右より )、right ( 右端 ) の位置に表示されます。各横方向の座標の中心 位置は Config.tjs で指定することができます。
+height=画像の高さを指定します。（ピクセル）,
+folder=画像が入っているフォルダを指定できます。デフォルトでは前景レイヤ用の画像は`fgimage`フォルダ、背景レイヤ用の画像は`bgimage`フォルダと決まっていますが、これを変更できます。,
+name=`[anim]`タグなどからこの名前でアニメーションさせられます。カンマで区切ることで複数指定できます。（高度な知識：`name`属性で指定した値はHTMLのクラス属性になります）,
+time=数値をミリ秒で指定できます。これを指定すると、その時間をかけて画像をフェードインさせられます。,
+wait=`time`属性を指定したとき、次のタグに進む前にフェードインの完了を待つかどうか。`true`または`false`で指定します。`false`を指定すると、画像が表示されきるのを待たずに次のタグに進みます。デフォルトは`true`,
+zindex=画像同士の重なりを指定できます。数値が大きい方が前に表示されます。,
+depth=zindexが同一な場合の重なりを指定できます。`front`(最前面)または`back`(最後面)で指定します。デフォルトはfront。,
+reflect=`true`を指定すると左右反転します。,
+pos=レイヤ位置を自動的に決定します。前景レイヤに対して使います。横方向の位置は、この属性で指定した`left`(左端)、`left_center`(左寄り)、`center`(中央)、`right_center`(右寄り)、`right`(右端)の位置に表示されます。各横方向の座標の中心位置は`Config.tjs`で指定できます。
 <br>left 、left_center、 center、 right_center、 right の代わりに、それぞれ l、 lc、 c、 rc、 r を 指定することもできます ( 動作は同じです )。
 <br>この属性を指定した場合は left 属性や top 属性は無視されます。
-<br>layerをbase と指定した場合にはこの属性は指定しないでください。各々の表示位置はConfig.tjsで事前に設定しておきましょう
+<br>layerをbase と指定した場合にはこの属性は指定しないでください。各々の表示位置はConfig.tjsで事前に設定しておきましょう。
 
 :demo
 1,kaisetsu/05_image
@@ -2547,31 +2607,34 @@ tyrano.plugin.kag.tag.image = {
 
 /*
 #[freeimage]
+
 :group
 レイヤ関連
+
 :title
-レイヤの解放
+レイヤのクリア
+
 :exp
+指定したレイヤに存在する画像などをすべて削除します。
 
-レイヤに追加された要素をすべて削除します　レイヤ指定は必須です。
 :sample
-;イメージの表示
-[image layer=0 page=fore visible=true top=100 left=300  storage=chara.png]
+;イメージを配置
+[image layer="0" page="fore" visible="true" top="100" left="300"  storage="chara.png"]
 
-;イメージをレイヤごと非表示にする
-[freeimage layer=0 ]
+;レイヤをクリア
+[freeimage layer="0"]
 
-;名前を指定して配置
-[image name="myimg" layer=0 visible=true top=100 left=300  storage=myimg.png]
+;名前を指定してイメージを配置
+[image name="myimg" layer="0" visible="true" top="100" left="300"  storage="myimg.png"]
 
 ;イメージの名前を指定して１つだけ消す
-[free name="myimg" layer=0 ]
+[free name="myimg" layer="0"]
 
 :param
-layer=操作対象のレイヤを指定します。指定がない場合、現在のメッセージレイヤとみなされます,
-page=表画面を対象とするか、裏画面を対象とするかを指定します。省略すると表ページとみなされます,
-time=ミリ秒を指定した場合、指定時間をかけてイメージが消えていきます,
-wait=完了を待つかどうかを指定できます。trueを指定すると完了を待ちます。デフォルトはtrue
+layer=操作対象のレイヤを指定します。省略すると、現在のメッセージレイヤとみなされます。,
+page=レイヤの裏表どちらのページを対象とするか。`fore`または`back`で指定します。省略すると、表ページとみなされます。,
+time=フェードアウト時間をミリ秒単位で指定します。省略すると、一瞬で消去されます。
+wait=フェードアウトの完了を待つかどうか。`true`または`false`で指定します。デフォルトは`true`。
 
 :demo
 1,kaisetsu/05_image
@@ -2650,12 +2713,16 @@ tyrano.plugin.kag.tag.freelayer = tyrano.plugin.kag.tag.freeimage;
 
 /*
 #[free]
+
 :group
 レイヤ関連
+
 :title
 オブジェクトの解放
+
 :exp
 レイヤに追加されたnameで指定された要素をすべて削除します　name指定は必須です。
+
 :sample
 [backlay]
 ;キャラクター表示
@@ -2751,15 +2818,19 @@ tyrano.plugin.kag.tag.free = {
 
 /*
 #[ptext]
+
 :group
 レイヤ関連
+
 :title
 レイヤにテキストを追加
+
 :exp
 レイヤにテキストを表示します。前景レイヤに対してのみ実行します<br />
 前景レイヤの属性を全て継承します。文字を消す時はfreeimageタグをレイヤに対して適応します
 また、前景レイヤはデフォルト非表示なので、トランジションで表示しない場合はレイヤを可視状態にしてから、追加します。
 [layopt layer=0 visible=true]が必要
+
 :sample
 [backlay]
 [ptext page=back text="テキストテキスト" size=30 x=200 y=300 color=red vertical=true]
@@ -2768,17 +2839,18 @@ tyrano.plugin.kag.tag.free = {
 [l]
 表示したテキストを消去します
 [freeimage layer = 0]
+
 :param
 layer=対象とするメレイヤを指定します。0以上の整数を指定すると対応する前景レイヤに画像を表示します,
 page=対象とするページを指定します。"fore"か"back"を指定して下さい。<br>この属性を省略すると"fore"であるとみなされます,
 text=表示するテキストの内容,
 x=テキストの左端位置を指定します。（ピクセル）,
 y=テキストの上端位置を指定します。（ピクセル）,
-vertical=true 、false のいずれかを指定してください。trueで縦書き表示されます。デフォルトは横書き,
-size=フォントサイズをピクセルで指定してください,
-face=フォントの種類を指定してください。非KAG互換ですが、ウェブフォントも使用できます,
+vertical=true 、false のいずれかを指定します。trueで縦書き表示されます。デフォルトは横書き,
+size=フォントサイズをピクセルで指定します,
+face=フォントの種類を指定します。非KAG互換ですが、ウェブフォントも使用できます,
 color=フォントの色を指定します,
-bold=太字指定 boldと指定してください　HTML５互換ならfont-style指定に変換できます,
+bold=太字指定 boldと指定します　HTML５互換ならfont-style指定に変換できます,
 edge=文字の縁取りを有効にできます。縁取りする文字色を 0xRRGGBB 形式で指定します。,
 shadow=文字に影をつけます。影の色を 0xRRGGBB 形式で指定します。縁取りをしている場合は無効化されます。,
 name=ティラノスクリプトのみ。animタグなどからこの名前でアニメーションさせることができます。でまた名前を指定しておくとクラス属性としてJSから操作できます。カンマで区切ることで複数指定することもできます,
@@ -2938,35 +3010,40 @@ tyrano.plugin.kag.tag.ptext = {
 
 /*
 #[mtext]
+
 :group
 レイヤ関連
+
 :title
 演出テキスト
+
 :exp
 多彩な演出効果をもったテキストを画面上に表示します。
 指定できる演出アニメーションは http://tyrano.jp/mtext/ を参照
 
 [layopt layer=0 visible=true]が必要です。
+
 :sample
 ;デフォルトは前景レイヤは配置されますので表示状態にしておく
 [layopt layer=0 visible=true]
 [mtext text="演出テキスト" x=100 y=100 in_effect="fadeIn" out_effect="fadeOut"]
+
 :param
 layer=対象とするレイヤを指定します。0以上の整数を指定すると対応する前景レイヤに画像を表示します,
 page=対象とするページを指定します。"fore"か"back"を指定して下さい。<br>この属性を省略すると"fore"であるとみなされます,
 text=表示するテキストの内容,
 x=テキストの左端位置を指定します。（ピクセル）,
 y=テキストの上端位置を指定します。（ピクセル）,
-vertical=true 、false のいずれかを指定してください。trueで縦書き表示されます。デフォルトは横書き,
-size=フォントサイズをピクセルで指定してください,
-face=フォントの種類を指定してください。非KAG互換ですが、ウェブフォントも使用できます,
+vertical=true 、false のいずれかを指定します。trueで縦書き表示されます。デフォルトは横書き,
+size=フォントサイズをピクセルで指定します,
+face=フォントの種類を指定します。非KAG互換ですが、ウェブフォントも使用できます,
 color=フォントの色を指定します,
 
 width=テキスト表示部分の横幅をピクセルで指定します,
 align=文字の横方向に関する位置を指定できます。left（左寄せ）center（中央寄せ）right（右寄せ）デフォルトはleftです。widthパラメータで横幅を指定するのを忘れないようにしてください,
 
 name=ティラノスクリプトのみ。animタグなどからこの名前でアニメーションさせることができます。でまた名前を指定しておくとクラス属性としてJSから操作できます。カンマで区切ることで複数指定することもできます,
-bold=太字指定 boldと指定してください　HTML５互換ならfont-style指定に変換できます,
+bold=太字指定 boldと指定します　HTML５互換ならfont-style指定に変換できます,
 edge=文字の縁取りを有効にできます。縁取りする文字色を 0xRRGGBB 形式で指定します,
 shadow=文字に影をつけます。影の色を 0xRRGGBB 形式で指定します。縁取りをしている場合は無効化されます。,
 
@@ -3160,14 +3237,18 @@ tyrano.plugin.kag.tag.mtext = {
 
 /*
 #[backlay]
+
 :group
 レイヤ関連
+
 :title
 レイヤ情報の表ページから裏ページへのコピー
+
 :exp
 指定したレイヤ、あるいはすべてのレイヤの情報を、表ページから裏ページに コピーします。
 利用方法としてはtrans タグで表ページのレイヤの画像を裏ページの レイヤの画像に置き換えます。
 そのため、トランジション前にこの backlay タ グで画像を裏ページに転送し、裏ページでレイヤを操作してから、トランジションを 行うという方法に用います。
+
 :sample
 ;背景変更をトランジションで実施
 @layopt layer=message0 visible=false
@@ -3175,6 +3256,7 @@ tyrano.plugin.kag.tag.mtext = {
 [image layer=base page=back storage=rouka.jpg]
 [trans time=2000]
 [wt]
+
 :param
 layer=対象となるレイヤを指定します。<br>
 base を指定すると 背景レイヤ になります。<br>
@@ -3203,23 +3285,27 @@ tyrano.plugin.kag.tag.backlay = {
 
 /*
 #[wt]
+
 :group
 レイヤ関連
+
 :title
 トランジションの終了待ち
+
 :exp
 トランジションが終了するまで、待ちます。
+
 :sample
 [backlay]
 [image layer=base page=back storage=rouka.jpg]
 [trans time=2000]
 ;トランジションが終わるまで先へ進まない
 [wt]
+
 :param
 
 :demo
 1,kaisetsu/03_layer
-
 
 #[end]
 */
@@ -3256,14 +3342,18 @@ start:function(pm){
 
 /*
 #[link]
+
 :group
 ラベル・ジャンプ操作
+
 :title
 ハイパーリンク（選択肢）
+
 :exp
 
 link タグと endlink タグで囲まれた部分の文章を、 マウスやキーボードで選択可能にし、そこでクリックされたりキーを押されたときに、 ジャンプする先を指定できます。
 また、囲まれた文章はページをまたぐことは出来ません(行をまたぐことはできます)。
+
 :sample
 選択肢を表示します[l][r][r]
 
@@ -3286,8 +3376,9 @@ link タグと endlink タグで囲まれた部分の文章を、 マウスや�
 [cm]
 
 共通ルートです
+
 :param
-storage=ジャンプ先のシナリオファイルを指定します。省略すると、現在 のシナリオファイル内であると見なされます,
+storage=ジャンプ先のシナリオファイルを指定します。省略すると、現在 のシナリオファイル内であるとみなされます。,
 target=ジャンプ先のラベルを指定します。省略すると、ファイルの先頭から実行されます。
 
 :demo
@@ -3356,24 +3447,29 @@ tyrano.plugin.kag.tag.link = {
 };
 
 /*
- #[endlink]
- :group
- ラベル・ジャンプ操作
- :title
- ハイパーリンク（選択肢）の終了を示します
- :exp
- ハイパーリンク（選択肢）の終了を示します
- :sample
- [link target=*select1]【１】選択肢　その１[endlink][r]
- [link target=*select2]【２】選択肢　その２[endlink][r]
- :param
+#[endlink]
+
+:group
+ラベル・ジャンプ操作
+
+:title
+ハイパーリンク（選択肢）の終了を示します
+
+:exp
+ハイパーリンク（選択肢）の終了を示します
+
+:sample
+[link target=*select1]【１】選択肢　その１[endlink][r]
+[link target=*select2]【２】選択肢　その２[endlink][r]
+
+:param
 
 
 :demo
 1,kaisetsu/14_select
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.endlink = {
     start: function (pm) {
@@ -3385,21 +3481,27 @@ tyrano.plugin.kag.tag.endlink = {
 };
 
 /*
- #[s]
- :group
- システム操作
- :title
- ゲームを停止する
- :exp
- シナリオファイルの実行を停止します。
- linkタグで選択肢表示した直後などに配置して利用する方法があります。
- :sample
- [link target=*select1]【１】選択肢　その１[endlink][r]
- [link target=*select2]【２】選択肢　その２[endlink][r]
- [s]
- :param
- #[end]
- */
+#[s]
+
+:group
+システム操作
+
+:title
+ゲームを停止する
+
+:exp
+シナリオファイルの実行を停止します。
+linkタグで選択肢表示した直後などに配置して利用する方法があります。
+
+:sample
+[link target=*select1]【１】選択肢　その１[endlink][r]
+[link target=*select2]【２】選択肢　その２[endlink][r]
+[s]
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.s = {
     start: function () {
@@ -3425,17 +3527,23 @@ tyrano.plugin.kag.tag._s = {
 
 /*
 #[wait]
+
 :group
 システム操作
+
 :title
 ウェイトを入れる
+
 :exp
 ウェイトを入れます。time属性で指定した時間、操作できなくなります。
+
 :sample
 ;2000ミリ秒（２秒）処理を停止します
 [wait time=2000]
+
 :param
 time=ウェイトをミリ秒で指定します。
+
 #[end]
 */
 
@@ -3466,13 +3574,17 @@ tyrano.plugin.kag.tag.wait = {
 
 /*
 #[wait_cancel]
+
 :group
 システム操作
+
 :title
 ウェイトをキャンセルする
+
 :exp
 [wait]タグで待ち状態のスタックが存在する場合、キャンセルできます。
 これは[wait]中にボタンクリックなどでジャンプした先でキャンセルするような使い方をします。
+
 :param
 
 :demo
@@ -3502,18 +3614,24 @@ tyrano.plugin.kag.tag.wait_cancel = {
 };
 
 /*
- #[hidemessage]
- :group
- レイヤ関連
- :title
- メッセージを消す
- :exp
- メッセージレイヤを一時的に隠します。メニューから「メッセージを消す」を選んだのと 同じ動作を行います。
- クリック待ちを行った後、メッセージレイヤは表示され、 実行は継続します。
- :sample
- :param
- #[end]
- */
+#[hidemessage]
+
+:group
+レイヤ関連
+
+:title
+メッセージを消す
+
+:exp
+メッセージレイヤを一時的に隠します。メニューから「メッセージを消す」を選んだのと 同じ動作を行います。
+クリック待ちを行った後、メッセージレイヤは表示され、 実行は継続します。
+
+:sample
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.hidemessage = {
     start: function () {
@@ -3530,21 +3648,26 @@ tyrano.plugin.kag.tag.hidemessage = {
 
 /*
 #[quake]
+
 :group
 システム操作
+
 :title
 画面を揺らす
+
 :exp
 指定したミリ秒だけ、画面を揺らします。（KAGの文字数指定は未対応）
 vmax 属性を 0 に設定すると横揺れになります。hmax 属性を 0 に設定すると縦揺れになります。
+
 :sample
 [quake count=5 time=300 hmax=20]
+
 :param
 count=指定した回数揺らします,
 wait  = trueかfalseを指定します。trueの場合は揺れが完了するまで、ゲームを停止します。デフォルトはtrue,
 time=１回揺れるのにかかる時間をミリ秒で指定します。デフォルトは300,
-hmax=揺れの横方向への最大振幅を指定します。省略すると 10(px) が指定されたと見なされます。,
-vmax=揺れの縦方向への最大振幅を指定します。省略すると 10(px) が指定されたと見なされます。
+hmax=揺れの横方向への最大振幅を指定します。省略すると 10(px) が指定されたとみなされます。,
+vmax=揺れの縦方向への最大振幅を指定します。省略すると 10(px) が指定されたとみなされます。
 
 :demo
 1,kaisetsu/12_anim
@@ -3607,39 +3730,44 @@ tyrano.plugin.kag.tag.quake = {
 };
 
 /*
- #[font]
- :group
- システム操作
- :title
- フォント属性設定
- :exp
- 文字の様々な属性を指定します。
- これらの属性は、メッセージレイヤごとに個別に設定できます。
- いずれの属性も、省略すると前の状態を引き継ぎます。また、default を指定すると Config.tjs 内で指定したデフォルトの値に戻ります。
- resetfont や　ct cm er タグが実行されると、、Config.tjs 内や deffont タグで指定し たデフォルトの値に戻ります。
- :sample
- [font size=40 bold=true]
- この文字は大きく、そして太字で表示されます。
- [resetfont]
- もとの大きさに戻りました。
- :param
- size=文字サイズを指定します,
- color=文字色を文字色を 0xRRGGBB 形式で指定します。（吉里吉里対応）　HTML5に限るならその他指定でも大丈夫です,
- bold=太字指定。true 又は　false で指定,
- italic=trueを指定すると、イタリック体になります。デフォルトはfalseです,
- face=フォントの種類を指定。非KAG互換でウェブフォントも利用可能。プロジェクトフォルダのothersフォルダに配置してください。そして、tyrano.cssの@font-faceを指定することで利用できます。,
- edge=文字の縁取りを有効にできます。縁取りする文字色を 0xRRGGBB 形式で指定します。縁取りを解除する場合は「none」と指定してください,
- shadow=文字に影をつけます。影の色を 0xRRGGBB 形式で指定します。影を解除する場合は「none」と指定してください,
- effect=フォントの表示演出にアニメーションを設定できます。noneを指定すると無効。デフォルトはnone。設定できる値は次のとおりです。/
+#[font]
+
+:group
+システム操作
+
+:title
+フォント属性設定
+
+:exp
+文字の様々な属性を指定します。
+これらの属性は、メッセージレイヤごとに個別に設定できます。
+いずれの属性も、省略すると前の状態を引き継ぎます。また、default を指定すると Config.tjs 内で指定したデフォルトの値に戻ります。
+resetfont や　ct cm er タグが実行されると、、Config.tjs 内や deffont タグで指定し たデフォルトの値に戻ります。
+
+:sample
+[font size=40 bold=true]
+この文字は大きく、そして太字で表示されます。
+[resetfont]
+もとの大きさに戻りました。
+
+:param
+size=文字サイズを指定します,
+color=文字色を文字色を 0xRRGGBB 形式で指定します。（吉里吉里対応）　HTML5に限るならその他指定でも大丈夫です,
+bold=太字指定。true 又は　false で指定,
+italic=trueを指定すると、イタリック体になります。デフォルトはfalseです,
+face=フォントの種類を指定。非KAG互換でウェブフォントも利用可能。プロジェクトフォルダのothersフォルダに配置してください。そして、tyrano.cssの@font-faceを指定することで利用できます。,
+edge=文字の縁取りを有効にできます。縁取りする文字色を 0xRRGGBB 形式で指定します。縁取りを解除する場合は「none」と指定します,
+shadow=文字に影をつけます。影の色を 0xRRGGBB 形式で指定します。影を解除する場合は「none」と指定します,
+effect=フォントの表示演出にアニメーションを設定できます。noneを指定すると無効。デフォルトはnone。設定できる値は次のとおりです。/
 fadeIn/fadeInDown/fadeInLeft/fadeInRight/fadeInUp/rotateIn<br />/zoomIn/slideIn/bounceIn/vanishIn/puffIn/rollIn/none,
- effect_speed=effectパラメータがnone以外の場合に、表示されるまでの時間を指定します。デフォルトは0.2s です。 sは秒を表します。
+effect_speed=effectパラメータがnone以外の場合に、表示されるまでの時間を指定します。デフォルトは0.2s です。 sは秒を表します。
 
 
 :demo
 1,kaisetsu/02_decotext
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.font = {
     pm: {},
@@ -3706,23 +3834,28 @@ tyrano.plugin.kag.tag.font = {
 
 /*
 #[deffont]
+
 :group
 システム操作
+
 :title
 デフォルトの文字属性設定
+
 :exp
 現在操作対象のメッセージレイヤに対する、デフォルトの文字属性を指定します。
 ここで指定した属性は、resetfont タグで実際に反映されます。
 つまり、このタグを実行しただけではすぐにはフォントの属性は反映されません。resetfont タグ を実行する必要があります。
+
 :sample
+
 :param
 size=文字サイズを指定します,
 color=文字色を文字色を 0xRRGGBB 形式で指定します。（吉里吉里対応）　HTML5に限るならその他指定でも大丈夫です,
 bold=太字指定。true 又は　false で指定,
 italic=trueを指定するとイタリック体で表示されます。デフォルトは
 face=フォントの種類を指定。非KAG互換でウェブフォントも利用可能。プロジェクトフォルダのothersフォルダに配置してください。そして、tyrano.cssの@font-faceを指定することで利用できます。,
-edge=文字の縁取りを有効にできます。縁取りする文字色を 0xRRGGBB 形式で指定します。縁取りを解除する場合は「none」と指定してください,
-shadow=文字に影をつけます。影の色を 0xRRGGBB 形式で指定します。影を解除する場合は「none」と指定してください
+edge=文字の縁取りを有効にできます。縁取りする文字色を 0xRRGGBB 形式で指定します。縁取りを解除する場合は「none」と指定します,
+shadow=文字に影をつけます。影の色を 0xRRGGBB 形式で指定します。影を解除する場合は「none」と指定します
 effect=フォントの表示演出にアニメーションを設定できます。noneを指定すると無効。デフォルトはnone。設定できる値は次のとおりです。/
 fadeIn/fadeInDown/fadeInLeft/fadeInRight/fadeInUp/rotateIn/<br />zoomIn/slideIn/bounceIn/vanishIn/puffIn/rollIn/none,
 effect_speed=effectパラメータがnone以外の場合に、表示されるまでの時間を指定します。デフォルトは0.2s です。 sは秒を表します。
@@ -3795,14 +3928,19 @@ tyrano.plugin.kag.tag.deffont = {
 
 /*
 #[delay]
+
 :group
 システム操作
+
 :title
 文字の表示速度の設定
+
 :exp
 文字の表示速度を指定します。
 文字表示をノーウェイトにするには nowait タグをつかう こともできます。
+
 :sample
+
 :param
 speed=文字の表示速度を指定します
 
@@ -3831,14 +3969,20 @@ tyrano.plugin.kag.tag.delay = {
 
 /*
 #[resetdelay]
+
 :group
 システム操作
+
 :title
 文字の表示速度をデフォルトに戻す
+
 :exp
 文字の表示速度をデフォルト速度に戻します
+
 :sample
+
 :param
+
 #[end]
 */
 
@@ -3858,17 +4002,23 @@ tyrano.plugin.kag.tag.resetdelay = {
 
 /*
 #[configdelay]
+
 :group
 システム操作
+
 :title
 デフォルトの文字の表示速度の設定
+
 :exp
 デフォルトの文字の表示速度を指定します。
 つまり、resetdelay時にはこの速度が指定されます。
 コンフィグ画面などで文字速度を指定する場合はこのタグをつかって指定します。
+
 :sample
+
 :param
 speed=文字の表示速度を指定します
+
 #[end]
 */
 
@@ -3892,17 +4042,23 @@ tyrano.plugin.kag.tag.configdelay = {
 };
 
 /*
- #[nowait]
- :group
- システム操作
- :title
- 文字表示の瞬間表示
- :exp
- 待ち時間なしに、テキストを配置します。
- :sample
- :param
- #[end]
- */
+#[nowait]
+
+:group
+システム操作
+
+:title
+文字表示の瞬間表示
+
+:exp
+待ち時間なしに、テキストを配置します。
+
+:sample
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.nowait = {
     pm: {},
@@ -3915,17 +4071,23 @@ tyrano.plugin.kag.tag.nowait = {
 };
 
 /*
- #[endnowait]
- :group
- システム操作
- :title
- テキストの瞬間表示を取り消します。
- :exp
- テキストメッセージは前回nowaitタグを指定した時のスピードへ戻ります
- :sample
- :param
- #[end]
- */
+#[endnowait]
+
+:group
+システム操作
+
+:title
+テキストの瞬間表示を取り消します。
+
+:exp
+テキストメッセージは前回nowaitタグを指定した時のスピードへ戻ります
+
+:sample
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.endnowait = {
     pm: {},
@@ -3938,18 +4100,24 @@ tyrano.plugin.kag.tag.endnowait = {
 };
 
 /*
- #[resetfont]
- :group
- システム操作
- :title
- フォント属性を元に戻す
- :exp
- font タグで指定した文字の属性をデフォルトに戻します。
- 文字属性は、メッセージレイヤごとに個別に設定できます
- :sample
- :param
- #[end]
- */
+#[resetfont]
+
+:group
+システム操作
+
+:title
+フォント属性を元に戻す
+
+:exp
+font タグで指定した文字の属性をデフォルトに戻します。
+文字属性は、メッセージレイヤごとに個別に設定できます
+
+:sample
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.resetfont = {
     log_join: "true",
@@ -3964,12 +4132,16 @@ tyrano.plugin.kag.tag.resetfont = {
 
 /*
 #[layopt]
+
 :group
 レイヤ関連
+
 :title
 レイヤの属性設定
+
 :exp
 レイヤの属性を指定します。
+
 :sample
 ;メッセージレイヤを消去
 @layopt layer=message0 visible=false
@@ -3979,17 +4151,17 @@ tyrano.plugin.kag.tag.resetfont = {
 @wt
 ;そしてレイヤ表示
 @layopt layer=message0 visible=true
+
 :param
 layer=対象となる前景レイヤまたはメッセージレイヤを指定します。 　message とのみ指定した場合は、current タグで指定した、現在の操作対象のメッセージレイヤが対象となります。,
-page=表(fore)画面のレイヤを対象とするか、裏(back)画面のレイヤを対象と するかを指定します。省略すると表ページであると見なされます。ただしlayerをmessage とのみ指定した場合でこの属性を省略した場合は 現在操作対象のページのメッセージレイヤが選択されます。,
+page=表(fore)画面のレイヤを対象とするか、裏(back)画面のレイヤを対象と するかを指定します。省略すると表ページであるとみなされます。ただしlayerをmessage とのみ指定した場合でこの属性を省略した場合は 現在操作対象のページのメッセージレイヤが選択されます。,
 visible=layer 属性で指定したレイヤを表示するか、しないかを指定 します。visibleをtrue と 指定すれば、レイヤは表示状態になります。visible=false と指定すれば、 非表示状態になります。省略すると表示状態は変わりません。,
-left=layer 属性で指定したレイヤの左端位置を指定します。 省略すると位置は変更しません。　layer 属性に message0 や message1 を指定した場合は、position タグで位置等を指定してください。,
-top=layer 属性で指定したレイヤの上端位置を指定します。 省略すると位置は変更しません。　layer 属性に message0 や message1 を指定した場合は、むしろ position タグで位置等を指定してください。,
-opacity=レイヤの不透明度を指定します。０～２５５の範囲で指定してください（２５５で全くの不透明）
+left=layer 属性で指定したレイヤの左端位置を指定します。 省略すると位置は変更しません。（メッセージレイヤの位置を調整したい場合はこのタグの代わりに[position]タグを使用します）,
+top=layer 属性で指定したレイヤの上端位置を指定します。 省略すると位置は変更しません。（メッセージレイヤの位置を調整したい場合はこのタグの代わりに[position]タグを使用します）,
+opacity=レイヤの不透明度を0～255の範囲で指定します。（255で全くの不透明）
 
 :demo
 1,kaisetsu/18_window_2
-
 
 #[end]
 */
@@ -4058,16 +4230,21 @@ tyrano.plugin.kag.tag.layopt = {
 
 /*
 #[ruby]
+
 :group
 メッセージ関連
+
 :title
 ルビを振る
+
 :exp
 次の一文字に対するルビを指定します。
-ルビを表示させたい場合は毎回指定してください。
+ルビを表示させたい場合は毎回指定する必要があります。
 複数の文字にルビを振る場合は、一文字毎にルビを指定する必要があります。
+
 :sample
 [ruby text="かん"]漢[ruby text="じ"]字
+
 :param
 text=ルビとして表示させる文字を指定します
 
@@ -4099,22 +4276,26 @@ tyrano.plugin.kag.tag["ruby"] = {
 
 /*
 #[mark]
+
 :group
 メッセージ関連
+
 :title
 テキストマーカー
+
 :exp
 テキストに蛍光ペンでマーカーを引いたような効果をつけることができます。
 色やサイズも指定可能
+
 :sample
 ここはまだです。[mark]ここにマーカーがひかれています。[endmark]ここはひかれません。
 
 [mark color="0xff7f50" size=70 ]マーカーの色やサイズを指定することもできます。[endmark]
 
 :param
-color=マーカーの色を指定します。デフォルトは黄色です。0xRRGGBB 形式で指定してください。 ,
-font_color=マーカーを引いたときのフォントの色を指定できます。0xRRGGBB 形式で指定してください。指定しないときはゲーム中のフォント色を継承します。,
-size=マーカーのサイズを指定できます。0〜100の間で指定してください。例えば50だとテキストの半分までマーカーがひかれます。10だと下線になります。
+color=マーカーの色を指定します。デフォルトは黄色です。0xRRGGBB 形式で指定します。 ,
+font_color=マーカーを引いたときのフォントの色を指定できます。0xRRGGBB 形式で指定します。指定しないときはゲーム中のフォント色を継承します。,
+size=マーカーのサイズを指定できます。0〜100の間で指定します。例えば50だとテキストの半分までマーカーがひかれます。10だと下線になります。
 
 :demo
 
@@ -4164,10 +4345,13 @@ tyrano.plugin.kag.tag["mark"] = {
 
 /*
 #[endmark]
+
 :group
 メッセージ関連
+
 :title
 テキストマーカー終了
+
 :exp
 [mark]タグで開始したテキストマーカーを終了します。
 
@@ -4202,18 +4386,24 @@ tyrano.plugin.kag.tag["endmark"] = {
 };
 
 /*
- #[cancelskip]
- :group
- システム操作
- :title
- スキップ解除
- :exp
- スキップ状態の解除を行います。
- プレイヤーにスキップ状態の停止を強制させることができます
- :sample
- :param
- #[end]
- */
+#[cancelskip]
+
+:group
+システム操作
+
+:title
+スキップ解除
+
+:exp
+スキップ状態の解除を行います。
+プレイヤーにスキップ状態の停止を強制させることができます
+
+:sample
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.cancelskip = {
     start: function (pm) {
@@ -4224,13 +4414,17 @@ tyrano.plugin.kag.tag.cancelskip = {
 
 /*
 #[locate]
+
 :group
 システム操作
+
 :title
 表示位置の指定
+
 :exp
 グラフィックボタンの表示位置を指定します。
 テキストには対応しておりません。
+
 :sample
 [locate x=20 y=100]
 [button graphic="oda.png" target=*oda]
@@ -4241,6 +4435,7 @@ tyrano.plugin.kag.tag.cancelskip = {
 :param
 x=横方向位置指定,
 y=縦方向位置指定
+
 #[end]
 */
 
@@ -4266,10 +4461,13 @@ tyrano.plugin.kag.tag.locate = {
 
 /*
 #[button]
+
 :group
 ラベル・ジャンプ操作
+
 :title
 グラフィカルボタンの表示
+
 :exp
 グラフィカルボタンを表示します。
 linkタグの画像版となります。
@@ -4279,6 +4477,7 @@ linkタグの画像版となります。
 ここから、移動した場合はコールスタックに残りません。つまり、リターンできないのでご注意ください
 注意→fixにtrueを指定した場合はコールスタックに残ります。コール先からリターンするまで全てのボタンは有効にならないのでご注意ください
 ジャンプ後に必ず[cm]タグでボタンを非表示にする必要があります。
+
 :sample
 [locate x=20 y=100]
 [button graphic="oda.png" target=*oda]
@@ -4288,7 +4487,7 @@ linkタグの画像版となります。
 
 :param
 graphic=ボタンにする画像を指定します。ファイルはプロジェクトフォルダのimageフォルダに入れて下さい,
-storage=ジャンプ先のシナリオファイルを指定します。省略すると、現在 のシナリオファイル内であると見なされます。,
+storage=ジャンプ先のシナリオファイルを指定します。省略すると、現在 のシナリオファイル内であるとみなされます。,
 target=ジャンプ先のラベルを指定します。省略すると、ファイルの先頭から実行されます。,
 name=ティラノスクリプトのみ。animタグなどからこの名前でアニメーションさせることができます。でまた名前を指定しておくとクラス属性としてJSから操作できます。カンマで区切ることで複数指定することもできます,
 x=ボタンの横位置を指定します,
@@ -4502,6 +4701,8 @@ tyrano.plugin.kag.tag.button = {
 
             //クリックが確定したとき
             j_button.click(function (event) {
+                button_clicked = true;
+
                 if (_pm.clickimg != "") {
                     //クリック画像が設定されているなら画像を変える
                     var click_img_url = parse_img_url(_pm.clickimg);
@@ -4525,8 +4726,6 @@ tyrano.plugin.kag.tag.button = {
                 ) {
                     return false;
                 }
-
-                button_clicked = true;
 
                 if (_pm.exp != "") {
                     //スクリプト実行
@@ -4716,15 +4915,20 @@ tyrano.plugin.kag.tag.button = {
 
 /*
 #[glink]
+
 :group
 ラベル・ジャンプ操作
+
 :title
 グラフィカルリンク
+
 :exp
-グラフィカルなボタンを表示することができます。画像は必要ありません
-グラフィックリンク表示中は強制的にシナリオ進行が停止しますので、必ずジャンプ先を指定して下さい
-また、グラフィックボタンの表示位置は直前のlocateタグによる指定位置を参照します。
+グラフィカルリンク(テキストボタン)を表示できます。画像は必要ありません。
+グラフィックリンク表示中は強制的にシナリオ進行が停止しますので、必ずジャンプ先を指定して下さい。
+
+また、グラフィックリンクの表示位置は直前のlocateタグによる指定位置を参照します。
 ただし、x、y が指定されている場合は、そちらが優先されます。
+
 ここから、移動した場合はコールスタックに残りません。つまり、リターンできないのでご注意ください
 ジャンプ後は自動的に[cm]タグが実行され、ボタンは消失します
 
@@ -4742,8 +4946,8 @@ https://tyrano.jp/sample2/code/siryou/1
 
 :param
 color=ボタンの色を指定できます。デフォルトはblackです（black gray white orange red blue rosy green pink）V501c以降で200パターン以上のデザイン追加。詳しくは→ https://tyrano.jp/sample2/code/siryou/1 ,
-font_color=フォントの色を指定できます。0xRRGGBB 形式で指定してください。 ,
-storage=ジャンプ先のシナリオファイルを指定します。省略すると、現在 のシナリオファイル内であると見なされます。,
+font_color=フォントの色を0xRRGGBB形式で指定します。 ,
+storage=ジャンプ先のシナリオファイルを指定します。省略すると、現在 のシナリオファイル内であるとみなされます。,
 target=ジャンプ先のラベルを指定します。省略すると、ファイルの先頭から実行されます。,
 name=ティラノスクリプトのみ。animタグなどからこの名前でアニメーションさせることができます。でまた名前を指定しておくとクラス属性としてJSから操作できます。カンマで区切ることで複数指定することもできます,
 text=ボタンの文字列です,
@@ -4960,16 +5164,20 @@ tyrano.plugin.kag.tag.glink = {
 
 /*
 #[clickable]
+
 :group
 ラベル・ジャンプ操作
+
 :title
 クリック可能な領域を設定
+
 :exp
-透明なクリック可能領域を設定することができます。
+透明なクリック可能領域を設定できます。
 クリッカブルエリアの表示中は強制的にシナリオ進行が停止しますので、必ずジャンプ先を指定して下さい
 また、グラフィックボタンの表示位置は直前のlocateタグによる指定位置を参照します
 ここから、移動した場合はコールスタックに残りません。つまり、リターンできないのでご注意ください
 ☆重要：[s]タグに到達していない間は、クリッカブルは有効になりません。かならず、[s]タグでゲームを停止してください。
+
 :sample
 [locate x=20 y=100]
 [clickable width=200 height=300 target=*oda]
@@ -4984,11 +5192,11 @@ width=領域の横幅を指定します,
 height=領域に高さを指定します,
 x=領域の左端位置のX座標を指定します,
 y=領域の左端位置のY座標を指定します。,
-borderstyle=領域に線を表示することができます。「線の太さ:線の種類（CSS準拠）:線の色」のフォーマットで記述して下さい。線の種類はsolid double groove dashed dotted などが指定できます,　
+borderstyle=領域に線を表示できます。「線の太さ:線の種類（CSS準拠）:線の色」のフォーマットで記述して下さい。線の種類はsolid double groove dashed dotted などが指定できます,　
 color=表示色を 0xRRGGBB 形式で指定 します。 ,
 opacity=領域の不透明度を 0 ～ 255 の数値で指定します0で完全 に透明です。,
-mouseopacity=領域にマウスが乗った時透明度を変更することができます。領域の不透明度を 0 ～ 255 の数値で指定します0で完全 に透明です,
-storage=クリックされた際のジャンプ先のシナリオファイルを指定します。省略すると、現在 のシナリオファイル内であると見なされます。,
+mouseopacity=領域にマウスが乗った時透明度を変更できます。領域の不透明度を 0 ～ 255 の数値で指定します0で完全 に透明です,
+storage=クリックされた際のジャンプ先のシナリオファイルを指定します。省略すると、現在 のシナリオファイル内であるとみなされます。,
 target=クリックされた際のジャンプ先のラベルを指定します。省略すると、ファイルの先頭から実行されます。
 
 :demo
@@ -5106,18 +5314,22 @@ tyrano.plugin.kag.tag.clickable = {
 
 /*
 #[glyph]
+
 :group
 システム操作
+
 :title
 クリック待ち記号の指定
+
 :exp
 クリック待ち記号を表示する位置を設定できます
 クリック記号はプロジェクトフォルダのtyrano/images/system/nextpage.gifを変更することで対応します
+
 :sample
 [glyph  fix=true left=200 top=100 ]
 
 :param
-line=クリック待ちの表示画像を指定することができます。tyrano/images/system/nextpage.gifと同一のフォルダに配置してください,
+line=クリック待ちの表示画像を指定できます。tyrano/images/system/nextpage.gifと同一のフォルダに配置してください,
 fix=trueを指定すると、left、及び、topを指定した位置に表示されます。,
 left=fix 属性を true にしたときに記号を表示する位置のうち、左端位置を 指定します,
 top=fix 属性を true にしたときに記号を表示する位置のうち、上端位置を 指定します
@@ -5184,20 +5396,25 @@ start:function(pm){
 
 /*
 #[trans]
+
 :group
 レイヤ関連
+
 :title
 レイヤのトランジション
+
 :exp
 指定したレイヤでトランジションを行います。
 トランジションは、常に裏ページの対象のレイヤが、表ページの対象のレイヤに 入れ替わる方向で行われます。
 トランジション後は、表ページの対象のレイヤの画像、位置、サイズ、可視・不可視 の状態は裏ページの対象のレイヤと同じになります。
 また、トランジション中はレイヤの属性変更などは行わないで下さい
+
 :sample
 [backlay]
 [image storage=fg0 layer=0 page=back]
 [trans time=1500 ]
 [wt]
+
 :param
 layer=対象となるレイヤを指定します。<br>
 base を指定すると 背景レイヤ になります。<br>
@@ -5327,21 +5544,26 @@ tyrano.plugin.kag.tag.trans = {
 
 /*
 #[bg]
+
 :group
 レイヤ関連
+
 :title
 背景の切り替え
+
 :exp
 背景の切り替えを簡易的に実行できます。
 常にforeのレイヤに対して切り替えが実行されます
+
 :sample
 [bg storage=fg0.png time=1500 wait=true]
+
 :param
 storage=切り替えるための画像ファイルを指定します。ファイルはbgimage以下に配置してください,
 time=時間をミリ秒で指定します。,
 wait=背景の切り替えが完了するまで処理を待ちます,
 cross=true or false を指定します。デフォルトはfalse。trueを指定すると２つの画像が同じタイミングで透明になりながら入れ替わります。falseを指定すると、古い背景を残しながら上に重なる形で新しい背景を表示します。CG差分などで使用する場合はfalseが良いでしょう。,
-position:指定しない場合は画面サイズぴったりに引き伸ばされて背景が表示されます（比率は崩れる）。この値を指定すると背景画像と画面サイズの比率が異なる場合に、比率を崩さずに背景を配置することができます。配置位置を指定してください。left（左寄せ）center（中央寄せ）right（右寄せ）top（上寄せ）bottom（下寄せ）,
+position=省略すると、画面サイズぴったりに引き伸ばされて背景が表示されます（比率は崩れる）。この値を指定すると背景画像と画面サイズの比率が異なる場合に、比率を崩さずに背景を配置できます。配置位置を次のキーワードから選択してください。left（左寄せ）center（中央寄せ）right（右寄せ）top（上寄せ）bottom（下寄せ）,
 method=切り替えのタイプを指定します。デフォルトは"fadeIn"です。指定できる演出は次の通りです。
 （V450以降）
 fadeIn/
@@ -5377,7 +5599,6 @@ puffIn
 
 :demo
 1,kaisetsu/04_bg
-
 
 #[end]
 */
@@ -5482,22 +5703,27 @@ tyrano.plugin.kag.tag.bg = {
 
 /*
 #[bg2]
+
 :group
 レイヤ関連
+
 :title
 背景の切り替え
+
 :exp
 背景の切り替えを簡易的に実行できます。
 常にforeのレイヤに対して切り替えが実行されます
+
 :sample
 [bg storage=fg0.png time=1500 wait=true]
+
 :param
 name=animタグなどからこの名前でアニメーションさせることができます。また、名前を指定しておくとクラス属性としてJSから操作できます。カンマで区切ることで複数指定することもできます,
 storage=切り替えるための画像ファイルを指定します。ファイルはbgimage以下に配置してください,
 left=画像の左端位置を指定します。デフォルトは０です（ピクセル）,
 top=画像の上端位置を指定します。デフォルトは０です（ピクセル）,
-width=画像の横幅を指定します。（ピクセル）指定しない場合はゲーム画面に一致するサイズが設定されます,
-height=画像の高さ位置を指定します。（ピクセル）指定しない場合はゲーム画面に一致するサイズが設定されます,
+width=画像の横幅を指定します。（ピクセル）省略すると、ゲーム画面に一致するサイズが設定されます,
+height=画像の高さ位置を指定します。（ピクセル）省略すると、ゲーム画面に一致するサイズが設定されます,
 time=時間をミリ秒で指定します。,
 wait=背景の切り替えが完了するまで処理を待ちます,
 cross=true or false を指定します。デフォルトはfalse。trueを指定すると２つの画像が同じタイミングで透明になりながら入れ替わります。falseを指定すると、古い背景を残しながら上に重なる形で新しい背景を表示します。CG差分などで使用する場合はfalseが良いでしょう。,
@@ -5533,6 +5759,7 @@ vanishIn/
 puffIn
 (V450以前)
 指定できる効果は「crossfade」「explode」「slide」「blind」「bounce」「clip」「drop」「fold」「puff」「scale」「shake」「size」
+
 #[end]
 */
 
@@ -5675,25 +5902,30 @@ tyrano.plugin.kag.tag.bg2 = {
 
 /*
 #[layermode]
+
 :group
 レイヤ関連
+
 :title
 レイヤーモード
+
 :exp
 レイヤの合成を行うことができます。
 PCゲーム環境での推奨機能です。
 一部ブラウザIE,Edge では動作しませんのでご注意ください
+
 :sample
 [layermode graphic=fg0.png time=1500 mode=overlay]
+
 :param
 name=レイヤ合成に名前をつけることができます。この名前はfree_layremovdeで特定の合成のみを消したい際に使用できます,
-graphic=合成する画像ファイルを指定してください。ファイルはimageフォルダに配置しします,
-color=合成に色を指定することができます0xFFFFFF形式で指定してください,
+graphic=合成する画像ファイルを指定します。ファイルはimageフォルダに配置します,
+color=合成する色を0xRRGGBB形式で指定します。,
 mode=合成方法を指定できます。デフォルトは「multiply」 次の効果が使えます→ multiply（乗算）screen（スクリーン）overlay（オーバーレイ）darken（暗く）lighten（明るく）color-dodge（覆い焼きカラー）color-burn（焼き込みカラー）hard-light（ハードライト）soft-light（ソフトライト）difference（差の絶対値）exclusion（除外）hue（色相）saturation（彩度）color（カラー）luminosity（輝度）,
-folder=graphicで指定する画像のフォルダを変更できます。例えばbgimageと指定することで、背景画像から取得することができます。,
+folder=graphicで指定する画像のフォルダを変更できます。例えばbgimageと指定することで、背景画像から取得できます。,
 opacity=不透明度を 0 ～ 255 の数値で指定します。0 で完全 に透明です。デフォルトは透明度指定なしです,
 time=合成はフェードインで行われます。合成が完了する時間をミリ秒(１秒=1000ミリ秒)で指定します。デフォルトは500ミリ秒です,
-wait=合成の完了を待つか否かを指定できます。trueかfalseを指定してください。デフォルトはtrueです
+wait=合成の完了を待つかどうかをtrueまたはfalseで指定します。デフォルトはtrueです。
 
 :demo
 2,kaisetsu/02_layermode
@@ -5787,10 +6019,13 @@ tyrano.plugin.kag.tag.layermode = {
 
 /*
 #[layermode_movie]
+
 :group
 レイヤ関連
+
 :title
 レイヤーモード動画
+
 :exp
 ゲーム画面に動画を合成を行うことができます。
 PCゲーム環境での推奨機能です。
@@ -5802,9 +6037,10 @@ PCゲーム形式の場合は webm形式を使ってください。 mp4 に対�
 
 :sample
 [layermode_movie video=test.webm time=1500 wait=true]
+
 :param
 name=レイヤ合成に名前をつけることができます。この名前はfree_layremovdeで特定の合成のみを消したい際に使用できます,
-video=合成する動画ファイルを指定してください。ファイルはvideoフォルダに配置しします,
+video=合成する動画ファイルを指定します。ファイルはvideoフォルダに配置しします,
 volume=合成する動画の音ボリュームを指定します。0〜100で指定します。デフォルトは０の消音です,
 mute=true/falseを指定します。デフォルトはfalse。動画の音をミュートにできます。スマホブラウザの場合、動作が再生前のユーザアクションが必要ですが、trueを指定することでこの制限を無視できます。,
 loop=動画をループするか否かをtrueかfalseで指定します。デフォルトはtrueです。ループ指定した場合、free_layermodeを行うまで演出が残ります。,
@@ -5812,8 +6048,8 @@ speed=動画の再生スピードを指定できます。デフォルトは１ �
 mode=合成方法を指定できます。デフォルトは「multiply」 次の効果が使えます→ multiply（乗算）screen（スクリーン）overlay（オーバーレイ）darken（暗く）lighten（明るく）color-dodge（覆い焼きカラー）color-burn（焼き込みカラー）hard-light（ハードライト）soft-light（ソフトライト）difference（差の絶対値）exclusion（除外）hue（色相）saturation（彩度）color（カラー）luminosity（輝度）,
 opacity=不透明度を 0 ～ 255 の数値で指定します。0 で完全 に透明です。デフォルトは透明度指定なしです,
 time=合成はフェードインで行われます。合成が完了する時間をミリ秒(１秒=1000ミリ秒)で指定します。デフォルトは500ミリ秒です,
-left=エフェクトをかける位置を指定することができます。（ピクセル）,
-top=エフェクトをかける位置を指定することができます。（ピクセル）,
+left=エフェクトをかける位置を指定できます。（ピクセル）,
+top=エフェクトをかける位置を指定できます。（ピクセル）,
 width=エフェクトの幅を指定します。（ピクセル）,
 height=エフェクトの高さを指定します。（ピクセル）,
 fit=true or false 演出を画面いっぱいに引き伸ばすことができます。デフォルトはtrue ,
@@ -5983,16 +6219,21 @@ tyrano.plugin.kag.tag.layermode_movie = {
 
 /*
 #[free_layermode]
+
 :group
 レイヤ関連
+
 :title
 レイヤーモードの開放
+
 :exp
 レイヤの合成を取り消します
+
 :sample
 [free_layermode name="test"]
+
 :param
-name=名前を指定して合成を行っている場合、ここで特定の合成のみを削除することも可能です。指定しない場合はすべての効果が消されます,
+name=名前を指定して合成を行っている場合、ここで特定の合成のみを削除することも可能です。省略すると、すべての効果が消されます,
 time=合成はフェードアウトで消えていきます。フェードアウトにかかる時間をミリ秒で指定できます。デフォルトは500ミリ秒です,
 wait=フェードアウトの完了を待つか否かをtrueかfalseで指定できます。デフォルトはtrueです。
 

--- a/tyrano/plugins/kag/kag.tag_ar.js
+++ b/tyrano/plugins/kag/kag.tag_ar.js
@@ -1,9 +1,12 @@
 /*
 #[bgcamera]
+
 :group
 AR関連
+
 :title
 ストリームカメラ背景
+
 :exp
 背景をデバイスのカメラ入力に切り替えることができます。
 キャラクターと記念撮影をするようなアプリが簡単につくれます。
@@ -52,15 +55,14 @@ name=animタグなどからこの名前でアニメーションさせること�
 wait=trueを指定するとカメラ入力の表示を待ちます。デフォルトはtrue,
 time=カメラ入力領域が表示されるフェードイン時間をミリ秒で指定します。デフォルトは1000,
 fit=比率を崩しても全画面に配置するならtrue。比率を保持して配置するならfalse。カメラの解像度によっては黒塗りの部分ができる可能性があります。デフォルトはtrue。,
-left=カメラを配置する位置を指定することができます。（ピクセル）,
-top=カメラを配置する位置を指定することができます。（ピクセル）,
+left=カメラを配置する位置を指定できます。（ピクセル）,
+top=カメラを配置する位置を指定できます。（ピクセル）,
 width=カメラを配置するエリアの幅を指定します。（ピクセル）,
 height=カメラを配置するエリアの高さを指定します。（ピクセル）,
 mode=「front」（前面カメラ）「back」（背面カメラ）を指定します。何も指定しないと標準のカメラが選択されます,
 qrcode=QRコードを読み込んだときの動作を設定できます。「jump」（ゲーム内移動のQRのみ反応）「web」（他サイトへのリンクだけ反応）「define」（qr_defineで定義したものだけに反応）「all」（すべてに反応）「off」（QRコードに反応しない）デフォルトは「off」,
 debug=QRコードが読み込まれたときにURLを表示するか否かを指定できます。デフォルトはfalse。trueでURLをアラート表示できます。 ,
 audio=音声入力も反映するか否か。trueを指定すると音声もゲームに反映されます。デフォルトはfalse
-
 
 #[end]
 */
@@ -337,22 +339,27 @@ tyrano.plugin.kag.tag.bgcamera = {
 };
 
 /*
- #[qr_config ]
- :group
- AR関連
- :title
- QRコードの動作設定
- :exp
- QRコードの各種動作設定が可能です。
- :sample
+#[qr_config]
 
- ;QRコードでティラノのジャップのみ有効にする
- [qr_config qrcode="jump"]
+:group
+AR関連
 
- :param
- qrcode=QRコードを読み込んだときの動作を設定できます。「jump」（ゲーム内移動のQRのみ反応）「web」（他サイトへのリンクだけ反応）「all」（jumpとweb両方に反応）「off」（QRコードに反応しない）デフォルトは「off」,
- #[end]
- */
+:title
+QRコードの動作設定
+
+:exp
+QRコードの各種動作設定が可能です。
+
+:sample
+
+;QRコードでティラノのジャップのみ有効にする
+[qr_config qrcode="jump"]
+
+:param
+qrcode=QRコードを読み込んだときの動作を設定できます。「jump」（ゲーム内移動のQRのみ反応）「web」（他サイトへのリンクだけ反応）「all」（jumpとweb両方に反応）「off」（QRコードに反応しない）デフォルトは「off」,
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.qr_config = {
     vital: [],
@@ -373,20 +380,26 @@ tyrano.plugin.kag.tag.qr_config = {
 };
 
 /*
- #[stop_bgcamera]
- :group
- AR関連
- :title
- カメラストリームの停止
- :exp
- [bgcamera]を非表示にします。
- :sample
- [stop_bgcamera time=1000 ]
- :param
- time=ミリ秒で指定。動画をフェードアウトして削除することが可能です。デフォルトは1000,
- wait=trueかfalse を指定します。動画のフェードアウトを待つかどうかを指定できます。デフォルトはtrue
- #[end]
- */
+#[stop_bgcamera]
+
+:group
+AR関連
+
+:title
+カメラストリームの停止
+
+:exp
+[bgcamera]を非表示にします。
+
+:sample
+[stop_bgcamera time=1000 ]
+
+:param
+time=ミリ秒で指定。動画をフェードアウトして削除することが可能です。デフォルトは1000,
+wait=trueかfalse を指定します。動画のフェードアウトを待つかどうかを指定できます。デフォルトはtrue
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.stop_bgcamera = {
     vital: [],
@@ -438,25 +451,29 @@ tyrano.plugin.kag.tag.stop_bgcamera = {
 };
 
 /*
- #[qr_define]
- :group
- AR関連
- :title
- QRコードの置き換え
- :exp
- QRコードのURLをjumpに置き換えることができます。
- 例えば、モニュメントや商品についているQRコードをゲーム内のイベントに置き換える事ができます。
+#[qr_define]
 
- :sample
- [qr_define url="https://tyrano.jp" storage="scene1.ks" target="test" ]
+:group
+AR関連
 
- :param
- url=カメラを写したときに反応させるURLを定義します,
- storage=URLが読み込まれたときに発動するjump先のシナリオファイルを指定します,
- target=ジャンプ先のラベルと指定する,
- clear=trueを指定すると定義を削除することができます。デフォルトはfalse
- #[end]
- */
+:title
+QRコードの置き換え
+
+:exp
+QRコードのURLをjumpに置き換えることができます。
+例えば、モニュメントや商品についているQRコードをゲーム内のイベントに置き換える事ができます。
+
+:sample
+[qr_define url="https://tyrano.jp" storage="scene1.ks" target="test" ]
+
+:param
+url=カメラを写したときに反応させるURLを定義します,
+storage=URLが読み込まれたときに発動するjump先のシナリオファイルを指定します,
+target=ジャンプ先のラベルと指定する,
+clear=trueを指定すると定義を削除できます。デフォルトはfalse
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.qr_define = {
     vital: ["url"],

--- a/tyrano/plugins/kag/kag.tag_ar.js
+++ b/tyrano/plugins/kag/kag.tag_ar.js
@@ -1,4 +1,3 @@
-
 /*
 #[bgcamera]
 :group
@@ -68,11 +67,9 @@ audio=音声入力も反映するか否か。trueを指定すると音声もゲ�
 
 //背景変更
 tyrano.plugin.kag.tag.bgcamera = {
-
     vital: [],
 
     pm: {
-
         name: "",
         wait: "true",
         time: 1000,
@@ -90,23 +87,20 @@ tyrano.plugin.kag.tag.bgcamera = {
         mode: "", // front or back or auto //前面と背面カメラが有る場合に、指定できます。何も指定しないと標準のカメラが選択されます。
         stop: "false",
 
-        audio: "false"
-
+        audio: "false",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.ftag.hideNextImg();
 
         var that = this;
 
         this.kag.stat.qr.mode = pm.qrcode;
 
-
         if (pm.time == 0) pm.wait = "false";
 
         //現在の背景画像の要素を取得
-        var video = document.createElement('video');
+        var video = document.createElement("video");
         video.id = "bgcamera";
 
         video.style.backgroundColor = "black";
@@ -118,7 +112,6 @@ tyrano.plugin.kag.tag.bgcamera = {
         video.autoplay = true;
         video.autobuffer = true;
 
-
         if (pm.width != "") {
             video.style.width = pm.width + "px";
         }
@@ -127,23 +120,16 @@ tyrano.plugin.kag.tag.bgcamera = {
             video.style.height = pm.height + "px";
         } else {
             if (pm.fit == "true") {
-
                 var scWidth = parseInt(this.kag.config.scWidth);
                 var scHeight = parseInt(this.kag.config.scHeight);
 
                 if (scWidth > scHeight) {
-
                     video.style.height = "";
                     video.style.width = "100%";
-
                 } else {
-
                     video.style.height = "100%";
                     video.style.width = "";
-
                 }
-
-
             } else {
                 video.style.height = "";
             }
@@ -164,29 +150,24 @@ tyrano.plugin.kag.tag.bgcamera = {
         }
 
         //表示の準備完了
-        (function() {
+        (function () {
             var _video = video;
             var _pm = pm;
-            video.addEventListener('canplay', function() {
-
-                j_video.fadeIn(parseInt(pm.time), function() {
-
+            video.addEventListener("canplay", function () {
+                j_video.fadeIn(parseInt(pm.time), function () {
                     that.kag.tmp.camera_stream = true;
 
                     if (pm.wait == "true" && pm.stop == "false") {
                         that.kag.ftag.nextOrder();
                     }
                     that.checkPicture(_video, _pm);
-
                 });
-
             });
-
         })();
 
         var opt = {
             video: true, //ビデオを取得する
-            audio: false //音声が必要な場合はture
+            audio: false, //音声が必要な場合はture
         };
 
         var audio = false;
@@ -198,9 +179,9 @@ tyrano.plugin.kag.tag.bgcamera = {
         var mode = "";
 
         if (pm.mode == "back") {
-            opt["video"] = { "facingMode": "environment" };
+            opt["video"] = { facingMode: "environment" };
         } else if (pm.mode == "front") {
-            opt["video"] = { "facingMode": "user" };
+            opt["video"] = { facingMode: "user" };
         }
 
         let j_video = $(video);
@@ -213,58 +194,49 @@ tyrano.plugin.kag.tag.bgcamera = {
 
         this.kag.stat.current_bgcamera = pm;
 
-
         $("#tyrano_base").append(j_video);
 
         var media = navigator.mediaDevices.getUserMedia(opt);
 
-
         //ストリーミング
         media.then((stream) => {
-
             video.srcObject = stream;
 
             video.onloadedmetadata = (e) => {
                 //this.checkPicture(video);
             };
-
         });
 
         if (pm.wait == "false" && pm.stop == "false") {
             that.kag.ftag.nextOrder();
         }
-
-
     },
 
-
-    checkPicture: function(video, pm) {
-
-
+    checkPicture: function (video, pm) {
         //カメラが非表示になったら停止させる。ストロングストップのときも停止
         if (this.kag.tmp.camera_stream == false) {
             return;
         }
 
-        if (this.kag.stat.qr.mode == "off" || this.kag.stat.is_strong_stop != true) {
-
+        if (
+            this.kag.stat.qr.mode == "off" ||
+            this.kag.stat.is_strong_stop != true
+        ) {
             setTimeout(() => {
                 this.checkPicture(video, pm);
             }, 1000);
 
             return;
-
         }
-
 
         var scWidth = parseInt(this.kag.config.scWidth) / 4;
         var scHeight = parseInt(this.kag.config.scHeight) / 4;
 
-        var canvas = document.createElement('canvas');
+        var canvas = document.createElement("canvas");
         canvas.width = scWidth;
         canvas.height = scHeight;
 
-        var ctx = canvas.getContext('2d');
+        var ctx = canvas.getContext("2d");
 
         // カメラの映像をCanvasに複写
         //ctx.fillRect(0, 0, w, h);
@@ -281,7 +253,6 @@ tyrano.plugin.kag.tag.bgcamera = {
         var mode = this.kag.stat.qr.mode;
 
         if (code) {
-
             var url = code.data;
 
             if (pm.debug == "true") {
@@ -291,10 +262,8 @@ tyrano.plugin.kag.tag.bgcamera = {
             if (url.indexOf("http") != -1) {
                 //webの場合かつ、QRコードが反応するようになってたら
                 if (mode == "all" || mode == "define" || mode == "web") {
-
                     //defineが存在したらジャンプに切り替える
                     if (this.kag.stat.qr.define[url]) {
-
                         var jump_pm = this.kag.stat.qr.define[url];
 
                         //[s]で止まってるときだけ有効
@@ -302,20 +271,14 @@ tyrano.plugin.kag.tag.bgcamera = {
                             this.kag.layer.showEventLayer();
                             this.kag.ftag.startTag("jump", jump_pm);
                         }
-
                     } else {
-
                         if (mode != "define") {
                             location.href = url;
                         }
                     }
-
                 }
-
             } else if (url.indexOf("tyrano:") != -1) {
-
                 if (mode == "all" || mode == "jump") {
-
                     var tmp = $.replaceAll(url, "tyrano://", "");
                     var tmp2 = $.getUrlQuery(tmp);
 
@@ -337,16 +300,11 @@ tyrano.plugin.kag.tag.bgcamera = {
                         this.kag.layer.showEventLayer();
                         this.kag.ftag.startTag("jump", jump_pm);
                     }
-
-
                 }
-
             } else if (url.indexOf("[jump") != -1) {
-
                 //文字列形式の場合
                 //[jump storage="scene1.ks" target="*test" ]
                 if (mode == "all" || mode == "jump") {
-
                     let obj = this.kag.parser.makeTag(url);
 
                     var jump_pm = obj.pm;
@@ -359,17 +317,12 @@ tyrano.plugin.kag.tag.bgcamera = {
                         this.kag.layer.showEventLayer();
                         this.kag.ftag.startTag("jump", jump_pm);
                     }
-
-
                 }
-
-
             }
 
             setTimeout(() => {
                 this.checkPicture(video, pm);
             }, 300);
-
         }
         //----------------------
         // 存在しない場合
@@ -380,12 +333,8 @@ tyrano.plugin.kag.tag.bgcamera = {
                 this.checkPicture(video, pm);
             }, 300);
         }
-
     },
-
-
 };
-
 
 /*
  #[qr_config ]
@@ -406,29 +355,22 @@ tyrano.plugin.kag.tag.bgcamera = {
  */
 
 tyrano.plugin.kag.tag.qr_config = {
-
     vital: [],
 
     pm: {
         qrcode: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         if (pm.qrcode != "") {
-
             this.kag.stat.qr.mode = pm.qrcode;
-
         }
 
         that.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
-
 
 /*
  #[stop_bgcamera]
@@ -447,38 +389,40 @@ tyrano.plugin.kag.tag.qr_config = {
  */
 
 tyrano.plugin.kag.tag.stop_bgcamera = {
-
     vital: [],
 
     pm: {
         time: "1000",
-        wait: "true"
+        wait: "true",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         that.kag.tmp.camera_stream = false;
 
-        $(".tyrano_base").find("#bgcamera").stop(true, true).fadeOut(parseInt(pm.time), function() {
+        $(".tyrano_base")
+            .find("#bgcamera")
+            .stop(true, true)
+            .fadeOut(parseInt(pm.time), function () {
+                $(this)[0]
+                    .srcObject.getVideoTracks()
+                    .forEach((track) => {
+                        track.stop();
+                    });
 
-            $(this)[0].srcObject.getVideoTracks().forEach((track) => {
-                track.stop();
+                $(this)[0]
+                    .srcObject.getAudioTracks()
+                    .forEach((track) => {
+                        track.stop();
+                    });
+
+                $(this).remove();
+
+                if (pm.wait == "true") {
+                    that.kag.ftag.nextOrder();
+                }
             });
-
-            $(this)[0].srcObject.getAudioTracks().forEach((track) => {
-                track.stop();
-            });
-
-
-            $(this).remove();
-
-            if (pm.wait == "true") {
-                that.kag.ftag.nextOrder();
-            }
-
-        });
 
         if (!$(".tyrano_base").find("#bgcamera").get(0)) {
             that.kag.ftag.nextOrder();
@@ -490,11 +434,8 @@ tyrano.plugin.kag.tag.stop_bgcamera = {
         }
 
         this.kag.stat.current_bgcamera = "";
-
-    }
+    },
 };
-
-
 
 /*
  #[qr_define]
@@ -518,7 +459,6 @@ tyrano.plugin.kag.tag.stop_bgcamera = {
  */
 
 tyrano.plugin.kag.tag.qr_define = {
-
     vital: ["url"],
 
     pm: {
@@ -526,26 +466,17 @@ tyrano.plugin.kag.tag.qr_define = {
         storage: "",
         target: "",
         clear: "false",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         if (pm["clear"] == "true") {
-
             delete this.kag.stat.qr.define[pm.url];
-
         } else {
-
             this.kag.stat.qr.define[pm.url] = pm;
-
         }
 
-
         that.kag.ftag.nextOrder();
-
-
-    }
+    },
 };

--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -34,7 +34,6 @@ volume=再生する音量を指定できます。0〜100 の範囲で指定し�
 
 //音楽再生
 tyrano.plugin.kag.tag.playbgm = {
-
     vital: ["storage"],
 
     pm: {
@@ -51,12 +50,10 @@ tyrano.plugin.kag.tag.playbgm = {
         html5: "false",
 
         click: "false", //音楽再生にクリックが必要か否か
-        stop: "false" //trueの場合自動的に次の命令へ移動しない。ロード対策
-
+        stop: "false", //trueの場合自動的に次の命令へ移動しない。ロード対策
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         if (pm.target == "bgm" && that.kag.stat.play_bgm == false) {
@@ -71,62 +68,41 @@ tyrano.plugin.kag.tag.playbgm = {
 
         //スマホアプリの場合
         if ($.userenv() != "pc") {
-
             this.kag.layer.hideEventLayer();
 
             if (this.kag.stat.is_skip == true && pm.target == "se") {
-
                 if (pm.stop == "false") {
                     that.kag.layer.showEventLayer();
                     that.kag.ftag.nextOrder();
                 }
-
             } else {
-
                 //スマホからのアクセスで ready audio 出来ていない場合は、クリックを挟む
                 if (this.kag.tmp.ready_audio == false) {
-
-                    $(".tyrano_base").on("click.bgm", function() {
-
+                    $(".tyrano_base").on("click.bgm", function () {
                         that.kag.readyAudio();
                         that.kag.tmp.ready_audio = true;
                         that.play(pm);
                         $(".tyrano_base").off("click.bgm");
-
                     });
-
                 } else {
-
                     that.play(pm);
-
                 }
-
             }
-
         } else {
-
             if (this.kag.tmp.ready_audio == false) {
-
-                $(".tyrano_base").on("click.bgm", function() {
-
+                $(".tyrano_base").on("click.bgm", function () {
                     that.kag.readyAudio();
                     that.kag.tmp.ready_audio = true;
                     that.play(pm);
                     $(".tyrano_base").off("click.bgm");
-
                 });
-
             } else {
                 that.play(pm);
             }
-
-
         }
-
     },
 
-    play: function(pm) {
-
+    play: function (pm) {
         var that = this;
 
         var target = "bgm";
@@ -155,7 +131,6 @@ tyrano.plugin.kag.tag.playbgm = {
                     }
                 }
             }
-
         } else {
             this.kag.tmp.is_audio_stopping = false;
             this.kag.tmp.is_bgm_play = true;
@@ -171,32 +146,35 @@ tyrano.plugin.kag.tag.playbgm = {
 
         //デフォルトで指定される値を設定
         if (target === "bgm") {
-
             if (typeof this.kag.config.defaultBgmVolume == "undefined") {
                 ratio = 1;
             } else {
-                ratio = parseFloat(parseInt(this.kag.config.defaultBgmVolume) / 100);
+                ratio = parseFloat(
+                    parseInt(this.kag.config.defaultBgmVolume) / 100,
+                );
             }
 
             //bufが指定されていて、かつ、デフォルトボリュームが指定されている場合は
             if (typeof this.kag.stat.map_bgm_volume[pm.buf] != "undefined") {
-                ratio = parseFloat(parseInt(this.kag.stat.map_bgm_volume[pm.buf]) / 100);
+                ratio = parseFloat(
+                    parseInt(this.kag.stat.map_bgm_volume[pm.buf]) / 100,
+                );
             }
-
-
         } else {
-
             if (typeof this.kag.config.defaultSeVolume == "undefined") {
                 ratio = 1;
             } else {
-                ratio = parseFloat(parseInt(this.kag.config.defaultSeVolume) / 100);
+                ratio = parseFloat(
+                    parseInt(this.kag.config.defaultSeVolume) / 100,
+                );
             }
 
             //bufが指定されていて、かつ、デフォルトボリュームが指定されている場合は
             if (typeof this.kag.stat.map_se_volume[pm.buf] != "undefined") {
-                ratio = parseFloat(parseInt(this.kag.stat.map_se_volume[pm.buf]) / 100);
+                ratio = parseFloat(
+                    parseInt(this.kag.stat.map_se_volume[pm.buf]) / 100,
+                );
             }
-
         }
 
         volume *= ratio;
@@ -228,13 +206,11 @@ tyrano.plugin.kag.tag.playbgm = {
         var audio_obj = null;
 
         var howl_opt = {
-
             src: storage_url,
-            volume: (volume),
+            volume: volume,
             onend: (e) => {
                 //this.j_btnPreviewBgm.parent().removeClass("soundOn");
-            }
-
+            },
         };
 
         //HTML5 audioを強制する
@@ -244,17 +220,15 @@ tyrano.plugin.kag.tag.playbgm = {
 
         //スプライトが指定されている場合
         if (pm.sprite_time != "") {
-
             let array_sprite = pm.sprite_time.split("-");
             let sprite_from = parseInt($.trim(array_sprite[0]));
             let sprite_to = parseInt($.trim(array_sprite[1]));
             let duration = sprite_to - sprite_from;
 
-            howl_opt["sprite"] = { "sprite_default": [sprite_from, duration, $.toBoolean(pm.loop)] };
-
+            howl_opt["sprite"] = {
+                sprite_default: [sprite_from, duration, $.toBoolean(pm.loop)],
+            };
         }
-
-
 
         audio_obj = new Howl(howl_opt);
 
@@ -265,7 +239,6 @@ tyrano.plugin.kag.tag.playbgm = {
         }
 
         if (target === "bgm") {
-
             if (this.kag.tmp.map_bgm[pm.buf]) {
                 this.kag.tmp.map_bgm[pm.buf].unload();
             }
@@ -274,8 +247,6 @@ tyrano.plugin.kag.tag.playbgm = {
             that.kag.stat.current_bgm = storage;
             that.kag.stat.current_bgm_vol = pm.volume;
             that.kag.stat.current_bgm_html5 = pm.html5;
-
-
         } else {
             //効果音の時はバッファ指定
             //すでにバッファが存在するなら、それを消す。
@@ -286,11 +257,9 @@ tyrano.plugin.kag.tag.playbgm = {
             }
 
             this.kag.tmp.map_se[pm.buf] = audio_obj;
-
         }
 
-
-        audio_obj.once("play", function() {
+        audio_obj.once("play", function () {
             that.kag.layer.showEventLayer();
             if (pm.stop == "false") {
                 that.kag.ftag.nextOrder();
@@ -304,46 +273,35 @@ tyrano.plugin.kag.tag.playbgm = {
         }
 
         if (pm.fadein == "true") {
-
             audio_obj.fade(0, volume, parseInt(pm.time));
-
         }
 
         //再生が完了した時
         if (pm.loop != "true") {
-
-            audio_obj.on("end", function(e) {
-
+            audio_obj.on("end", function (e) {
                 if (pm.target == "se") {
-
                     that.kag.tmp.is_se_play = false;
                     that.kag.tmp.is_vo_play = false;
 
                     if (that.kag.tmp.is_se_play_wait == true) {
                         that.kag.tmp.is_se_play_wait = false;
                         that.kag.ftag.nextOrder();
-
                     } else if (that.kag.tmp.is_vo_play_wait == true) {
                         that.kag.tmp.is_vo_play_wait = false;
-                        setTimeout(function() {
+                        setTimeout(function () {
                             that.kag.ftag.nextOrder();
                         }, 500);
                     }
-
                 } else if (pm.target == "bgm") {
-
                     that.kag.tmp.is_bgm_play = false;
 
                     if (that.kag.tmp.is_bgm_play_wait == true) {
                         that.kag.tmp.is_bgm_play_wait = false;
                         that.kag.ftag.nextOrder();
                     }
-
                 }
             });
         }
-
-
     },
 
     /*
@@ -424,7 +382,6 @@ tyrano.plugin.kag.tag.playbgm = {
     }
 
     */
-
 };
 
 /*
@@ -442,18 +399,15 @@ tyrano.plugin.kag.tag.playbgm = {
  */
 
 tyrano.plugin.kag.tag.stopbgm = {
-
     pm: {
         fadeout: "false",
         time: 2000,
         target: "bgm",
         buf: "0",
-        stop: "false" //trueの場合自動的に次の命令へ移動しない。ロード対策
-
+        stop: "false", //trueの場合自動的に次の命令へ移動しない。ロード対策
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         var target_map = null;
@@ -462,7 +416,6 @@ tyrano.plugin.kag.tag.stopbgm = {
             target_map = this.kag.tmp.map_bgm;
             that.kag.tmp.is_bgm_play = false;
             that.kag.tmp.is_bgm_play_wait = false;
-
         } else {
             target_map = this.kag.tmp.map_se;
 
@@ -475,7 +428,6 @@ tyrano.plugin.kag.tag.stopbgm = {
                 this.kag.stat.current_se = {};
             }
 
-
             if (pm.stop == "false") {
                 if (this.kag.stat.current_se[pm.buf]) {
                     delete this.kag.stat.current_se[pm.buf];
@@ -486,11 +438,8 @@ tyrano.plugin.kag.tag.stopbgm = {
         var browser = $.getBrowser();
 
         for (key in target_map) {
-
             if (key == pm.buf) {
-
-                (function() {
-
+                (function () {
                     var _key = key;
 
                     var _audio_obj = null;
@@ -503,32 +452,29 @@ tyrano.plugin.kag.tag.stopbgm = {
                             that.kag.stat.current_bgm = "";
                             that.kag.stat.current_bgm_vol = "";
                         }
-
                     } else {
                         _audio_obj = target_map[_key];
                     }
 
                     //フェードアウトしながら再生停止
                     if (pm.fadeout == "true") {
-
-                        _audio_obj.fade(_audio_obj.volume(), 0, parseInt(pm.time));
+                        _audio_obj.fade(
+                            _audio_obj.volume(),
+                            0,
+                            parseInt(pm.time),
+                        );
 
                         //fadeが完了した際にvolumeが0だったらstopを行う処理を追加
                         if (_audio_obj.playing()) {
-                            _audio_obj.once('fade', () => {
+                            _audio_obj.once("fade", () => {
                                 if (_audio_obj.volume() === 0) {
                                     _audio_obj.stop();
                                 }
                             });
                         }
-
-
                     } else {
-
                         _audio_obj.stop();
-
                     }
-
                 })();
             }
         }
@@ -536,7 +482,7 @@ tyrano.plugin.kag.tag.stopbgm = {
         if (pm.stop == "false") {
             this.kag.ftag.nextOrder();
         }
-    }
+    },
 };
 
 /*
@@ -562,7 +508,6 @@ tyrano.plugin.kag.tag.stopbgm = {
  */
 
 tyrano.plugin.kag.tag.fadeinbgm = {
-
     vital: ["storage", "time"],
 
     pm: {
@@ -571,16 +516,15 @@ tyrano.plugin.kag.tag.fadeinbgm = {
         fadein: "true",
         sprite_time: "", //200-544
         html5: "false",
-        time: 2000
+        time: 2000,
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         if (parseInt(pm.time) <= 100) {
             pm.time = 100;
         }
         this.kag.ftag.startTag("playbgm", pm);
-    }
+    },
 };
 
 /*
@@ -599,19 +543,18 @@ tyrano.plugin.kag.tag.fadeinbgm = {
  #[end]
  */
 tyrano.plugin.kag.tag.fadeoutbgm = {
-
     //vital:["time"],
 
     pm: {
         loop: "true",
         storage: "",
         fadeout: "true",
-        time: 2000
+        time: 2000,
     },
 
-    start: function(pm) {
+    start: function (pm) {
         this.kag.ftag.startTag("stopbgm", pm);
-    }
+    },
 };
 
 /*
@@ -635,7 +578,6 @@ tyrano.plugin.kag.tag.fadeoutbgm = {
  */
 
 tyrano.plugin.kag.tag.xchgbgm = {
-
     vital: ["storage", "time"],
 
     pm: {
@@ -643,15 +585,13 @@ tyrano.plugin.kag.tag.xchgbgm = {
         storage: "",
         fadein: "true",
         fadeout: "true",
-        time: 2000
+        time: 2000,
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.ftag.startTag("stopbgm", pm);
         this.kag.ftag.startTag("playbgm", pm);
-
-    }
+    },
 };
 
 /*
@@ -690,7 +630,6 @@ tyrano.plugin.kag.tag.xchgbgm = {
  */
 
 tyrano.plugin.kag.tag.playse = {
-
     vital: ["storage"],
 
     pm: {
@@ -701,23 +640,21 @@ tyrano.plugin.kag.tag.playse = {
         buf: "0",
         sprite_time: "", //200-544
         html5: "false",
-        clear: "false" //他のSEがなっている場合、それをキャンセルして、新しく再生します
+        clear: "false", //他のSEがなっている場合、それをキャンセルして、新しく再生します
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.layer.hideEventLayer();
 
         if (pm.clear == "true") {
             this.kag.ftag.startTag("stopbgm", {
                 target: "se",
-                stop: "true"
+                stop: "true",
             });
         }
 
         this.kag.ftag.startTag("playbgm", pm);
-
-    }
+    },
 };
 
 /*
@@ -736,18 +673,17 @@ tyrano.plugin.kag.tag.playse = {
  */
 
 tyrano.plugin.kag.tag.stopse = {
-
     pm: {
         storage: "",
         fadeout: "false",
         time: 2000,
         buf: "0",
-        target: "se"
+        target: "se",
     },
 
-    start: function(pm) {
+    start: function (pm) {
         this.kag.ftag.startTag("stopbgm", pm);
-    }
+    },
 };
 
 /*
@@ -772,7 +708,6 @@ tyrano.plugin.kag.tag.stopse = {
  */
 
 tyrano.plugin.kag.tag.fadeinse = {
-
     vital: ["storage", "time"],
 
     pm: {
@@ -784,19 +719,16 @@ tyrano.plugin.kag.tag.fadeinse = {
         buf: "0",
         sprite_time: "", //200-544
         html5: "false",
-        time: "2000"
-
+        time: "2000",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         if (parseInt(pm.time) <= 100) {
             pm.time = 100;
         }
 
         this.kag.ftag.startTag("playbgm", pm);
-
-    }
+    },
 };
 
 /*
@@ -816,20 +748,17 @@ tyrano.plugin.kag.tag.fadeinse = {
  */
 
 tyrano.plugin.kag.tag.fadeoutse = {
-
     pm: {
         storage: "",
         target: "se",
         loop: "false",
         buf: "0",
-        fadeout: "true"
+        fadeout: "true",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.ftag.startTag("stopbgm", pm);
-
-    }
+    },
 };
 
 /*
@@ -851,14 +780,13 @@ tyrano.plugin.kag.tag.fadeoutse = {
  */
 
 tyrano.plugin.kag.tag.bgmopt = {
-
     pm: {
         volume: "100",
         effect: "true",
-        buf: ""
+        buf: "",
     },
 
-    start: function(pm) {
+    start: function (pm) {
         //再生中のBGMに変更を加える
         var map_bgm = this.kag.tmp.map_bgm;
 
@@ -872,7 +800,6 @@ tyrano.plugin.kag.tag.bgmopt = {
 
         //すぐに反映 スマホアプリの場合はすぐに変更はできない
         if (pm.effect == "true" && this.kag.define.FLAG_APRI == false) {
-
             var new_volume = parseFloat(parseInt(pm.volume) / 100);
 
             if (pm.buf == "") {
@@ -886,17 +813,15 @@ tyrano.plugin.kag.tag.bgmopt = {
                     map_bgm[pm.buf].volume(new_volume);
                 }
             }
-
-
         }
 
         //this.kag.ftag.nextOrder();
 
         //この中でnextOrderしてる
-        this.kag.ftag.startTag("eval", { "exp": "sf._system_config_bgm_volume = " + pm.volume });
-
-
-    }
+        this.kag.ftag.startTag("eval", {
+            exp: "sf._system_config_bgm_volume = " + pm.volume,
+        });
+    },
 };
 
 /*
@@ -918,14 +843,13 @@ tyrano.plugin.kag.tag.bgmopt = {
  */
 
 tyrano.plugin.kag.tag.seopt = {
-
     pm: {
         volume: "100",
         effect: "true",
-        buf: ""
+        buf: "",
     },
 
-    start: function(pm) {
+    start: function (pm) {
         //再生中のBGMに変更を加える
         var map_se = this.kag.tmp.map_se;
 
@@ -939,12 +863,10 @@ tyrano.plugin.kag.tag.seopt = {
 
         //すぐに反映
         if (pm.effect == "true" && this.kag.define.FLAG_APRI == false) {
-
             var new_volume = parseFloat(parseInt(pm.volume) / 100);
 
             if (pm.buf == "") {
                 for (key in map_se) {
-
                     if (map_se[key]) {
                         map_se[key].volume(new_volume);
                     }
@@ -954,16 +876,15 @@ tyrano.plugin.kag.tag.seopt = {
                     map_se[pm.buf].volume(new_volume);
                 }
             }
-
         }
 
         //この中でnextOrderしてる
-        this.kag.ftag.startTag("eval", { "exp": "sf._system_config_se_volume = " + pm.volume });
-
+        this.kag.ftag.startTag("eval", {
+            exp: "sf._system_config_se_volume = " + pm.volume,
+        });
 
         //this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -983,11 +904,8 @@ BGMの再生完了を待ちます。playbgmでループ再生している場合�
 
 //BGMのフェード完了を待ちます
 tyrano.plugin.kag.tag.wbgm = {
-
-    pm: {
-    },
-    start: function() {
-
+    pm: {},
+    start: function () {
         //今、音楽再生中なら、
         if (this.kag.tmp.is_bgm_play == true) {
             //this.kag.layer.hideEventLayer();
@@ -995,8 +913,7 @@ tyrano.plugin.kag.tag.wbgm = {
         } else {
             this.kag.ftag.nextOrder();
         }
-
-    }
+    },
 };
 
 /*
@@ -1015,11 +932,8 @@ tyrano.plugin.kag.tag.wbgm = {
 */
 
 tyrano.plugin.kag.tag.wse = {
-
-    pm: {
-    },
-    start: function() {
-
+    pm: {},
+    start: function () {
         //今、音楽再生中なら、
 
         if (this.kag.tmp.is_se_play == true) {
@@ -1028,8 +942,7 @@ tyrano.plugin.kag.tag.wse = {
         } else {
             this.kag.ftag.nextOrder();
         }
-
-    }
+    },
 };
 
 /*
@@ -1077,30 +990,27 @@ number=デフォルトは０。vostorageで適応する数字をここで指定�
 */
 
 tyrano.plugin.kag.tag.voconfig = {
-
     pm: {
         sebuf: "0",
         name: "",
         vostorage: "",
-        number: ""
+        number: "",
     },
-    start: function(pm) {
-
+    start: function (pm) {
         var map_vo = this.kag.stat.map_vo;
 
         //ボイスバッファに指定する
         this.kag.stat.map_vo["vobuf"][pm.sebuf] = 1;
 
         if (pm.name != "") {
-
             var vochara = {};
             if (this.kag.stat.map_vo["vochara"][pm.name]) {
                 vochara = this.kag.stat.map_vo["vochara"][pm.name];
             } else {
                 vochara = {
-                    "vostorage": "",
-                    "buf": pm.sebuf,
-                    "number": 0
+                    vostorage: "",
+                    buf: pm.sebuf,
+                    number: 0,
                 };
             }
 
@@ -1113,16 +1023,11 @@ tyrano.plugin.kag.tag.voconfig = {
             }
 
             this.kag.stat.map_vo["vochara"][pm.name] = vochara;
-
         }
 
-
         this.kag.ftag.nextOrder();
-
-
-    }
+    },
 };
-
 
 /*
 #[vostart]
@@ -1143,15 +1048,11 @@ voconfigで指定したボイスの自動再生を開始します。
 */
 
 tyrano.plugin.kag.tag.vostart = {
-
-    pm: {
-    },
-    start: function() {
-
+    pm: {},
+    start: function () {
         this.kag.stat.vostart = true;
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -1169,18 +1070,12 @@ voconfigで指定したボイスの自動再生を停止します。
 */
 
 tyrano.plugin.kag.tag.vostop = {
-
-    pm: {
-    },
-    start: function() {
-
+    pm: {},
+    start: function () {
         this.kag.stat.vostart = false;
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
-
 
 /*
  #[speak_on]
@@ -1198,29 +1093,26 @@ tyrano.plugin.kag.tag.vostop = {
  */
 
 tyrano.plugin.kag.tag.speak_on = {
-
     vital: [],
 
     pm: {
-        volume: ""
+        volume: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
-        if ('speechSynthesis' in window) {
+        if ("speechSynthesis" in window) {
             that.kag.stat.play_speak = true;
         } else {
-            console.error("*error:この環境は[speak_on]の読み上げ機能に対応していません");
+            console.error(
+                "*error:この環境は[speak_on]の読み上げ機能に対応していません",
+            );
         }
 
         this.kag.ftag.nextOrder();
-
-
-    }
+    },
 };
-
 
 /*
  #[speak_off]
@@ -1239,20 +1131,16 @@ tyrano.plugin.kag.tag.speak_on = {
  */
 
 tyrano.plugin.kag.tag.speak_off = {
-
     vital: [],
 
     pm: {
-        volume: ""
+        volume: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         this.kag.stat.play_speak = false;
         this.kag.ftag.nextOrder();
-
-
-    }
+    },
 };

--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -1,12 +1,15 @@
 /*
 #[playbgm]
+
 :group
 オーディオ関連
+
 :title
 BGMの再生
+
 :exp
 BGMを再生します。
-再生するファイルはプロジェクトフォルダのbgmフォルダに格納してください。
+再生するファイルはbgmフォルダに格納してください。
 
 ogg形式、HTML5標準をサポートします。
 動作させる環境によって対応フォーマットが異なります。
@@ -14,7 +17,7 @@ ogg形式、HTML5標準をサポートします。
 基本的にogg形式を指定しておけば問題ありません。
 ただし、複数のブラウザ形式の場合、IEとSafariにも対応させるためには
 bgmフォルダに同名でaac形式(m4a)ファイルも配置して下さい。
-すると自動的に適切なファイルを選択して再生します。
+そうした場合、自動的に適切なファイルを選択して再生します。
 
 デフォルト設定ではmp3は再生できません。
 Confit.tjs の mediaFormatDefaultをmp3に変更して下さい。
@@ -22,10 +25,11 @@ Confit.tjs の mediaFormatDefaultをmp3に変更して下さい。
 
 :sample
 [playbgm storage="music.ogg"]
+
 :param
-storage=再生する音楽ファイルを指定してください,
-loop=true（デフォルト）またはfalse を指定してください。trueを指定すると繰り返し再生されます。,
-sprite_time=再生の開始時間と終了時間を指定することができます。ミリ秒で指定します。例えば 6000-10000 と指定すると 6:00〜10:00　の間のみ再生できます。loopがtrueの場合はこの間のみループ再生します。,
+storage=再生する音楽ファイルを指定します,
+loop=true（デフォルト）またはfalse を指定します。trueを指定すると繰り返し再生されます。,
+sprite_time=再生の開始時間と終了時間を指定できます。ミリ秒で指定します。例えば 6000-10000 と指定すると 6:00〜10:00　の間のみ再生できます。loopがtrueの場合はこの間のみループ再生します。,
 html5=true or falseを指定。デフォルトはfalse。trueを指定するとHTML5 Audioで再生します。通常はWeb Audio API での再生です。特に指示がない場合はそのままでOKです。,
 volume=再生する音量を指定できます。0〜100 の範囲で指定して下さい。（デフォルトは100）
 
@@ -385,18 +389,24 @@ tyrano.plugin.kag.tag.playbgm = {
 };
 
 /*
- #[stopbgm]
- :group
- オーディオ関連
- :title
- BGMの停止
- :exp
- 再生しているBGMの再生を停止します
- :sample
- [stopbgm ]
- :param
- #[end]
- */
+#[stopbgm]
+
+:group
+オーディオ関連
+
+:title
+BGMの停止
+
+:exp
+再生しているBGMの再生を停止します
+
+:sample
+[stopbgm ]
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.stopbgm = {
     pm: {
@@ -489,26 +499,31 @@ tyrano.plugin.kag.tag.stopbgm = {
 };
 
 /*
- #[fadeinbgm]
- :group
- オーディオ関連
- :title
- BGMをフェードイン再生
- :exp
- BGMを徐々に再生します。
- 一部環境（Firefox、Sarafi等）においては対応していません。その場合、playbgmの動作となります。
- :sample
- [fadeinbgm storage=sample.ogg loop=false time=3000]
- :param
- storage=再生する音楽ファイルを指定してください,
- loop=true（デフォルト）またはfalse を指定してください。trueを指定すると繰り返し再生されます,
- sprite_time=再生の開始時間と終了時間を指定することができます。ミリ秒で指定します。例えば 6000-10000 と指定すると 6:00〜10:00　の間のみ再生できます。loopがtrueの場合はこの間のみループ再生します。,
- html5=true or falseを指定。デフォルトはfalse。trueを指定するとHTML5 Audioで再生します。通常はWeb Audio API での再生です。特に指示がない場合はそのままでOKです。,
- time=フェードインを行なっている時間をミリ秒で指定します。,
- volume=BGMの再生音量を変更できます（0〜100）
+#[fadeinbgm]
 
- #[end]
- */
+:group
+オーディオ関連
+
+:title
+BGMをフェードイン再生
+
+:exp
+BGMを徐々に再生します。
+一部環境（Firefox、Sarafi等）においては対応していません。その場合、playbgmの動作となります。
+
+:sample
+[fadeinbgm storage=sample.ogg loop=false time=3000]
+
+:param
+storage=再生する音楽ファイルを指定します,
+loop=true（デフォルト）またはfalse を指定します。trueを指定すると繰り返し再生されます,
+sprite_time=再生の開始時間と終了時間を指定できます。ミリ秒で指定します。例えば 6000-10000 と指定すると 6:00〜10:00　の間のみ再生できます。loopがtrueの場合はこの間のみループ再生します。,
+html5=true or falseを指定。デフォルトはfalse。trueを指定するとHTML5 Audioで再生します。通常はWeb Audio API での再生です。特に指示がない場合はそのままでOKです。,
+time=フェードインを行なっている時間をミリ秒で指定します。,
+volume=BGMの再生音量を変更できます（0〜100）
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.fadeinbgm = {
     vital: ["storage", "time"],
@@ -531,20 +546,26 @@ tyrano.plugin.kag.tag.fadeinbgm = {
 };
 
 /*
- #[fadeoutbgm]
- :group
- オーディオ関連
- :title
- BGMをフェードアウト停止
- :exp
- 再生中のBGMをフェードアウトしながら停止します。
- 一部環境（Firefox、Sarafi等）においては対応していません。その場合、stopbgmの動作となります。
- :sample
- [fadeoutbgm  time=3000]
- :param
- time=フェードアウトを行なっている時間をミリ秒で指定します。
- #[end]
- */
+#[fadeoutbgm]
+
+:group
+オーディオ関連
+
+:title
+BGMをフェードアウト停止
+
+:exp
+再生中のBGMをフェードアウトしながら停止します。
+一部環境（Firefox、Sarafi等）においては対応していません。その場合、stopbgmの動作となります。
+
+:sample
+[fadeoutbgm  time=3000]
+
+:param
+time=フェードアウトを行なっている時間をミリ秒で指定します。
+
+#[end]
+*/
 tyrano.plugin.kag.tag.fadeoutbgm = {
     //vital:["time"],
 
@@ -561,24 +582,29 @@ tyrano.plugin.kag.tag.fadeoutbgm = {
 };
 
 /*
- #[xchgbgm]
- :group
- オーディオ関連
- :title
- 【非推奨】BGMのクロスフェード（入れ替え）
+#[xchgbgm]
 
- :exp
- 【非推奨】BGMを入れ替えます。
- 音楽が交差して切り替わる演出に使用できます。
- 一部環境（Firefox、Safari等）において対応していません。その場合、playbgmの動作となります。
- :sample
- [xchgbgm storage=new.ogg loop=true time=3000]
- :param
- storage=次に再生するファイルを指定してください,
- loop=true（デフォルト）またはfalse を指定してください。trueを指定すると繰り返し再生されます,
- time=クロスフェードを行なっている時間をミリ秒で指定します。
- #[end]
- */
+:group
+オーディオ関連
+
+:title
+【非推奨】BGMのクロスフェード（入れ替え）
+
+:exp
+【非推奨】BGMを入れ替えます。
+音楽が交差して切り替わる演出に使用できます。
+一部環境（Firefox、Safari等）において対応していません。その場合、playbgmの動作となります。
+
+:sample
+[xchgbgm storage=new.ogg loop=true time=3000]
+
+:param
+storage=次に再生するファイルを指定します,
+loop=true（デフォルト）またはfalse を指定します。trueを指定すると繰り返し再生されます,
+time=クロスフェードを行なっている時間をミリ秒で指定します。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.xchgbgm = {
     vital: ["storage", "time"],
@@ -598,39 +624,44 @@ tyrano.plugin.kag.tag.xchgbgm = {
 };
 
 /*
- #[playse]
- :group
- オーディオ関連
- :title
- 効果音の再生
- :exp
- 効果音を再生します
- 効果音ファイルはプロジェクトフォルダのsoundフォルダに入れてください
+#[playse]
 
- ogg形式、HTML5標準をサポートします。
- 動作させる環境によって対応フォーマットが異なります。
+:group
+オーディオ関連
 
- 基本的にogg形式を指定しておけば問題ありません。
- ただし、複数のブラウザ形式の場合、IEとSafariにも対応させるためには
- bgmフォルダに同名でaac形式(m4a)ファイルも配置して下さい。
- すると自動的に適切なファイルを選択して再生します。
+:title
+効果音の再生
 
- デフォルト設定ではmp3は再生できません。
- Confit.tjs の mediaFormatDefaultをmp3に変更して下さい。
- ただしこの場合 PCアプリとしては動作しません
+:exp
+効果音を再生します。
+効果音ファイルはdata/soundフォルダに入れてください。
 
- :sample
- [playse storage=sound.ogg loop=false ]
- :param
- storage=再生するファイルを指定してください,
- buf=効果音を再生するスロットを指定できます。デフォルトは0,
- loop=trueまたはfalse （デフォルト）を指定してください。trueを指定すると繰り返し再生されます,
- sprite_time=再生の開始時間と終了時間を指定することができます。ミリ秒で指定します。例えば 6000-10000 と指定すると 6:00〜10:00　の間のみ再生できます。loopがtrueの場合はこの間のみループ再生します。,
- clear=trueまたはfalse(デフォルト) 他のSEが鳴っている場合、trueだと他のSEを停止した後、再生します。音声などはtrueが便利でしょう,
- html5=true or falseを指定。デフォルトはfalse。trueを指定するとHTML5 Audioで再生します。通常はWeb Audio API での再生です。特に指示がない場合はそのままでOKです。,
- volume=効果音の再生音量を変更できます（0〜100）
- #[end]
- */
+ogg形式、HTML5標準をサポートします。
+動作させる環境によって対応フォーマットが異なります。
+
+基本的にogg形式を指定しておけば問題ありません。
+ただし、複数のブラウザ形式の場合、IEとSafariにも対応させるためには
+同じ場所に同名のAAC形式（m4a）ファイルを配置して下さい。
+そうした場合、自動的に適切なファイルが選択されます。
+
+デフォルト設定ではmp3は再生できません。
+Confit.tjsのmediaFormatDefaultをmp3に変更して下さい。
+ただしそうした場合、PCアプリとしては動作しません。
+
+:sample
+[playse storage=sound.ogg loop=false ]
+
+:param
+storage=再生するファイルを指定します,
+buf=効果音を再生するスロットを指定できます。デフォルトは0,
+loop=trueまたはfalse （デフォルト）を指定できます。trueを指定すると繰り返し再生されます,
+sprite_time=再生の開始時間と終了時間を指定できます。ミリ秒で指定します。例えば 6000-10000 と指定すると 6:00〜10:00　の間のみ再生できます。loopがtrueの場合はこの間のみループ再生します。,
+clear=trueまたはfalse(デフォルト) 他のSEが鳴っている場合、trueだと他のSEを停止した後、再生します。音声などはtrueが便利でしょう,
+html5=true or falseを指定。デフォルトはfalse。trueを指定するとHTML5 Audioで再生します。通常はWeb Audio API での再生です。特に指示がない場合はそのままでOKです。,
+volume=効果音の再生音量を変更できます（0〜100）
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.playse = {
     vital: ["storage"],
@@ -662,19 +693,25 @@ tyrano.plugin.kag.tag.playse = {
 };
 
 /*
- #[stopse]
- :group
- オーディオ関連
- :title
- 効果音の停止
- :exp
- 効果音を再生を停止します
- :sample
- [stopse ]
- :param
- buf=効果音を停止するスロットを指定できます。デフォルトは0
- #[end]
- */
+#[stopse]
+
+:group
+オーディオ関連
+
+:title
+効果音の停止
+
+:exp
+効果音を再生を停止します。
+
+:sample
+[stopse ]
+
+:param
+buf=効果音を停止するスロットを指定できます。デフォルトは0。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.stopse = {
     pm: {
@@ -691,25 +728,30 @@ tyrano.plugin.kag.tag.stopse = {
 };
 
 /*
- #[fadeinse]
- :group
- オーディオ関連
- :title
- 効果音のフェードイン
- :exp
- です。stopse を使用して下さい
- 効果音をフェードインしながら再生します
- :sample
- [fadeinse storage=sound.ogg loop=false time=2000 ]
- :param
- storage=次に再生するファイルを指定してください,
- loop=trueまたはfalse （デフォルト）を指定してください。trueを指定すると繰り返し再生されます,
- sprite_time=再生の開始時間と終了時間を指定することができます。ミリ秒で指定します。例えば 6000-10000 と指定すると 6:00〜10:00　の間のみ再生できます。loopがtrueの場合はこの間のみループ再生します。,
- buf=効果音を停止するスロットを指定できます。デフォルトは0,
- html5=true or falseを指定。デフォルトはfalse。trueを指定するとHTML5 Audioで再生します。通常はWeb Audio API での再生です。特に指示がない場合はそのままでOKです。,
- time=フェードインの時間をミリ秒で指定します
- #[end]
- */
+#[fadeinse]
+
+:group
+オーディオ関連
+
+:title
+効果音のフェードイン
+
+:exp
+効果音をフェードインしながら再生します。
+
+:sample
+[fadeinse storage=sound.ogg loop=false time=2000 ]
+
+:param
+storage=次に再生するファイルを指定します。,
+loop=trueまたはfalseを指定します。trueを指定すると繰り返し再生されます。デフォルトはfalse。,
+sprite_time=再生の開始時間と終了時間をミリ秒で指定します。たとえば 6000-10000 と指定すると 6:00〜10:00　の間のみ再生できます。loopがtrueの場合はこの間のみループ再生します。,
+buf=効果音を停止するスロットを指定できます。デフォルトは0,
+html5=true or falseを指定。デフォルトはfalse。trueを指定するとHTML5 Audioで再生します。通常はWeb Audio API での再生です。特に指示がない場合はそのままでOKです。,
+time=フェードインの時間をミリ秒で指定します
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.fadeinse = {
     vital: ["storage", "time"],
@@ -736,20 +778,26 @@ tyrano.plugin.kag.tag.fadeinse = {
 };
 
 /*
- #[fadeoutse]
- :group
- オーディオ関連
- :title
- 効果音の停止
- :exp
- 効果音をフェードアウトします
- :sample
- [fadeoutse time=2000 ]
- :param
- time=フェードアウトを行なっている時間をミリ秒で指定します。
- buf=効果音を停止するスロットを指定できます。デフォルトは0,
- #[end]
- */
+#[fadeoutse]
+
+:group
+オーディオ関連
+
+:title
+効果音の停止
+
+:exp
+効果音をフェードアウトします
+
+:sample
+[fadeoutse time=2000 ]
+
+:param
+time=フェードアウトを行なっている時間をミリ秒で指定します。
+buf=効果音を停止するスロットを指定できます。デフォルトは0,
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.fadeoutse = {
     pm: {
@@ -766,22 +814,28 @@ tyrano.plugin.kag.tag.fadeoutse = {
 };
 
 /*
- #[bgmopt]
- :group
- オーディオ関連
- :title
- BGM設定
- :exp
- BGMの設定を変更できます
- 音量設定については スマートフォンブラウザからの閲覧の場合、端末の制限により変更できません。
- :sample
- [bgmopt volume=50 ]
- :param
- volume=BGMの再生音量を変更できます（0〜100）,
- effect=true false を指定して下さい（デフォルトはtrue） trueだと再生中のBGMに即反映します,
- buf=設定を変更するスロットを指定できます。指定がない場合はすべてのスロットが対象になります
- #[end]
- */
+#[bgmopt]
+
+:group
+オーディオ関連
+
+:title
+BGM設定
+
+:exp
+BGMの設定を変更できます
+音量設定については スマートフォンブラウザからの閲覧の場合、端末の制限により変更できません。
+
+:sample
+[bgmopt volume=50 ]
+
+:param
+volume=BGMの再生音量を変更できます（0〜100）,
+effect=true false を指定して下さい（デフォルトはtrue） trueだと再生中のBGMに即反映します,
+buf=設定を変更するスロットを指定できます。指定がない場合はすべてのスロットが対象になります
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.bgmopt = {
     pm: {
@@ -829,22 +883,28 @@ tyrano.plugin.kag.tag.bgmopt = {
 };
 
 /*
- #[seopt]
- :group
- オーディオ関連
- :title
- SE設定
- :exp
- SEの設定を変更できます
- 音量設定については スマートフォンブラウザからの閲覧の場合、端末の制限により変更できません。
- :sample
- [seopt volume=50 ]
- :param
- volume=SEの再生音量を変更できます（0〜100）,
- effect=true false を指定して下さい（デフォルトはtrue） trueだと再生中のBGMに即反映します,
- buf=設定を変更するスロットを指定できます。指定がない場合はすべてのスロットが対象になります
- #[end]
- */
+#[seopt]
+
+:group
+オーディオ関連
+
+:title
+SE設定
+
+:exp
+SEの設定を変更できます
+音量設定については スマートフォンブラウザからの閲覧の場合、端末の制限により変更できません。
+
+:sample
+[seopt volume=50 ]
+
+:param
+volume=SEの再生音量を変更できます（0〜100）,
+effect=true false を指定して下さい（デフォルトはtrue） trueだと再生中のBGMに即反映します,
+buf=設定を変更するスロットを指定できます。指定がない場合はすべてのスロットが対象になります
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.seopt = {
     pm: {
@@ -893,16 +953,22 @@ tyrano.plugin.kag.tag.seopt = {
 
 /*
 #[wbgm]
+
 :group
 オーディオ関連
+
 :title
 BGMの再生完了を待つ
+
 :exp
 BGMの再生完了を待ちます。playbgmでループ再生している場合は永遠に止まりますのでご注意下さい。
 このタグはPCゲーム、ブラウザゲームで利用できます。
 スマホアプリでは利用できませんのでご注意ください。
+
 :sample
+
 :param
+
 #[end]
 */
 
@@ -922,16 +988,22 @@ tyrano.plugin.kag.tag.wbgm = {
 
 /*
 #[wse]
+
 :group
 オーディオ関連
+
 :title
 効果音の再生完了を待つ
+
 :exp
 効果音の再生完了を待ちます。
 このタグはPCゲーム、ブラウザゲームで利用できます。
 スマホアプリでは利用できませんのでご注意ください。
+
 :sample
+
 :param
+
 #[end]
 */
 
@@ -951,10 +1023,13 @@ tyrano.plugin.kag.tag.wse = {
 
 /*
 #[voconfig]
+
 :group
 オーディオ関連
+
 :title
 ボイスの再生設定
+
 :exp
 ボイスを効率的に再生するための設定ができます。
 キャラクター名と音声ファイル名を関連させておくことで
@@ -981,14 +1056,13 @@ tyrano.plugin.kag.tag.wse = {
 あかねの音声再生(akane_3.ogg)[p]
 
 :param
-sebuf=ボイスで使用するplayseのbufを指定してください,
+sebuf=ボイスで使用するplayseのbufを指定します,
 name=ボイスを再生するキャラクター名を指定します。[chara_new ]タグのnameパラメータです,
 vostorage=音声ファイルとして使用するファイル名のテンプレートを指定します。{number}の部分に再生されることに+1された数字が入っていきます,
 number=デフォルトは０。vostorageで適応する数字をここで指定した値にリセットできます
 
 :demo
 2,kaisetsu/19_voconfig
-
 
 #[end]
 */
@@ -1035,14 +1109,19 @@ tyrano.plugin.kag.tag.voconfig = {
 
 /*
 #[vostart]
+
 :group
 オーディオ関連
+
 :title
 ボイス自動再生開始
+
 :exp
 voconfigで指定したボイスの自動再生を開始します。
 コレ以降、#で名前を指定した場合、紐付いたボイスが再生されていきます。
+
 :sample
+
 :param
 
 :demo
@@ -1061,15 +1140,21 @@ tyrano.plugin.kag.tag.vostart = {
 
 /*
 #[vostop]
+
 :group
 オーディオ関連
+
 :title
 ボイス自動再生停止
+
 :exp
 voconfigで指定したボイスの自動再生を停止します。
 コレ以降、#で名前を指定しても、ボイスが紐付いて再生されることを防ぎます。
+
 :sample
+
 :param
+
 #[end]
 */
 
@@ -1082,19 +1167,25 @@ tyrano.plugin.kag.tag.vostop = {
 };
 
 /*
- #[speak_on]
- :group
- オーディオ関連
- :title
- 読み上げ機能の有効化
- :exp
- ストーリーのシナリオを音声で読み上げることができます。
- :sample
- [speak_on ]
- :param
- volume=読み上げのボリュームを設定できます(まだ実装)。
- #[end]
- */
+#[speak_on]
+
+:group
+オーディオ関連
+
+:title
+読み上げ機能の有効化
+
+:exp
+ストーリーのシナリオを音声で読み上げることができます。
+
+:sample
+[speak_on ]
+
+:param
+volume=読み上げのボリュームを設定できます(まだ実装)。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.speak_on = {
     vital: [],
@@ -1119,20 +1210,26 @@ tyrano.plugin.kag.tag.speak_on = {
 };
 
 /*
- #[speak_off]
- :group
- オーディオ関連
- :title
- 読み上げ機能の無効化
- :exp
- シナリオの読み上げをオフにします。
- ＊ブラウザのみ動作。PC版パッケージ版では動作しません。
- :sample
- [speak_off ]
- :param
- volume=読み上げのボリュームを設定できます。
- #[end]
- */
+#[speak_off]
+
+:group
+オーディオ関連
+
+:title
+読み上げ機能の無効化
+
+:exp
+シナリオの読み上げをオフにします。
+＊ブラウザのみ動作。PC版パッケージ版では動作しません。
+
+:sample
+[speak_off ]
+
+:param
+volume=読み上げのボリュームを設定できます。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.speak_off = {
     vital: [],

--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -404,6 +404,7 @@ tyrano.plugin.kag.tag.stopbgm = {
         time: 2000,
         target: "bgm",
         buf: "0",
+        buf_all: "false",
         stop: "false", //trueの場合自動的に次の命令へ移動しない。ロード対策
     },
 
@@ -438,7 +439,9 @@ tyrano.plugin.kag.tag.stopbgm = {
         var browser = $.getBrowser();
 
         for (key in target_map) {
-            if (key == pm.buf) {
+            // pm.buf_allが"true"の場合はpm.bufを見ずにすべてのスロットの効果音を止める
+            // [playse ... clear="true"]の内部で[stopbgm]が呼び出されたときはpm.buf_allに"true"が入っている
+            if (pm.buf_all === "true" || key == pm.buf) {
                 (function () {
                     var _key = key;
 
@@ -650,6 +653,7 @@ tyrano.plugin.kag.tag.playse = {
             this.kag.ftag.startTag("stopbgm", {
                 target: "se",
                 stop: "true",
+                buf_all: "true",
             });
         }
 

--- a/tyrano/plugins/kag/kag.tag_camera.js
+++ b/tyrano/plugins/kag/kag.tag_camera.js
@@ -1,4 +1,3 @@
-
 /*
  #[camera]
  :group
@@ -58,13 +57,10 @@
  #[end]
  */
 
-
 tyrano.plugin.kag.tag.camera = {
-
     vital: [],
 
     pm: {
-
         time: 1000,
 
         from_x: "0",
@@ -79,12 +75,10 @@ tyrano.plugin.kag.tag.camera = {
         layer: "layer_camera",
 
         wait: "true",
-        ease_type: "ease"
-
-
+        ease_type: "ease",
     },
 
-    start: function(pm) {
+    start: function (pm) {
         var that = this;
 
         /*
@@ -102,11 +96,15 @@ tyrano.plugin.kag.tag.camera = {
                 x: "0",
                 y: "0",
                 scale: "1",
-                rotate: "0"
+                rotate: "0",
             };
         }
 
-        var to_camera = $.extend(true, {}, this.kag.stat.current_camera[pm.layer]);
+        var to_camera = $.extend(
+            true,
+            {},
+            this.kag.stat.current_camera[pm.layer],
+        );
 
         //指定されて項目があるなら、上書きする
         if (pm.x != "") to_camera.x = parseInt(pm.x) * -1 + "px";
@@ -114,16 +112,18 @@ tyrano.plugin.kag.tag.camera = {
         if (pm.zoom != "") to_camera.scale = pm.zoom;
         if (pm.rotate != "") to_camera.rotate = pm.rotate + "deg";
 
-
-        if (pm.from_x != "0" || pm.from_y != "0" || pm.from_zoom != "1" || pm.from_rotate != "0") {
-
+        if (
+            pm.from_x != "0" ||
+            pm.from_y != "0" ||
+            pm.from_zoom != "1" ||
+            pm.from_rotate != "0"
+        ) {
             this.kag.stat.current_camera[pm.layer] = {
                 x: parseInt(pm.from_x) * -1 + "px",
                 y: parseInt(pm.from_y) * 1 + "px",
                 scale: pm.from_zoom,
-                rotate: pm.from_rotate + "deg"
+                rotate: pm.from_rotate + "deg",
             };
-
         }
 
         var flag_complete = false;
@@ -131,42 +131,38 @@ tyrano.plugin.kag.tag.camera = {
 
         var a3d_define = {
             frames: {
-
                 "0%": {
-                    trans: this.kag.stat.current_camera[pm.layer]
+                    trans: this.kag.stat.current_camera[pm.layer],
                 },
                 "100%": {
-                    trans: to_camera
-                }
+                    trans: to_camera,
+                },
             },
 
             config: {
                 duration: duration,
                 state: "running",
-                easing: pm.ease_type
+                easing: pm.ease_type,
             },
 
-            complete: function() {
+            complete: function () {
                 //アニメーションが完了しないと次へはいかない
                 if (pm.wait == "true" && flag_complete == false) {
                     flag_complete = true; //最初の一回だけwait有効
 
-                    setTimeout(function() {
+                    setTimeout(function () {
                         that.kag.ftag.nextOrder();
                     }, 300);
-
                 } else {
-
                     //カメラを待ってる状態なら
                     if (that.kag.stat.is_wait_camera == true) {
                         that.kag.stat.is_wait_camera = false;
                         that.kag.ftag.nextOrder();
                     }
-
                 }
 
                 that.kag.stat.is_move_camera = false;
-            }
+            },
         };
 
         this.kag.stat.current_camera[pm.layer] = to_camera;
@@ -181,16 +177,16 @@ tyrano.plugin.kag.tag.camera = {
             $(".layer_camera").a3d(a3d_define);
             this.kag.stat.current_camera_layer = "";
         } else {
-            $("." + pm.layer + "_fore").css("-webkit-transform-origin", "center center");
+            $("." + pm.layer + "_fore").css(
+                "-webkit-transform-origin",
+                "center center",
+            );
             $("." + pm.layer + "_fore").a3d(a3d_define);
             this.kag.stat.current_camera_layer = pm.layer;
         }
-
     },
 
-    play: function(obj, cb) {
-
-    }
+    play: function (obj, cb) {},
 };
 
 /*
@@ -216,22 +212,18 @@ tyrano.plugin.kag.tag.camera = {
  #[end]
  */
 
-
 tyrano.plugin.kag.tag.reset_camera = {
-
     vital: [],
 
     pm: {
-
         time: 1000,
 
         wait: "true",
         ease_type: "ease",
-        layer: "layer_camera"
-
+        layer: "layer_camera",
     },
 
-    start: function(pm) {
+    start: function (pm) {
         var that = this;
         //duration を確認する
 
@@ -247,7 +239,7 @@ tyrano.plugin.kag.tag.reset_camera = {
             x: "0px",
             y: "0px",
             scale: "1",
-            rotate: "0deg"
+            rotate: "0deg",
         };
 
         var flag_complete = false;
@@ -256,23 +248,21 @@ tyrano.plugin.kag.tag.reset_camera = {
 
         var a3d_define = {
             frames: {
-
                 "0%": {
-                    trans: this.kag.stat.current_camera[pm.layer]
+                    trans: this.kag.stat.current_camera[pm.layer],
                 },
                 "100%": {
-                    trans: to_camera
-                }
+                    trans: to_camera,
+                },
             },
 
             config: {
                 duration: duration,
                 state: "running",
-                easing: pm.ease_type
+                easing: pm.ease_type,
             },
 
-            complete: function() {
-
+            complete: function () {
                 //リセットした時は、本当に消す
                 $("." + pm.layer).css({
                     "-animation-name": "",
@@ -283,7 +273,7 @@ tyrano.plugin.kag.tag.reset_camera = {
                     "-animation-direction": "",
                     "-animation-fill-mode": "",
                     "-animation-timing-function": "",
-                    "transform": ""
+                    "transform": "",
                 });
 
                 //アニメーションが完了しないと次へはいかない
@@ -291,19 +281,15 @@ tyrano.plugin.kag.tag.reset_camera = {
                     flag_complete = true; //最初の一回だけwait有効
                     that.kag.ftag.nextOrder();
                 } else {
-
                     //カメラを待ってる状態なら
                     if (that.kag.stat.is_wait_camera == true) {
                         that.kag.stat.is_wait_camera = false;
                         that.kag.ftag.nextOrder();
                     }
-
                 }
 
-
                 that.kag.stat.is_move_camera = false;
-
-            }
+            },
         };
 
         if (pm.layer != "layer_camera") {
@@ -323,20 +309,17 @@ tyrano.plugin.kag.tag.reset_camera = {
             $(".layer_camera").a3d(a3d_define);
             this.kag.stat.current_camera_layer = "";
         } else {
-            $("." + pm.layer + "_fore").css("-webkit-transform-origin", "center center");
+            $("." + pm.layer + "_fore").css(
+                "-webkit-transform-origin",
+                "center center",
+            );
             $("." + pm.layer + "_fore").a3d(a3d_define);
             this.kag.stat.current_camera_layer = "";
         }
-
-
     },
 
-    play: function(obj, cb) {
-
-    }
+    play: function (obj, cb) {},
 };
-
-
 
 /*
  #[wait_camera]
@@ -366,8 +349,7 @@ tyrano.plugin.kag.tag.reset_camera = {
  */
 
 tyrano.plugin.kag.tag.wait_camera = {
-    start: function(pm) {
-
+    start: function (pm) {
         //今、カメラ中なら待つ
         if (this.kag.stat.is_move_camera == true) {
             //this.kag.layer.hideEventLayer();
@@ -375,7 +357,7 @@ tyrano.plugin.kag.tag.wait_camera = {
         } else {
             this.kag.ftag.nextOrder();
         }
-    }
+    },
 };
 
 /*
@@ -439,23 +421,18 @@ folder=graphicで指定するフォルダをimage以外に変更したい場合�
  #[end]
  */
 
-
 tyrano.plugin.kag.tag.mask = {
-
     vital: [],
 
     pm: {
-
         time: 1000,
         effect: "fadeIn",
         color: "0x000000",
         graphic: "",
-        folder: ""
-
+        folder: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
         that.kag.layer.hideEventLayer();
 
@@ -463,7 +440,11 @@ tyrano.plugin.kag.tag.mask = {
             pm.time = "1";
         }
 
-        var j_div = $("<div class='layer layer_mask' data-effect='" + pm.effect + "' style='z-index:100000000;position:absolute;'>");
+        var j_div = $(
+            "<div class='layer layer_mask' data-effect='" +
+                pm.effect +
+                "' style='z-index:100000000;position:absolute;'>",
+        );
         j_div.css("animation-duration", parseInt(pm.time) + "ms");
 
         var sc_width = parseInt(that.kag.config.scWidth);
@@ -496,7 +477,6 @@ tyrano.plugin.kag.tag.mask = {
 
             //画像が設定されている場合
             behind = true;
-
         }
 
         //外に線が見える対応
@@ -506,8 +486,9 @@ tyrano.plugin.kag.tag.mask = {
 
         $(".tyrano_base").append(j_div);
 
-        var animationEnd = 'webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend';
-        j_div.addClass('animated ' + pm.effect).one(animationEnd, function() {
+        var animationEnd =
+            "webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend";
+        j_div.addClass("animated " + pm.effect).one(animationEnd, function () {
             //$(this).removeClass('animated ' + pm.effect);
 
             if (behind == false) {
@@ -516,8 +497,7 @@ tyrano.plugin.kag.tag.mask = {
 
             that.kag.ftag.nextOrder();
         });
-
-    }
+    },
 };
 
 /*
@@ -575,19 +555,15 @@ bounceOutUp
  #[end]
  */
 
-
 tyrano.plugin.kag.tag.mask_off = {
-
     vital: [],
 
     pm: {
-
         time: 1000,
-        effect: "fadeOut"
-
+        effect: "fadeOut",
     },
 
-    start: function(pm) {
+    start: function (pm) {
         var that = this;
         var j_div = $(".layer_mask");
 
@@ -598,24 +574,22 @@ tyrano.plugin.kag.tag.mask_off = {
         $("#root_layer_game").css("opacity", 1);
 
         if (j_div.get(0)) {
-
             var _effect = j_div.attr("data-effect");
-            j_div.removeClass('animated ' + _effect);
+            j_div.removeClass("animated " + _effect);
             j_div.css("animation-duration", parseInt(pm.time) + "ms");
 
-            var animationEnd = 'webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend';
-            j_div.addClass('animated ' + pm.effect).one(animationEnd, function() {
-                j_div.remove();
-                that.kag.layer.showEventLayer();
-                that.kag.ftag.nextOrder();
-            });
-
+            var animationEnd =
+                "webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend";
+            j_div
+                .addClass("animated " + pm.effect)
+                .one(animationEnd, function () {
+                    j_div.remove();
+                    that.kag.layer.showEventLayer();
+                    that.kag.ftag.nextOrder();
+                });
         } else {
             that.kag.layer.showEventLayer();
             that.kag.ftag.nextOrder();
         }
-
-    }
-
-
+    },
 };

--- a/tyrano/plugins/kag/kag.tag_camera.js
+++ b/tyrano/plugins/kag/kag.tag_camera.js
@@ -1,28 +1,31 @@
 /*
- #[camera]
- :group
- カメラ操作
- :title
- カメラを移動する
- :exp
- カメラをズームやパンさせる演出を追加できます。
- この機能を使うと、立ち絵のキャラクター表情にフォーカスをあてたり
- 一枚絵であっても多彩な演出が可能になります。
+#[camera]
 
- カメラ機能を使用するにはConfig.tjs の useCameraをtrueにする必要があります。
- また、カメラ機能を有効にした場合、画面の中央寄せ（ScreenCentering）が無効になります。
+:group
+カメラ操作
 
- カメラの座標は画面中央が(x:0,y:0)です。
- 例えば、画面右上は x:200 y:200 　画面左下は x:-200 y:-200 という座標指定になります。
+:title
+カメラを移動する
 
- カメラを元の位置に戻すためには[reset_camera]タグを使用します。
- カメラの演出完了を待ちたい場合は[wait_camera]タグを使用します。
+:exp
+カメラをズームやパンさせる演出を追加できます。
+この機能を使うと、立ち絵のキャラクター表情にフォーカスをあてたり
+一枚絵であっても多彩な演出が可能になります。
 
- 【重要】
- カメラ演出が終わったら、必ず[reset_camera]でカメラの位置を初期値に戻して下さい。
- カメラを戻さないと、背景の変更 [bg]タグ等は使用できません。
+カメラ機能を使用するにはConfig.tjs の useCameraをtrueにする必要があります。
+また、カメラ機能を有効にした場合、画面の中央寄せ（ScreenCentering）が無効になります。
 
- :sample
+カメラの座標は画面中央が(x:0,y:0)です。
+例えば、画面右上は x:200 y:200 　画面左下は x:-200 y:-200 という座標指定になります。
+
+カメラを元の位置に戻すためには[reset_camera]タグを使用します。
+カメラの演出完了を待ちたい場合は[wait_camera]タグを使用します。
+
+【重要】
+カメラ演出が終わったら、必ず[reset_camera]でカメラの位置を初期値に戻して下さい。
+カメラを戻さないと、背景の変更 [bg]タグ等は使用できません。
+
+:sample
 
 @camera zoom=2 x=180 y=100 time=1000
 @camera x=-180 y=100 time=2000
@@ -31,31 +34,31 @@
 ;カメラの位置を元に戻す
 @reset_camera
 
- :param
- time=カメラが座標へ移動する時間を指定できます。ミリ秒で指定して下さい。デフォルトは1000,
- x=カメラの移動するX座標を指定して下さい,
- y=カメラの移動するY座標を指定して下さい,
- zoom=カメラの拡大率を指定して下さい。例えば２と指定すると２倍ズームします,
- rotate=カメラの傾きを指定します。例えば20 だとカメラが20度傾きます。,
- from_x=カメラの移動開始時のX座標を指定できます,
- from_y=カメラの移動開始時のY座標を指定できます,
- from_zoom=カメラの移動開始時の倍率を指定できます,
- from_rotate=カメラの移動開始時の傾きを指定できます,
- wait=カメラ移動の完了を待つかどうかを指定します。falseを指定するとカメラ移動中もゲームを進行することができます。デフォルトはtrue,
- layer=レイヤを指定します。背景ならbase 前景レイヤならう 0以上の数字。カメラの効果を特定レイヤだけに適応できます。,　
- ease_type=カメラの移動演出を指定できます。
- ease(開始時点と終了時点を滑らかに再生する)
- linear(一定の間隔で再生する)
- ease-in(開始時点をゆっくり再生する)
- ease-out(終了時点をゆっくり再生する)
- ease-in-out(開始時点と終了時点をゆっくり再生する)
- デフォルトはeaseです。
+:param
+time=カメラが座標へ移動する時間を指定できます。ミリ秒で指定して下さい。デフォルトは1000,
+x=カメラの移動するX座標を指定して下さい,
+y=カメラの移動するY座標を指定して下さい,
+zoom=カメラの拡大率を指定して下さい。例えば２と指定すると２倍ズームします,
+rotate=カメラの傾きを指定します。例えば20 だとカメラが20度傾きます。,
+from_x=カメラの移動開始時のX座標を指定できます,
+from_y=カメラの移動開始時のY座標を指定できます,
+from_zoom=カメラの移動開始時の倍率を指定できます,
+from_rotate=カメラの移動開始時の傾きを指定できます,
+wait=カメラ移動の完了を待つかどうかを指定します。falseを指定するとカメラ移動中もゲームを進行できます。デフォルトはtrue,
+layer=レイヤを指定します。背景ならbase 前景レイヤならう 0以上の数字。カメラの効果を特定レイヤだけに適応できます。,　
+ease_type=カメラの移動演出を指定できます。
+ease(開始時点と終了時点を滑らかに再生する)
+linear(一定の間隔で再生する)
+ease-in(開始時点をゆっくり再生する)
+ease-out(終了時点をゆっくり再生する)
+ease-in-out(開始時点と終了時点をゆっくり再生する)
+デフォルトはeaseです。
 
- :demo
+:demo
 2,kaisetsu/01_camera
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.camera = {
     vital: [],
@@ -190,27 +193,32 @@ tyrano.plugin.kag.tag.camera = {
 };
 
 /*
- #[reset_camera]
- :group
- カメラ操作
- :title
- カメラをリセットする
- :exp
- カメラの位置を初期値に戻します。
- [camera]タグを使った演出が終わった後は、必ず[reset_camera]で位置を元に戻して下さい。
- 位置を戻さない場合は背景変更などで不具合が生じる場合があります。
- :sample
- :param
- time=初期位置にカメラが移動する時間をミリ秒で指定します。デフォルトは1000です。,
- wait=カメラ移動の完了を待つかどうかを指定します。falseを指定するとカメラ移動中もゲームを進行することができます。デフォルトはtrue,
- ease_type=カメラの戻り方を指定できます。デフォルトはease　詳細はcameraタグを確認。,
- layer=レイヤを指定します。背景ならbase 前景レイヤならう 0以上の数字。カメラの効果を特定レイヤだけに適応できます。
+#[reset_camera]
+
+:group
+カメラ操作
+
+:title
+カメラをリセットする
+
+:exp
+カメラの位置を初期値に戻します。
+[camera]タグを使った演出が終わった後は、必ず[reset_camera]で位置を元に戻して下さい。
+位置を戻さない場合は背景変更などで不具合が生じる場合があります。
+
+:sample
+
+:param
+time=初期位置にカメラが移動する時間をミリ秒で指定します。デフォルトは1000です。,
+wait=カメラ移動の完了を待つかどうかを指定します。falseを指定するとカメラ移動中もゲームを進行できます。デフォルトはtrue,
+ease_type=カメラの戻り方を指定できます。デフォルトはease　詳細はcameraタグを確認。,
+layer=レイヤを指定します。背景ならbase 前景レイヤならう 0以上の数字。カメラの効果を特定レイヤだけに適応できます。
 
 :demo
 2,kaisetsu/01_camera
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.reset_camera = {
     vital: [],
@@ -322,31 +330,33 @@ tyrano.plugin.kag.tag.reset_camera = {
 };
 
 /*
- #[wait_camera]
- :group
- カメラ操作
- :title
- カメラの演出を待つ
- :exp
- このタグはカメラの操作中である場合、完了を待つことができます。
- 例えば、cameraタグでwaitにfalseを指定して、ゲームを進行する場合、特定の位置で必ずカメラ演出の完了を待たせる事が出来ます
+#[wait_camera]
 
- :sample
+:group
+カメラ操作
 
- [camera zoom=2 x=180 y=100 time=5000]
- カメラ演出中[p]
- ここでもカメラ演出中[p]
- [wait_camera]
- カメラの演出が終わったので進行[p]
+:title
+カメラの演出を待つ
 
- :param
+:exp
+このタグはカメラの操作中である場合、完了を待つことができます。
+例えば、cameraタグでwaitにfalseを指定して、ゲームを進行する場合、特定の位置で必ずカメラ演出の完了を待たせる事が出来ます
 
- :demo
- 2,kaisetsu/01_camera
+:sample
 
+[camera zoom=2 x=180 y=100 time=5000]
+カメラ演出中[p]
+ここでもカメラ演出中[p]
+[wait_camera]
+カメラの演出が終わったので進行[p]
 
- #[end]
- */
+:param
+
+:demo
+2,kaisetsu/01_camera
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.wait_camera = {
     start: function (pm) {
@@ -361,15 +371,19 @@ tyrano.plugin.kag.tag.wait_camera = {
 };
 
 /*
- #[mask]
- :group
- レイヤ関連
- :title
- スクリーンマスク表示
- :exp
- ゲーム画面全体を豊富な効果とともに暗転させることができます。
- 暗転中にゲーム画面を再構築して[mask_off]タグでゲームを再開する使い方ができます。
- :sample
+#[mask]
+
+:group
+レイヤ関連
+
+:title
+スクリーンマスク表示
+
+:exp
+ゲーム画面全体を豊富な効果とともに暗転させることができます。
+暗転中にゲーム画面を再構築して[mask_off]タグでゲームを再開する使い方ができます。
+
+:sample
 ;暗転開始
 [mask effect="fadeInDownBig" time=2000]
 
@@ -379,9 +393,9 @@ tyrano.plugin.kag.tag.wait_camera = {
 ;暗転解除
 [mask_off]
 
- :param
- time=暗転が完了するまでの時間をミリ秒で指定できます ,
- effect=暗転の効果を指定できます。デフォルトは「fadeIn」指定できるのは次のとおりです
+:param
+time=暗転が完了するまでの時間をミリ秒で指定できます ,
+effect=暗転の効果を指定できます。デフォルトは「fadeIn」指定できるのは次のとおりです
 fadeIn/
 fadeInDownBig/
 fadeInLeftBig/
@@ -410,16 +424,15 @@ bounceInLeft/<br >
 bounceInRight/
 bounceInUp/
 rollIn,
-color=文字の色を指定して下さい。デフォルトは黒です。0xFFFFFF形式で指定します,
+color=文字の色を指定して下さい。デフォルトは黒です。0xRRGGBB形式で指定します,
 graphic=暗転部分に独自画像を指定できます。画像はimageフォルダに配置してください,
 folder=graphicで指定するフォルダをimage以外に変更したい場合はこちらに記述します。例えばbgimage fgimageなどです
 
- :demo
- 2,kaisetsu/05_mask
+:demo
+2,kaisetsu/05_mask
 
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.mask = {
     vital: [],
@@ -501,14 +514,18 @@ tyrano.plugin.kag.tag.mask = {
 };
 
 /*
- #[mask_off]
- :group
- レイヤ関連
- :title
- スクリーンマスク消去
- :exp
- スクリーンマスクを消去してゲームを再開します。
- :sample
+#[mask_off]
+
+:group
+レイヤ関連
+
+:title
+スクリーンマスク消去
+
+:exp
+スクリーンマスクを消去してゲームを再開します。
+
+:sample
 ;暗転開始
 [mask effect="fadeInDownBig" time=2000]
 
@@ -518,9 +535,9 @@ tyrano.plugin.kag.tag.mask = {
 ;暗転解除
 [mask_off]
 
- :param
- time=暗転が完了するまでの時間をミリ秒で指定できます ,
- effect=暗転の効果を指定できます。デフォルトは「fadeOut」指定できるのは次のとおりです
+:param
+time=暗転が完了するまでの時間をミリ秒で指定できます ,
+effect=暗転の効果を指定できます。デフォルトは「fadeOut」指定できるのは次のとおりです
 fadeOut/
 fadeOutDownBig/
 fadeOutLeftBig/
@@ -550,10 +567,10 @@ bounceOutRight/
 bounceOutUp
 
 :demo
- 2,kaisetsu/05_mask
+2,kaisetsu/05_mask
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.mask_off = {
     vital: [],

--- a/tyrano/plugins/kag/kag.tag_ext.js
+++ b/tyrano/plugins/kag/kag.tag_ext.js
@@ -22,22 +22,19 @@
  */
 
 tyrano.plugin.kag.tag.loadjs = {
-
     vital: ["storage"],
 
     pm: {
-        storage: ""
+        storage: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
-        $.getScript("./data/others/" + pm.storage, function() {
+        $.getScript("./data/others/" + pm.storage, function () {
             that.kag.ftag.nextOrder();
         });
-
-    }
+    },
 };
 
 /*
@@ -63,7 +60,6 @@ tyrano.plugin.kag.tag.loadjs = {
  */
 
 tyrano.plugin.kag.tag.movie = {
-
     vital: ["storage"],
 
     pm: {
@@ -73,12 +69,10 @@ tyrano.plugin.kag.tag.movie = {
         mute: "false",
         //隠しパラメータ
         bgmode: "false",
-        loop: "false"
-
+        loop: "false",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         if ($.userenv() != "pc") {
@@ -95,9 +89,7 @@ tyrano.plugin.kag.tag.movie = {
                 $(".tyrano_base").unbind("click.movie");
                 //});
             }
-
         } else {
-
             //firefox opera の場合、webMに変更する。
             if ($.getBrowser() == "opera") {
                 pm.storage = $.replaceAll(pm.storage, ".mp4", ".webm");
@@ -105,16 +97,14 @@ tyrano.plugin.kag.tag.movie = {
 
             that.playVideo(pm);
         }
-
     },
 
-    playVideo: function(pm) {
-
+    playVideo: function (pm) {
         var that = this;
 
         var url = "./data/video/" + pm.storage;
 
-        var video = document.createElement('video');
+        var video = document.createElement("video");
         video.id = "bgmovie";
         //video.setAttribute('myvideo');
         video.src = url;
@@ -122,12 +112,12 @@ tyrano.plugin.kag.tag.movie = {
         if (pm.volume != "") {
             video.volume = parseFloat(parseInt(pm.volume) / 100);
         } else {
-
             if (typeof this.kag.config.defaultMovieVolume != "undefined") {
-                video.volume = parseFloat(parseInt(this.kag.config.defaultMovieVolume) / 100);
+                video.volume = parseFloat(
+                    parseInt(this.kag.config.defaultMovieVolume) / 100,
+                );
             }
         }
-
 
         //top:0px;left:0px;width:100%;height:100%;'";
 
@@ -147,11 +137,9 @@ tyrano.plugin.kag.tag.movie = {
             video.muted = true;
         }
 
-
         //document.createElement("video");
 
         if (pm.bgmode == "true") {
-
             that.kag.tmp.video_playing = true;
 
             //背景モード
@@ -163,8 +151,7 @@ tyrano.plugin.kag.tag.movie = {
                 video.loop = false;
             }
 
-            video.addEventListener("ended", function(e) {
-
+            video.addEventListener("ended", function (e) {
                 //alert("ended");
                 //ビデオ再生が終わった時に、次の再生用のビデオが登録されていたら、
                 //ループ完了後に、そのビデオを再生する。
@@ -178,13 +165,10 @@ tyrano.plugin.kag.tag.movie = {
                     }
 
                     //that.kag.ftag.nextOrder();
-
                 } else {
-
                     var video_pm = that.kag.stat.video_stack;
 
                     var video2 = document.createElement("video");
-
 
                     video2.style.backgroundColor = "black";
                     video2.style.position = "absolute";
@@ -207,7 +191,6 @@ tyrano.plugin.kag.tag.movie = {
                         video2.muted = true;
                     }
 
-
                     // プリロードを設定する
                     video2.src = "./data/video/" + video_pm.storage;
                     video2.load();
@@ -216,29 +199,31 @@ tyrano.plugin.kag.tag.movie = {
                     j_video2.css("z-index", -1);
                     $("#tyrano_base").append(j_video2);
 
-                    video2.addEventListener('canplay', function(event) {
+                    video2.addEventListener(
+                        "canplay",
+                        function (event) {
+                            var arg = arguments.callee;
 
-                        var arg = arguments.callee;
+                            // Video is loaded and can be played
+                            j_video2.css("z-index", 1);
 
-                        // Video is loaded and can be played
-                        j_video2.css("z-index", 1);
+                            setTimeout(function () {
+                                $("#bgmovie").remove();
+                                video2.id = "bgmovie";
+                            }, 100);
 
-                        setTimeout(function() {
-                            $("#bgmovie").remove();
-                            video2.id = "bgmovie";
-                        }, 100);
+                            that.kag.stat.video_stack = null;
+                            //that.kag.ftag.nextOrder();
 
-                        that.kag.stat.video_stack = null;
-                        //that.kag.ftag.nextOrder();
+                            that.kag.tmp.video_playing = true;
 
-                        that.kag.tmp.video_playing = true;
+                            video2.removeEventListener("canplay", arg, false);
+                            //document.getElementById("tyrano_base").appendChild(video);
 
-                        video2.removeEventListener('canplay', arg, false);
-                        //document.getElementById("tyrano_base").appendChild(video);
-
-                        //$("#tyrano_base").append(j_video);
-
-                    }, false);
+                            //$("#tyrano_base").append(j_video);
+                        },
+                        false,
+                    );
 
                     //video2でも呼び出し
 
@@ -249,35 +234,26 @@ tyrano.plugin.kag.tag.movie = {
                     video.load();
                     video.play();
                     */
-
-
                 }
-
             });
-
         } else {
-
             video.style.zIndex = 199999;
 
-            video.addEventListener("ended", function(e) {
+            video.addEventListener("ended", function (e) {
                 $(".tyrano_base").find("video").remove();
                 that.kag.ftag.nextOrder();
-
             });
 
             //スキップ可能なら、クリックで削除
             //bgmodeがtrueならはスキップ関係なし
 
             if (pm.skip == "true") {
-
-                $(video).on("click touchstart", function(e) {
+                $(video).on("click touchstart", function (e) {
                     $(video).off("click touchstart");
                     $(".tyrano_base").find("video").remove();
                     that.kag.ftag.nextOrder();
                 });
-
             }
-
         }
 
         var j_video = $(video);
@@ -287,30 +263,27 @@ tyrano.plugin.kag.tag.movie = {
 
         $("#tyrano_base").append(j_video);
         j_video.animate(
-            { opacity: '1' },
+            { opacity: "1" },
             {
                 duration: parseInt(pm.time),
-                complete: function() {
+                complete: function () {
                     //$(this).remove();
                     //that.kag.ftag.nextOrder();
                     //if(pm.wait=="true"){
                     //    that.kag.ftag.nextOrder();
                     //}
-
-                }
-            }
+                },
+            },
         );
 
         video.load();
 
         //アンドロイドで一瞬再生ボタンが表示される対策
-        video.addEventListener('canplay', function() {
+        video.addEventListener("canplay", function () {
             video.style.display = "";
             video.play();
         });
-
-
-    }
+    },
 };
 
 /*
@@ -342,7 +315,6 @@ bgmovieをループ中に別のbgmovieを重ねることで、ループが完了
  */
 
 tyrano.plugin.kag.tag.bgmovie = {
-
     vital: ["storage"],
 
     pm: {
@@ -351,11 +323,10 @@ tyrano.plugin.kag.tag.bgmovie = {
         loop: "true",
         mute: "false",
         time: "300",
-        stop: "false" //nextorderするかしないk
+        stop: "false", //nextorderするかしないk
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         pm.skip = "false";
@@ -372,7 +343,6 @@ tyrano.plugin.kag.tag.bgmovie = {
 
             that.kag.ftag.nextOrder();
             return;
-
         }
 
         this.kag.ftag.startTag("movie", pm);
@@ -380,8 +350,7 @@ tyrano.plugin.kag.tag.bgmovie = {
         if (pm.stop == "false") {
             this.kag.ftag.nextOrder();
         }
-
-    }
+    },
 };
 
 /*
@@ -398,27 +367,23 @@ tyrano.plugin.kag.tag.bgmovie = {
  */
 
 tyrano.plugin.kag.tag.wait_bgmovie = {
-
     vital: [],
 
     pm: {
-        stop: "false" //nextorderするかしないk
+        stop: "false", //nextorderするかしないk
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         if (this.kag.tmp.video_playing == true) {
-
             var video = document.getElementById("bgmovie");
             this.kag.stat.is_wait_bgmovie = true;
             video.loop = false;
-
         } else {
             this.kag.ftag.nextOrder();
         }
-    }
+    },
 };
 
 /*
@@ -438,16 +403,14 @@ tyrano.plugin.kag.tag.wait_bgmovie = {
  */
 
 tyrano.plugin.kag.tag.stop_bgmovie = {
-
     vital: [],
 
     pm: {
         time: "300",
-        wait: "true"
+        wait: "true",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         that.kag.tmp.video_playing = false;
@@ -455,21 +418,21 @@ tyrano.plugin.kag.tag.stop_bgmovie = {
         that.kag.stat.current_bgmovie["storage"] = "";
         that.kag.stat.current_bgmovie["volume"] = "";
 
+        $(".tyrano_base")
+            .find("video")
+            .animate(
+                { opacity: "0" },
+                {
+                    duration: parseInt(pm.time),
+                    complete: function () {
+                        $(this).remove();
 
-        $(".tyrano_base").find("video").animate(
-            { opacity: '0' },
-            {
-                duration: parseInt(pm.time),
-                complete: function() {
-                    $(this).remove();
-
-                    if (pm.wait == "true") {
-                        that.kag.ftag.nextOrder();
-                    }
-
-                }
-            }
-        );
+                        if (pm.wait == "true") {
+                            that.kag.ftag.nextOrder();
+                        }
+                    },
+                },
+            );
 
         if (!$(".tyrano_base").find("video").get(0)) {
             that.kag.ftag.nextOrder();
@@ -479,8 +442,7 @@ tyrano.plugin.kag.tag.stop_bgmovie = {
         if (pm.wait == "false") {
             that.kag.ftag.nextOrder();
         }
-
-    }
+    },
 };
 
 /*
@@ -498,20 +460,17 @@ tyrano.plugin.kag.tag.stop_bgmovie = {
  */
 
 tyrano.plugin.kag.tag.showsave = {
+    pm: {},
 
-    pm: {
-    },
-
-    start: function(pm) {
+    start: function (pm) {
         var that = this;
 
         that.kag.stat.load_auto_next = true;
-        this.kag.menu.displaySave(function() {
+        this.kag.menu.displaySave(function () {
             that.kag.stat.load_auto_next = false;
             that.kag.ftag.nextOrder();
         });
-
-    }
+    },
 };
 
 /*
@@ -529,17 +488,14 @@ tyrano.plugin.kag.tag.showsave = {
  */
 
 tyrano.plugin.kag.tag.showload = {
+    pm: {},
 
-    pm: {
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
-        this.kag.menu.displayLoad(function() {
+        this.kag.menu.displayLoad(function () {
             that.kag.ftag.nextOrder();
         });
-    }
+    },
 };
 
 /*
@@ -557,16 +513,12 @@ tyrano.plugin.kag.tag.showload = {
  */
 
 tyrano.plugin.kag.tag.showmenu = {
+    pm: {},
 
-    pm: {
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.menu.showMenu();
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -584,18 +536,14 @@ tyrano.plugin.kag.tag.showmenu = {
  */
 
 tyrano.plugin.kag.tag.showmenubutton = {
+    pm: {},
 
-    pm: {
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         $(".button_menu").show();
         this.kag.stat.visible_menu_button = true;
         this.kag.config.configVisible = "true";
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -613,18 +561,14 @@ tyrano.plugin.kag.tag.showmenubutton = {
  */
 
 tyrano.plugin.kag.tag.hidemenubutton = {
+    pm: {},
 
-    pm: {
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         $(".button_menu").hide();
         this.kag.stat.visible_menu_button = false;
         this.kag.config.configVisible = "false";
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -641,12 +585,9 @@ tyrano.plugin.kag.tag.hidemenubutton = {
  */
 
 tyrano.plugin.kag.tag.skipstart = {
+    pm: {},
 
-    pm: {
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         //文字追加中は、スキップしない。
         if (this.kag.stat.is_skip == true || this.kag.stat.is_adding_text) {
             return false;
@@ -656,8 +597,7 @@ tyrano.plugin.kag.tag.skipstart = {
 
         this.kag.stat.is_skip = true;
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -674,16 +614,12 @@ tyrano.plugin.kag.tag.skipstart = {
  */
 
 tyrano.plugin.kag.tag.skipstop = {
+    pm: {},
 
-    pm: {
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.is_skip = false;
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -701,12 +637,9 @@ tyrano.plugin.kag.tag.skipstop = {
  */
 
 tyrano.plugin.kag.tag.autostart = {
+    pm: {},
 
-    pm: {
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         if (this.kag.stat.is_auto == true) {
             return false;
         }
@@ -716,8 +649,7 @@ tyrano.plugin.kag.tag.autostart = {
         //[p][l] の処理に、オート判定が入ってます
         this.kag.stat.is_auto = true;
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -734,13 +666,11 @@ tyrano.plugin.kag.tag.autostart = {
  */
 
 tyrano.plugin.kag.tag.autostop = {
-
     pm: {
-        next: "true"
+        next: "true",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.is_auto = false;
         this.kag.stat.is_wait_auto = false;
 
@@ -749,7 +679,7 @@ tyrano.plugin.kag.tag.autostop = {
         if (pm.next == "true") {
             this.kag.ftag.nextOrder();
         }
-    }
+    },
 };
 
 /*
@@ -768,34 +698,30 @@ tyrano.plugin.kag.tag.autostop = {
  */
 
 tyrano.plugin.kag.tag.autoconfig = {
-
     pm: {
         speed: "",
-        clickstop: ""
+        clickstop: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         if (pm.speed != "") {
             this.kag.config.autoSpeed = pm.speed;
             this.kag.ftag.startTag("eval", {
-                "exp": "sf._system_config_auto_speed = " + pm.speed,
-                "next": "false"
+                exp: "sf._system_config_auto_speed = " + pm.speed,
+                next: "false",
             });
         }
 
         if (pm.clickstop != "") {
             this.kag.config.autoClickStop = pm.clickstop;
             this.kag.ftag.startTag("eval", {
-                "exp": "sf._system_config_auto_click_stop = " + pm.clickstop,
-                "next": "false"
+                exp: "sf._system_config_auto_click_stop = " + pm.clickstop,
+                next: "false",
             });
-
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -880,9 +806,7 @@ tyrano.plugin.kag.tag.autoconfig = {
  */
 
 tyrano.plugin.kag.tag.anim = {
-
     pm: {
-
         name: "",
         layer: "",
         left: "",
@@ -892,12 +816,10 @@ tyrano.plugin.kag.tag.anim = {
         opacity: "",
         color: "",
         time: "2000",
-        effect: ""
-
+        effect: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         var anim_style = {};
@@ -926,18 +848,21 @@ tyrano.plugin.kag.tag.anim = {
         var target = "";
 
         if (pm.name != "") {
-
             //アニメーションスタックの積み上げ
-            $("." + pm.name).each(function() {
+            $("." + pm.name).each(function () {
                 that.kag.pushAnimStack();
-                $(this).stop(true, true).animate(anim_style, parseInt(pm.time), pm.effect, function() {
-                    that.kag.popAnimStack();
-                });
+                $(this)
+                    .stop(true, true)
+                    .animate(
+                        anim_style,
+                        parseInt(pm.time),
+                        pm.effect,
+                        function () {
+                            that.kag.popAnimStack();
+                        },
+                    );
             });
-
-
         } else if (pm.layer != "") {
-
             var layer_name = pm.layer + "_fore";
 
             //フリーレイヤに対して実施
@@ -948,23 +873,25 @@ tyrano.plugin.kag.tag.anim = {
             //レイヤ指定の場合、その配下にある要素全てに対して、実施
             var target_array = $("." + layer_name).children();
 
-            target_array.each(function() {
-
+            target_array.each(function () {
                 that.kag.pushAnimStack();
 
-                $(this).stop(true, true).animate(anim_style, parseInt(pm.time), pm.effect, function() {
-                    that.kag.popAnimStack();
-
-                });
-
+                $(this)
+                    .stop(true, true)
+                    .animate(
+                        anim_style,
+                        parseInt(pm.time),
+                        pm.effect,
+                        function () {
+                            that.kag.popAnimStack();
+                        },
+                    );
             });
-
         }
 
         //次の命令へ　アニメーション終了街の場合は厳しい
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -982,18 +909,15 @@ tyrano.plugin.kag.tag.anim = {
 
 //トランジション完了を待つ
 tyrano.plugin.kag.tag.wa = {
-    start: function(pm) {
-
+    start: function (pm) {
         //実行中のアニメーションがある場合だけ待つ
         if (this.kag.tmp.num_anim > 0) {
             this.kag.stat.is_wait_anim = true;
             this.kag.layer.hideEventLayer();
         } else {
             this.kag.ftag.nextOrder();
-
         }
-
-    }
+    },
 };
 
 /*
@@ -1015,16 +939,14 @@ tyrano.plugin.kag.tag.stopanim = {
     vital: ["name"],
 
     pm: {
-        name: ""
+        name: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         $("." + pm.name).stop();
         this.kag.popAnimStack();
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 //================キーフレームアニメーション系
@@ -1059,20 +981,17 @@ tyrano.plugin.kag.tag.stopanim = {
  */
 
 tyrano.plugin.kag.tag.keyframe = {
-
     vital: ["name"],
 
     pm: {
-        name: ""
+        name: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.current_keyframe = pm.name;
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -1089,16 +1008,12 @@ tyrano.plugin.kag.tag.keyframe = {
  */
 
 tyrano.plugin.kag.tag.endkeyframe = {
+    pm: {},
 
-    pm: {
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.current_keyframe = "";
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -1137,40 +1052,38 @@ tyrano.plugin.kag.tag.endkeyframe = {
  */
 
 tyrano.plugin.kag.tag.frame = {
-
     vital: ["p"],
 
     pm: {
-        p: ""
+        p: "",
     },
 
     master_trans: {
-        "x": "",
-        "y": "",
-        "z": "",
-        "translate": "",
-        "translate3d": "",
-        "translateX": "",
-        "translateY": "",
-        "translateZ": "",
-        "scale": "",
-        "scale3d": "",
-        "scaleX": "",
-        "scaleY": "",
-        "scaleZ": "",
-        "rotate": "",
-        "rotate3d": "",
-        "rotateX": "",
-        "rotateY": "",
-        "rotateZ": "",
-        "skew": "",
-        "skewX": "",
-        "skewY": "",
-        "perspective": ""
+        x: "",
+        y: "",
+        z: "",
+        translate: "",
+        translate3d: "",
+        translateX: "",
+        translateY: "",
+        translateZ: "",
+        scale: "",
+        scale3d: "",
+        scaleX: "",
+        scaleY: "",
+        scaleZ: "",
+        rotate: "",
+        rotate3d: "",
+        rotateX: "",
+        rotateY: "",
+        rotateZ: "",
+        skew: "",
+        skewX: "",
+        skewY: "",
+        perspective: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var percentage = pm.p;
         delete pm.p;
 
@@ -1179,20 +1092,20 @@ tyrano.plugin.kag.tag.frame = {
         //色々定義できる
 
         if (this.kag.stat.map_keyframe[this.kag.stat.current_keyframe]) {
-
         } else {
-
             this.kag.stat.map_keyframe[this.kag.stat.current_keyframe] = {};
-            this.kag.stat.map_keyframe[this.kag.stat.current_keyframe]["frames"] = {};
-            this.kag.stat.map_keyframe[this.kag.stat.current_keyframe]["styles"] = {};
-
+            this.kag.stat.map_keyframe[this.kag.stat.current_keyframe][
+                "frames"
+            ] = {};
+            this.kag.stat.map_keyframe[this.kag.stat.current_keyframe][
+                "styles"
+            ] = {};
         }
 
         var map_trans = {};
         var map_style = {};
 
         for (key in pm) {
-
             if (this.master_trans[key] == "") {
                 map_trans[key] = pm[key];
             } else {
@@ -1200,14 +1113,15 @@ tyrano.plugin.kag.tag.frame = {
             }
         }
 
-        this.kag.stat.map_keyframe[this.kag.stat.current_keyframe]["frames"][percentage] = {
-            "trans": map_trans,
-            "styles": map_style
+        this.kag.stat.map_keyframe[this.kag.stat.current_keyframe]["frames"][
+            percentage
+        ] = {
+            trans: map_trans,
+            styles: map_style,
         };
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -1245,17 +1159,15 @@ tyrano.plugin.kag.tag.frame = {
  */
 
 tyrano.plugin.kag.tag.kanim = {
-
     vital: ["keyframe"],
 
     pm: {
-        "name": "",
-        "layer": "",
-        "keyframe": ""
+        name: "",
+        layer: "",
+        keyframe: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         var anim = this.kag.stat.map_keyframe[pm.keyframe];
@@ -1273,24 +1185,19 @@ tyrano.plugin.kag.tag.kanim = {
         }
 
         //アニメーション完了したら、
-        anim.complete = function() {
-
+        anim.complete = function () {
             that.kag.popAnimStack();
-
         };
 
         if (pm.name != "") {
             delete pm.name;
             delete pm.keyframe;
 
-            $(class_name).each(function() {
+            $(class_name).each(function () {
                 that.kag.pushAnimStack();
                 $(this).a3d(anim);
             });
-
-
         } else if (pm.layer != "") {
-
             var layer_name = pm.layer + "_fore";
 
             //フリーレイヤに対して実施
@@ -1304,23 +1211,16 @@ tyrano.plugin.kag.tag.kanim = {
             //レイヤ指定の場合、その配下にある要素全てに対して、実施
             var target_array = $("." + layer_name).children();
 
-            target_array.each(function() {
-
+            target_array.each(function () {
                 that.kag.pushAnimStack();
 
                 $(this).a3d(anim);
-
             });
-
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
-
-
 
 /*
  #[stop_kanim]
@@ -1338,14 +1238,12 @@ tyrano.plugin.kag.tag.kanim = {
  */
 
 tyrano.plugin.kag.tag.stop_kanim = {
-
     pm: {
-        "name": "",
-        "layer": ""
+        name: "",
+        layer: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         if (pm.name != "") {
@@ -1355,10 +1253,9 @@ tyrano.plugin.kag.tag.stop_kanim = {
                 "animation-iteration-count": "",
                 "animation-fill-mode": "",
                 "animation-timing-function": "",
-                "transform": ""
+                "transform": "",
             });
         } else if (pm.layer != "") {
-
             var layer_name = pm.layer + "_fore";
             //フリーレイヤに対して実施
             if (pm.layer == "free") {
@@ -1371,21 +1268,13 @@ tyrano.plugin.kag.tag.stop_kanim = {
                 "animation-iteration-count": "",
                 "animation-fill-mode": "",
                 "animation-timing-function": "",
-                "transform": ""
+                "transform": "",
             });
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
-
-
-
-
-
-
 
 //=====================================
 
@@ -1410,36 +1299,28 @@ tyrano.plugin.kag.tag.stop_kanim = {
  #[end]
  */
 tyrano.plugin.kag.tag.chara_ptext = {
-
     pm: {
-
         name: "",
-        face: ""
+        face: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
         this.kag.layer.hideEventLayer();
 
         if (pm.name == "") {
-
             $("." + this.kag.stat.chara_ptext).html("");
 
             //全員の明度を下げる。誰も話していないから
             //明度設定が有効な場合
             if (this.kag.stat.chara_talk_focus != "none") {
-
                 $("#tyrano_base").find(".tyrano_chara").css({
                     "-webkit-filter": this.kag.stat.apply_filter_str,
                     "-ms-filter": this.kag.stat.apply_filter_str,
-                    "-moz-filter": this.kag.stat.apply_filter_str
+                    "-moz-filter": this.kag.stat.apply_filter_str,
                 });
-
             }
-
         } else {
-
             //日本語から逆変換することも可能とする
             if (this.kag.stat.jcharas[pm.name]) {
                 pm.name = this.kag.stat.jcharas[pm.name];
@@ -1453,43 +1334,51 @@ tyrano.plugin.kag.tag.chara_ptext = {
 
                 //色指定がある場合は、その色を指定する。
                 if (cpm.color != "") {
-                    $("." + this.kag.stat.chara_ptext).css("color", $.convertColor(cpm.color));
+                    $("." + this.kag.stat.chara_ptext).css(
+                        "color",
+                        $.convertColor(cpm.color),
+                    );
                 }
 
                 //明度設定が有効な場合
                 if (this.kag.stat.chara_talk_focus != "none") {
-
                     $("#tyrano_base").find(".tyrano_chara").css({
                         "-webkit-filter": this.kag.stat.apply_filter_str,
                         "-ms-filter": this.kag.stat.apply_filter_str,
-                        "-moz-filter": this.kag.stat.apply_filter_str
+                        "-moz-filter": this.kag.stat.apply_filter_str,
                     });
 
-                    $("#tyrano_base").find("." + pm.name + ".tyrano_chara").css({
-                        "-webkit-filter": "brightness(100%) blur(0px)",
-                        "-ms-filter": "brightness(100%) blur(0px)",
-                        "-moz-filter": "brightness(100%) blur(0px)"
-                    });
-
+                    $("#tyrano_base")
+                        .find("." + pm.name + ".tyrano_chara")
+                        .css({
+                            "-webkit-filter": "brightness(100%) blur(0px)",
+                            "-ms-filter": "brightness(100%) blur(0px)",
+                            "-moz-filter": "brightness(100%) blur(0px)",
+                        });
                 }
 
                 //指定したキャラクターでアニメーション設定があった場合
                 if (this.kag.stat.chara_talk_anim != "none") {
-
-                    var chara_obj = $("#tyrano_base").find("." + pm.name + ".tyrano_chara");
+                    var chara_obj = $("#tyrano_base").find(
+                        "." + pm.name + ".tyrano_chara",
+                    );
                     if (chara_obj.get(0)) {
-
-                        this.animChara(chara_obj, this.kag.stat.chara_talk_anim, pm.name);
+                        this.animChara(
+                            chara_obj,
+                            this.kag.stat.chara_talk_anim,
+                            pm.name,
+                        );
 
                         if (pm.face != "") {
                             //即表情変更、アニメーション中になるから
-                            this.kag.ftag.startTag("chara_mod", { name: pm.name, face: pm.face, time: "0" });
+                            this.kag.ftag.startTag("chara_mod", {
+                                name: pm.name,
+                                face: pm.face,
+                                time: "0",
+                            });
                         }
                     }
-
                 }
-
-
             } else {
                 //存在しない場合はそのまま表示できる
                 $("." + this.kag.stat.chara_ptext).html(pm.name);
@@ -1499,68 +1388,74 @@ tyrano.plugin.kag.tag.chara_ptext = {
                     $("#tyrano_base").find(".tyrano_chara").css({
                         "-webkit-filter": this.kag.stat.apply_filter_str,
                         "-ms-filter": this.kag.stat.apply_filter_str,
-                        "-moz-filter": this.kag.stat.apply_filter_str
+                        "-moz-filter": this.kag.stat.apply_filter_str,
                     });
                 }
-
             }
         }
-
 
         //ボイス設定が有効な場合
         if (this.kag.stat.vostart == true) {
             //キャラクターのボイス設定がある場合
 
             if (this.kag.stat.map_vo["vochara"][pm.name]) {
-
                 var vochara = this.kag.stat.map_vo["vochara"][pm.name];
 
-                var playsefile = $.replaceAll(vochara.vostorage, "{number}", vochara.number);
+                var playsefile = $.replaceAll(
+                    vochara.vostorage,
+                    "{number}",
+                    vochara.number,
+                );
 
                 var se_pm = {
                     loop: "false",
                     storage: playsefile,
                     stop: "true",
-                    buf: vochara.buf
+                    buf: vochara.buf,
                 };
 
                 this.kag.ftag.startTag("playse", se_pm);
 
-                this.kag.stat.map_vo["vochara"][pm.name]["number"] = parseInt(vochara.number) + 1;
-
+                this.kag.stat.map_vo["vochara"][pm.name]["number"] =
+                    parseInt(vochara.number) + 1;
             }
-
         }
 
         this.kag.stat.f_chara_ptext = "true";
 
         //表情の変更もあわせてできる
         if (pm.face != "") {
-            if (!(this.kag.stat.charas[pm.name]["map_face"][pm.face])) {
-                this.kag.error("指定されたキャラクター「" + pm.name + "」もしくはface:「" + pm.face + "」は定義されていません。もう一度確認をお願いします");
+            if (!this.kag.stat.charas[pm.name]["map_face"][pm.face]) {
+                this.kag.error(
+                    "指定されたキャラクター「" +
+                        pm.name +
+                        "」もしくはface:「" +
+                        pm.face +
+                        "」は定義されていません。もう一度確認をお願いします",
+                );
                 return;
             }
 
-            var storage_url = this.kag.stat.charas[pm.name]["map_face"][pm.face];
+            var storage_url =
+                this.kag.stat.charas[pm.name]["map_face"][pm.face];
 
             //chara_mod タグで実装するように調整
             if (this.kag.stat.chara_talk_anim == "none") {
-                this.kag.ftag.startTag("chara_mod", { name: pm.name, face: pm.face });
+                this.kag.ftag.startTag("chara_mod", {
+                    name: pm.name,
+                    face: pm.face,
+                });
             }
 
             //$("."+pm.name).attr("src",storage_url);
-
         } else {
             this.kag.layer.showEventLayer();
             this.kag.ftag.nextOrder();
-
         }
-
     },
 
     //キャラクターのアニメーション設定
-    animChara: function(chara_obj, type, name) {
-
+    animChara: function (chara_obj, type, name) {
         //アニメーション中の場合は、重ねない
         if (typeof this.kag.tmp.map_chara_talk_top[name] != "undefined") {
             return;
@@ -1581,23 +1476,21 @@ tyrano.plugin.kag.tag.chara_ptext = {
         if (type == "up") {
             a_obj["top"] = tmp_top - this.kag.stat.chara_talk_anim_value;
             b_obj["top"] = tmp_top;
-
         } else if (type == "down") {
             a_obj["top"] = tmp_top + this.kag.stat.chara_talk_anim_value;
             b_obj["top"] = tmp_top;
-
         }
 
-
-        chara_obj.stop(true, true).animate(a_obj, anim_time, "easeOutQuad", function() {
-            chara_obj.stop(true, true).animate(b_obj, anim_time, "easeOutQuad", function() {
-                delete that.kag.tmp.map_chara_talk_top[name];
+        chara_obj
+            .stop(true, true)
+            .animate(a_obj, anim_time, "easeOutQuad", function () {
+                chara_obj
+                    .stop(true, true)
+                    .animate(b_obj, anim_time, "easeOutQuad", function () {
+                        delete that.kag.tmp.map_chara_talk_top[name];
+                    });
             });
-        });
-
-
-    }
-
+    },
 };
 
 /*
@@ -1663,9 +1556,7 @@ tyrano.plugin.kag.tag.chara_ptext = {
  */
 
 tyrano.plugin.kag.tag.chara_config = {
-
     pm: {
-
         pos_mode: "",
         effect: "",
         ptext: "",
@@ -1678,66 +1569,54 @@ tyrano.plugin.kag.tag.chara_config = {
         blur_value: "",
         talk_anim: "",
         talk_anim_time: "",
-        talk_anim_value: ""
-
+        talk_anim_value: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         //入力されている項目のみ、反映させる
-        if (pm.pos_mode != "")
-            this.kag.stat.chara_pos_mode = pm.pos_mode;
-        if (pm.effect != "")
-            this.kag.stat.chara_effect = pm.effect;
-        if (pm.ptext != "")
-            this.kag.stat.chara_ptext = pm.ptext;
-        if (pm.time != "")
-            this.kag.stat.chara_time = pm.time;
-        if (pm.memory != "")
-            this.kag.stat.chara_memory = pm.memory;
-        if (pm.anim != "")
-            this.kag.stat.chara_anim = pm.anim;
+        if (pm.pos_mode != "") this.kag.stat.chara_pos_mode = pm.pos_mode;
+        if (pm.effect != "") this.kag.stat.chara_effect = pm.effect;
+        if (pm.ptext != "") this.kag.stat.chara_ptext = pm.ptext;
+        if (pm.time != "") this.kag.stat.chara_time = pm.time;
+        if (pm.memory != "") this.kag.stat.chara_memory = pm.memory;
+        if (pm.anim != "") this.kag.stat.chara_anim = pm.anim;
         if (pm.pos_change_time != "")
             this.kag.stat.pos_change_time = pm.pos_change_time;
 
         if (pm.brightness_value != "")
             this.kag.stat.chara_brightness_value = pm.brightness_value;
-        if (pm.blur_value != "")
-            this.kag.stat.chara_blur_value = pm.blur_value;
+        if (pm.blur_value != "") this.kag.stat.chara_blur_value = pm.blur_value;
 
-        if (pm.talk_anim != "")
-            this.kag.stat.chara_talk_anim = pm.talk_anim;
+        if (pm.talk_anim != "") this.kag.stat.chara_talk_anim = pm.talk_anim;
         if (pm.talk_anim_time != "")
             this.kag.stat.chara_talk_anim_time = parseInt(pm.talk_anim_time);
         if (pm.talk_anim_value != "")
             this.kag.stat.chara_talk_anim_value = parseInt(pm.talk_anim_value);
 
-
         //フォーカス設定
         if (pm.talk_focus != "") {
-
             if (pm.talk_focus == "none") {
                 this.kag.stat.apply_filter_str = "";
             } else if (pm.talk_focus == "brightness") {
-                this.kag.stat.apply_filter_str = "brightness(" + this.kag.stat.chara_brightness_value + "%)";
+                this.kag.stat.apply_filter_str =
+                    "brightness(" + this.kag.stat.chara_brightness_value + "%)";
             } else if (pm.talk_focus == "blur") {
-                this.kag.stat.apply_filter_str = "blur(" + this.kag.stat.chara_blur_value + "px)";
+                this.kag.stat.apply_filter_str =
+                    "blur(" + this.kag.stat.chara_blur_value + "px)";
             }
 
             //フォーカスの指定が変わった段階で一旦すべて無効にする
             $("#tyrano_base").find(".tyrano_chara").css({
                 "-webkit-filter": "brightness(100%) blur(0px)",
                 "-ms-filter": "brightness(100%) blur(0px)",
-                "-moz-filter": "brightness(100%) blur(0px)"
+                "-moz-filter": "brightness(100%) blur(0px)",
             });
 
             this.kag.stat.chara_talk_focus = pm.talk_focus;
-
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -1768,11 +1647,9 @@ tyrano.plugin.kag.tag.chara_config = {
  */
 
 tyrano.plugin.kag.tag.chara_new = {
-
     vital: ["name", "storage"],
 
     pm: {
-
         name: "",
         storage: "",
         width: "",
@@ -1785,11 +1662,9 @@ tyrano.plugin.kag.tag.chara_new = {
         fuki: { enable: "false" },
 
         is_show: "false",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         //イメージの追加
 
         var storage_url = "./data/fgimage/" + pm.storage;
@@ -1809,26 +1684,24 @@ tyrano.plugin.kag.tag.chara_new = {
         }
 
         this.kag.preload(storage_url, (img_obj) => {
-
             if (img_obj) {
-
                 let img_width = $(img_obj).get(0).width;
                 let img_height = $(img_obj).get(0).height;
 
                 this.kag.stat.charas[pm.name]["origin_width"] = img_width;
                 this.kag.stat.charas[pm.name]["origin_height"] = img_height;
 
-                this.kag.stat.charas[pm.name]["fuki"]["left"] = Math.round(img_width / 2);
-                this.kag.stat.charas[pm.name]["fuki"]["top"] = Math.round(img_height / 3);
-
+                this.kag.stat.charas[pm.name]["fuki"]["left"] = Math.round(
+                    img_width / 2,
+                );
+                this.kag.stat.charas[pm.name]["fuki"]["top"] = Math.round(
+                    img_height / 3,
+                );
             }
 
             this.kag.ftag.nextOrder();
-
         });
-
-
-    }
+    },
 };
 
 /*
@@ -1865,11 +1738,9 @@ tyrano.plugin.kag.tag.chara_new = {
  */
 
 tyrano.plugin.kag.tag.chara_show = {
-
     vital: ["name"],
 
     pm: {
-
         name: "",
         page: "fore",
         layer: "0", //レイヤーデフォルトは０に追加
@@ -1883,12 +1754,10 @@ tyrano.plugin.kag.tag.chara_show = {
         reflect: "",
         face: "",
         storage: "",
-        time: 1000
-
+        time: 1000,
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         var cpm = this.kag.stat.charas[pm.name];
@@ -1896,7 +1765,11 @@ tyrano.plugin.kag.tag.chara_show = {
         var array_storage = [];
 
         if (cpm == null) {
-            this.kag.error("指定されたキャラクター「" + pm.name + "」は定義されていません。[chara_new]で定義してください");
+            this.kag.error(
+                "指定されたキャラクター「" +
+                    pm.name +
+                    "」は定義されていません。[chara_new]で定義してください",
+            );
             return;
         }
 
@@ -1906,14 +1779,12 @@ tyrano.plugin.kag.tag.chara_show = {
         check_obj.stop(true, true);
 
         if (check_obj.get(0)) {
-
             check_obj.stop(true, true);
 
             if (check_obj.css("display") != "none") {
                 that.kag.ftag.nextOrder();
                 return;
             }
-
         } else {
             //別の方法で消された場合
             cpm.is_show = "false";
@@ -1933,14 +1804,18 @@ tyrano.plugin.kag.tag.chara_show = {
 
         //表情が指定されている場合はその値を活用する。
         if (pm.face != "") {
-            if (!(cpm["map_face"][pm.face])) {
-                this.kag.error("指定されたキャラクター「" + pm.name + "」もしくはface:「" + pm.face + "」は定義されていません。もう一度確認をお願いします");
+            if (!cpm["map_face"][pm.face]) {
+                this.kag.error(
+                    "指定されたキャラクター「" +
+                        pm.name +
+                        "」もしくはface:「" +
+                        pm.face +
+                        "」は定義されていません。もう一度確認をお願いします",
+                );
                 return;
             }
             storage_url = "./data/fgimage/" + cpm["map_face"][pm.face];
-
         } else if (pm.storage != "") {
-
             if ($.isHTTP(pm.storage)) {
                 folder = "";
                 storage_url = pm.storage;
@@ -1949,13 +1824,12 @@ tyrano.plugin.kag.tag.chara_show = {
             }
 
             that.kag.stat.charas[pm.name]["storage"] = pm.storage;
-
         }
 
         var j_chara_root = $("<div></div>");
         j_chara_root.css({
-            "position": "absolute",
-            "display": "none"
+            position: "absolute",
+            display: "none",
         });
 
         var img_obj = $("<img />");
@@ -1971,13 +1845,11 @@ tyrano.plugin.kag.tag.chara_show = {
         if (pm.width != "") {
             var width = parseInt(pm.width);
             cpm.width = width;
-
         }
 
         if (pm.height != "") {
             var height = parseInt(pm.height);
             cpm.height = height;
-
         }
 
         if (cpm.width != "") {
@@ -1988,12 +1860,9 @@ tyrano.plugin.kag.tag.chara_show = {
             j_chara_root.css("height", cpm.height + "px");
         }
 
-
         if (pm.zindex != "") {
-
             var zindex = parseInt(pm.zindex);
             j_chara_root.css("z-index", zindex);
-
         }
 
         ////キャラ差分の指定があれば、それを適応する。
@@ -2003,9 +1872,7 @@ tyrano.plugin.kag.tag.chara_show = {
             chara_layer = cpm["_layer"];
         }
 
-
         for (key in chara_layer) {
-
             var chara_part = chara_layer[key];
 
             //どれを表示すべきか
@@ -2016,13 +1883,11 @@ tyrano.plugin.kag.tag.chara_show = {
             if (current_part_id == "allow_storage") {
                 chara_obj = {
                     storage: chara_part["allow_storage"],
-                    visible: "true"
+                    visible: "true",
                 };
             }
 
-
             if (true) {
-
                 var part_storage = "./data/fgimage/" + chara_obj["storage"];
 
                 var j_img = $("<img />");
@@ -2037,25 +1902,20 @@ tyrano.plugin.kag.tag.chara_show = {
                 j_img.attr("src", part_storage);
 
                 j_img.css({
-                    position: "absolute",
-                    left: 0,
-                    top: 0,
-                    width: "100%",
-                    height: "100%",
-                    "z-index": chara_part.zindex
+                    "position": "absolute",
+                    "left": 0,
+                    "top": 0,
+                    "width": "100%",
+                    "height": "100%",
+                    "z-index": chara_part.zindex,
                 });
 
                 j_img.addClass("part");
                 j_img.addClass(key); //mouse とか head
 
                 j_chara_root.append(j_img);
-
-
             }
-
         }
-
-
 
         //反転表示
         if (pm.reflect != "") {
@@ -2071,10 +1931,8 @@ tyrano.plugin.kag.tag.chara_show = {
         //
         cpm.is_show = "true";
 
-
         //画像は事前にロードしておく必要がありそう
-        this.kag.preloadAll(array_storage, function() {
-
+        this.kag.preloadAll(array_storage, function () {
             var target_layer = that.kag.layer.getLayer(pm.layer, pm.page);
 
             //最後に挿入
@@ -2092,8 +1950,6 @@ tyrano.plugin.kag.tag.chara_show = {
 
             //立ち位置を自動的に設定する場合
             if (that.kag.stat.chara_pos_mode == "true" && pm.left == "0") {
-
-
                 //立ち位置自動調整
                 if (pm.top != "0") {
                     j_chara_root.css("top", parseInt(pm.top));
@@ -2107,7 +1963,9 @@ tyrano.plugin.kag.tag.chara_show = {
                 var sc_width = parseInt(that.kag.config.scWidth);
                 var sc_height = parseInt(that.kag.config.scHeight);
 
-                var center = Math.floor(parseInt(j_chara_root.css("width")) / 2);
+                var center = Math.floor(
+                    parseInt(j_chara_root.css("width")) / 2,
+                );
 
                 //一つあたりの位置決定
                 var base = Math.floor(sc_width / (chara_cnt + 2));
@@ -2117,9 +1975,11 @@ tyrano.plugin.kag.tag.chara_show = {
                 j_chara_root.css("left", first_left + "px");
 
                 //すべてのanimationが完了するまで、次へ進めないように指定
-                var array_tyrano_chara = target_layer.find(".tyrano_chara").get().reverse();
-                $(array_tyrano_chara).each(function() {
-
+                var array_tyrano_chara = target_layer
+                    .find(".tyrano_chara")
+                    .get()
+                    .reverse();
+                $(array_tyrano_chara).each(function () {
                     chara_num++;
 
                     tmp_base += base;
@@ -2131,13 +1991,48 @@ tyrano.plugin.kag.tag.chara_show = {
                     var left = tmp_base - center;
 
                     if (that.kag.stat.chara_anim == "false") {
+                        j_chara
+                            .stop(true, true)
+                            .fadeTo(
+                                parseInt(that.kag.cutTimeWithSkip(pm.time)),
+                                0,
+                                function () {
+                                    j_chara.css("left", left);
 
-                        j_chara.stop(true, true).fadeTo(parseInt(that.kag.cutTimeWithSkip(pm.time)), 0, function() {
-
-                            j_chara.css("left", left);
-
-                            j_chara.stop(true, true).fadeTo(parseInt(that.kag.cutTimeWithSkip(that.kag.stat.pos_change_time)), 1, function() {
-
+                                    j_chara
+                                        .stop(true, true)
+                                        .fadeTo(
+                                            parseInt(
+                                                that.kag.cutTimeWithSkip(
+                                                    that.kag.stat
+                                                        .pos_change_time,
+                                                ),
+                                            ),
+                                            1,
+                                            function () {
+                                                chara_num--;
+                                                if (chara_num == 0) {
+                                                    that.kag.layer.showEventLayer();
+                                                    if (pm.wait == "true") {
+                                                        that.kag.ftag.nextOrder();
+                                                    }
+                                                }
+                                            },
+                                        );
+                                },
+                            );
+                    } else {
+                        j_chara.stop(true, true).animate(
+                            {
+                                left: left,
+                            },
+                            parseInt(
+                                that.kag.cutTimeWithSkip(
+                                    that.kag.stat.pos_change_time,
+                                ),
+                            ),
+                            that.kag.stat.chara_effect,
+                            function () {
                                 chara_num--;
                                 if (chara_num == 0) {
                                     that.kag.layer.showEventLayer();
@@ -2145,40 +2040,19 @@ tyrano.plugin.kag.tag.chara_show = {
                                         that.kag.ftag.nextOrder();
                                     }
                                 }
-                            });
-
-                        });
-
-                    } else {
-
-                        j_chara.stop(true, true).animate({
-                            left: left
-                        }, parseInt(that.kag.cutTimeWithSkip(that.kag.stat.pos_change_time)), that.kag.stat.chara_effect, function() {
-                            chara_num--;
-                            if (chara_num == 0) {
-                                that.kag.layer.showEventLayer();
-                                if (pm.wait == "true") {
-                                    that.kag.ftag.nextOrder();
-                                }
-                            }
-                        });
-
+                            },
+                        );
                     }
-
                 });
-
             } else {
-
                 j_chara_root.css("top", pm.top + "px");
                 j_chara_root.css("left", pm.left + "px");
 
                 //that.kag.ftag.nextOrder();
-
             }
 
             //読み込み後、サイズを指定する
-            setTimeout(function() {
-
+            setTimeout(function () {
                 var width = img_obj.css("width");
                 var height = img_obj.css("height");
 
@@ -2187,8 +2061,6 @@ tyrano.plugin.kag.tag.chara_show = {
 
                 j_chara_root.find(".part").css("width", width);
                 j_chara_root.find(".part").css("height", height);
-
-
             }, 1);
 
             //オブジェクトにクラス名をセットします name属性は一意でなければなりません
@@ -2217,30 +2089,28 @@ tyrano.plugin.kag.tag.chara_show = {
             }
 
             //アニメーションでj表示させます
-            j_chara_root.stop(true, true).animate({
-                opacity: "show"
-            }, {
-                duration: parseInt(that.kag.cutTimeWithSkip(pm.time)),
-                easing: that.kag.stat.chara_effect,
-                complete: function() {
+            j_chara_root.stop(true, true).animate(
+                {
+                    opacity: "show",
+                },
+                {
+                    duration: parseInt(that.kag.cutTimeWithSkip(pm.time)),
+                    easing: that.kag.stat.chara_effect,
+                    complete: function () {
+                        chara_num--;
+                        if (chara_num == 0) {
+                            that.kag.layer.showEventLayer();
 
-                    chara_num--;
-                    if (chara_num == 0) {
-                        that.kag.layer.showEventLayer();
-
-                        if (pm.wait == "true") {
-                            that.kag.ftag.nextOrder();
+                            if (pm.wait == "true") {
+                                that.kag.ftag.nextOrder();
+                            }
                         }
-
-                    }
-
-                }//end complerte
-            });
-
+                    }, //end complerte
+                },
+            );
         });
         //end preload
-
-    }
+    },
 };
 
 /*
@@ -2267,7 +2137,6 @@ tyrano.plugin.kag.tag.chara_show = {
  */
 
 tyrano.plugin.kag.tag.chara_hide = {
-
     vital: ["name"],
 
     pm: {
@@ -2276,12 +2145,10 @@ tyrano.plugin.kag.tag.chara_hide = {
         name: "",
         wait: "true",
         pos_mode: "true",
-        time: "1000"
-
+        time: "1000",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         var target_layer = this.kag.layer.getLayer(pm.layer, pm.page);
@@ -2294,16 +2161,13 @@ tyrano.plugin.kag.tag.chara_hide = {
         //画面上に存在しないなら無視する。
         img_obj.stop(true, true);
         if (!img_obj.get(0)) {
-
             img_obj.stop(true, true);
 
             if (img_obj.css("display") == "none") {
                 that.kag.ftag.nextOrder();
                 return;
             }
-
         }
-
 
         //キャラがいない場合、次へ
         if (!img_obj.get(0)) {
@@ -2315,105 +2179,133 @@ tyrano.plugin.kag.tag.chara_hide = {
         that.kag.layer.hideEventLayer();
 
         //アニメーションでj表示させます
-        img_obj.stop(true, true).animate({
-            opacity: "hide"
-        }, {
-            duration: parseInt(that.kag.cutTimeWithSkip(pm.time)),
-            easing: "linear",
-            complete: function() {
+        img_obj.stop(true, true).animate(
+            {
+                opacity: "hide",
+            },
+            {
+                duration: parseInt(that.kag.cutTimeWithSkip(pm.time)),
+                easing: "linear",
+                complete: function () {
+                    img_obj.remove();
 
-                img_obj.remove();
+                    if (
+                        that.kag.stat.chara_pos_mode == "true" &&
+                        pm.pos_mode == "true"
+                    ) {
+                        //既存キャラの位置を調整する
+                        var chara_cnt =
+                            target_layer.find(".tyrano_chara").length;
+                        var sc_width = parseInt(that.kag.config.scWidth);
+                        var sc_height = parseInt(that.kag.config.scHeight);
 
-                if (that.kag.stat.chara_pos_mode == "true" && pm.pos_mode == "true") {
+                        //一つあたりの位置決定
+                        var base = Math.floor(sc_width / (chara_cnt + 1));
+                        var tmp_base = 0;
 
-                    //既存キャラの位置を調整する
-                    var chara_cnt = target_layer.find(".tyrano_chara").length;
-                    var sc_width = parseInt(that.kag.config.scWidth);
-                    var sc_height = parseInt(that.kag.config.scHeight);
+                        if (chara_cnt == 0) {
+                            that.kag.layer.showEventLayer();
+                            if (pm.wait == "true") {
+                                that.kag.ftag.nextOrder();
+                            }
 
-                    //一つあたりの位置決定
-                    var base = Math.floor(sc_width / (chara_cnt + 1));
-                    var tmp_base = 0;
-
-                    if (chara_cnt == 0) {
-                        that.kag.layer.showEventLayer();
-                        if (pm.wait == "true") {
-                            that.kag.ftag.nextOrder();
+                            return;
                         }
 
-                        return;
-                    }
+                        var array_tyrano_chara = target_layer
+                            .find(".tyrano_chara")
+                            .get()
+                            .reverse();
+                        $(array_tyrano_chara).each(function () {
+                            chara_num++;
 
-                    var array_tyrano_chara = target_layer.find(".tyrano_chara").get().reverse();
-                    $(array_tyrano_chara).each(function() {
+                            tmp_base += base;
 
-                        chara_num++;
+                            var j_chara = $(this);
+                            //この分をプラスする感じですね
+                            var center = Math.floor(
+                                parseInt(j_chara.css("width")) / 2,
+                            );
+                            //1つ目は主人公にゆずる
+                            var left = tmp_base - center;
 
-                        tmp_base += base;
+                            if (that.kag.stat.chara_anim == "false") {
+                                j_chara
+                                    .stop(true, true)
+                                    .fadeTo(
+                                        parseInt(
+                                            that.kag.cutTimeWithSkip(pm.time),
+                                        ),
+                                        0,
+                                        function () {
+                                            j_chara.css("left", left);
 
-                        var j_chara = $(this);
-                        //この分をプラスする感じですね
-                        var center = Math.floor(parseInt(j_chara.css("width")) / 2);
-                        //1つ目は主人公にゆずる
-                        var left = tmp_base - center;
-
-                        if (that.kag.stat.chara_anim == "false") {
-
-                            j_chara.stop(true, true).fadeTo(parseInt(that.kag.cutTimeWithSkip(pm.time)), 0, function() {
-
-                                j_chara.css("left", left);
-
-                                j_chara.stop(true, true).fadeTo(parseInt(that.kag.cutTimeWithSkip(that.kag.stat.pos_change_time)), 1, function() {
-
-                                    chara_num--;
-                                    if (chara_num == 0) {
-                                        that.kag.layer.showEventLayer();
-                                        if (pm.wait == "true") {
-                                            that.kag.ftag.nextOrder();
+                                            j_chara
+                                                .stop(true, true)
+                                                .fadeTo(
+                                                    parseInt(
+                                                        that.kag.cutTimeWithSkip(
+                                                            that.kag.stat
+                                                                .pos_change_time,
+                                                        ),
+                                                    ),
+                                                    1,
+                                                    function () {
+                                                        chara_num--;
+                                                        if (chara_num == 0) {
+                                                            that.kag.layer.showEventLayer();
+                                                            if (
+                                                                pm.wait ==
+                                                                "true"
+                                                            ) {
+                                                                that.kag.ftag.nextOrder();
+                                                            }
+                                                        }
+                                                    },
+                                                );
+                                        },
+                                    );
+                            } else {
+                                j_chara.stop(true, true).animate(
+                                    {
+                                        left: left,
+                                    },
+                                    parseInt(
+                                        that.kag.cutTimeWithSkip(
+                                            that.kag.stat.pos_change_time,
+                                        ),
+                                    ),
+                                    that.kag.stat.chara_effect,
+                                    function () {
+                                        chara_num--;
+                                        if (chara_num == 0) {
+                                            that.kag.layer.showEventLayer();
+                                            if (pm.wait == "true") {
+                                                that.kag.ftag.nextOrder();
+                                            }
                                         }
-                                    }
-                                });
+                                    },
+                                );
+                            } // end else
+                        });
 
-                            });
-
-                        } else {
-
-                            j_chara.stop(true, true).animate({
-                                left: left
-                            }, parseInt(that.kag.cutTimeWithSkip(that.kag.stat.pos_change_time)), that.kag.stat.chara_effect, function() {
-
-                                chara_num--;
-                                if (chara_num == 0) {
-                                    that.kag.layer.showEventLayer();
-                                    if (pm.wait == "true") {
-                                        that.kag.ftag.nextOrder();
-                                    }
-                                }
-
-                            });
-
-                        }// end else
-
-                    });
-
-                    //that.kag.ftag.nextOrder();
-
-                } else {
-
-                    //実行待の時だけ実施する
-                    if (pm.wait == "true") {
-                        that.kag.layer.showEventLayer();
-                        that.kag.ftag.nextOrder();
+                        //that.kag.ftag.nextOrder();
+                    } else {
+                        //実行待の時だけ実施する
+                        if (pm.wait == "true") {
+                            that.kag.layer.showEventLayer();
+                            that.kag.ftag.nextOrder();
+                        }
                     }
-
-                }
-            }//end complerte
-        });
+                }, //end complerte
+            },
+        );
         // end animate
 
         //キャラクターの表情を引き継がない
         if (this.kag.stat.chara_memory == "false") {
-            this.kag.stat.charas[pm.name].storage = this.kag.stat.charas[pm.name]["map_face"]["default"];
+            this.kag.stat.charas[pm.name].storage =
+                this.kag.stat.charas[pm.name]["map_face"]["default"];
         }
 
         //すぐに次の命令を実行
@@ -2422,8 +2314,7 @@ tyrano.plugin.kag.tag.chara_hide = {
         }
 
         //this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -2445,19 +2336,16 @@ tyrano.plugin.kag.tag.chara_hide = {
  */
 
 tyrano.plugin.kag.tag.chara_hide_all = {
-
     vital: [],
 
     pm: {
         page: "fore",
         layer: "0", //レイヤーデフォルトは０に追加
         wait: "true",
-        time: "1000"
-
+        time: "1000",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         var target_layer = this.kag.layer.getLayer(pm.layer, pm.page);
@@ -2475,36 +2363,37 @@ tyrano.plugin.kag.tag.chara_hide_all = {
             charas[key].is_show = "false";
         }
 
-
         //キャラがいない場合、次へ
         if (!img_obj.get(0)) {
             that.kag.ftag.nextOrder();
             return;
         }
 
-        img_obj.stop(true, true).animate({
-            opacity: "hide"
-        }, {
-            duration: parseInt(that.kag.cutTimeWithSkip(pm.time)),
-            easing: "linear",
-            complete: function() {
-
-                img_obj.remove();
-                if (pm.wait == "true") {
-
-                    if (flag_complete == false) {
-                        flag_complete = true;
-                        that.kag.layer.showEventLayer();
-                        that.kag.ftag.nextOrder();
+        img_obj.stop(true, true).animate(
+            {
+                opacity: "hide",
+            },
+            {
+                duration: parseInt(that.kag.cutTimeWithSkip(pm.time)),
+                easing: "linear",
+                complete: function () {
+                    img_obj.remove();
+                    if (pm.wait == "true") {
+                        if (flag_complete == false) {
+                            flag_complete = true;
+                            that.kag.layer.showEventLayer();
+                            that.kag.ftag.nextOrder();
+                        }
                     }
-                }
-            }
-        });
+                },
+            },
+        );
 
         //キャラクターの表情を引き継がない
         if (this.kag.stat.chara_memory == "false") {
             for (key in this.kag.stat.charas) {
-                this.kag.stat.charas[key].storage = this.kag.stat.charas[key]["map_face"]["default"];
+                this.kag.stat.charas[key].storage =
+                    this.kag.stat.charas[key]["map_face"]["default"];
             }
         }
 
@@ -2515,8 +2404,7 @@ tyrano.plugin.kag.tag.chara_hide_all = {
         }
 
         //this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -2536,21 +2424,17 @@ tyrano.plugin.kag.tag.chara_hide_all = {
  */
 
 tyrano.plugin.kag.tag.chara_delete = {
-
     vital: ["name"],
 
     pm: {
-
-        name: ""
-
+        name: "",
     },
 
-    start: function(pm) {
+    start: function (pm) {
         delete this.kag.stat.charas[pm.name];
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -2579,23 +2463,19 @@ tyrano.plugin.kag.tag.chara_delete = {
  */
 
 tyrano.plugin.kag.tag.chara_mod = {
-
     vital: ["name"],
 
     pm: {
-
         name: "",
         face: "",
         reflect: "",
         storage: "",
         time: "",
         cross: "true",
-        wait: "true"
-
+        wait: "true",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
         that.kag.layer.hideEventLayer();
 
@@ -2603,20 +2483,24 @@ tyrano.plugin.kag.tag.chara_mod = {
         var folder = "./data/fgimage/";
 
         if (pm.face != "") {
-            if (!(this.kag.stat.charas[pm.name]["map_face"][pm.face])) {
-                this.kag.error("指定されたキャラクター「" + pm.name + "」もしくはface:「" + pm.face + "」は定義されていません。もう一度確認をお願いします");
+            if (!this.kag.stat.charas[pm.name]["map_face"][pm.face]) {
+                this.kag.error(
+                    "指定されたキャラクター「" +
+                        pm.name +
+                        "」もしくはface:「" +
+                        pm.face +
+                        "」は定義されていません。もう一度確認をお願いします",
+                );
                 return;
             }
             storage_url = this.kag.stat.charas[pm.name]["map_face"][pm.face];
         } else {
-
             if ($.isHTTP(pm.storage)) {
                 folder = "";
                 storage_url = pm.storage;
             } else {
                 storage_url = pm.storage;
             }
-
         }
 
         if ($(".layer_fore").find("." + pm.name).length == 0) {
@@ -2633,15 +2517,25 @@ tyrano.plugin.kag.tag.chara_mod = {
         }
 
         //変更する際の画像が同じ場合は、即時表示
-        if ($(".layer_fore").find("." + pm.name).find(".chara_img").attr("src") == folder + storage_url) {
+        if (
+            $(".layer_fore")
+                .find("." + pm.name)
+                .find(".chara_img")
+                .attr("src") ==
+            folder + storage_url
+        ) {
             chara_time = "0";
         }
 
         if (pm.reflect != "") {
             if (pm.reflect == "true") {
-                $(".layer_fore").find("." + pm.name).addClass("reflect");
+                $(".layer_fore")
+                    .find("." + pm.name)
+                    .addClass("reflect");
             } else {
-                $(".layer_fore").find("." + pm.name).removeClass("reflect");
+                $(".layer_fore")
+                    .find("." + pm.name)
+                    .removeClass("reflect");
             }
             this.kag.stat.charas[pm.name]["reflect"] = pm.reflect;
         }
@@ -2653,63 +2547,84 @@ tyrano.plugin.kag.tag.chara_mod = {
             return;
         }
 
-        this.kag.preload(folder + storage_url, function() {
-
+        this.kag.preload(folder + storage_url, function () {
             if ($(".chara-mod-animation").get(0)) {
                 $(".chara-mod-animation_" + pm.name).remove();
             }
 
             if (chara_time != "0") {
-
                 //アニメーションの停止
-                $(".layer_fore").find("." + pm.name).stop(true, true);
+                $(".layer_fore")
+                    .find("." + pm.name)
+                    .stop(true, true);
 
-                var j_new_img = $(".layer_fore").find("." + pm.name).clone();
+                var j_new_img = $(".layer_fore")
+                    .find("." + pm.name)
+                    .clone();
                 j_new_img.find(".chara_img").attr("src", folder + storage_url);
                 j_new_img.css("opacity", 0);
-
 
                 var j_img = $(".layer_fore").find("." + pm.name);
                 j_img.addClass("chara-mod-animation_" + pm.name);
                 j_img.after(j_new_img);
 
                 if (pm.cross == "true") {
-                    j_img.stop(true, true).fadeTo(parseInt(that.kag.cutTimeWithSkip(chara_time)), 0, function() {
-                        //alert("完了");
-                    });
+                    j_img
+                        .stop(true, true)
+                        .fadeTo(
+                            parseInt(that.kag.cutTimeWithSkip(chara_time)),
+                            0,
+                            function () {
+                                //alert("完了");
+                            },
+                        );
                 }
 
-                j_new_img.stop(true, true).fadeTo(parseInt(that.kag.cutTimeWithSkip(chara_time)), 1, function() {
+                j_new_img
+                    .stop(true, true)
+                    .fadeTo(
+                        parseInt(that.kag.cutTimeWithSkip(chara_time)),
+                        1,
+                        function () {
+                            if (pm.cross == "false") {
+                                j_img
+                                    .stop(true, true)
+                                    .fadeTo(
+                                        parseInt(
+                                            that.kag.cutTimeWithSkip(
+                                                chara_time,
+                                            ),
+                                        ),
+                                        0,
+                                        function () {
+                                            j_img.remove();
 
-                    if (pm.cross == "false") {
-                        j_img.stop(true, true).fadeTo(parseInt(that.kag.cutTimeWithSkip(chara_time)), 0, function() {
+                                            if (pm.wait == "true") {
+                                                that.kag.layer.showEventLayer();
+                                                that.kag.ftag.nextOrder();
+                                            }
+                                        },
+                                    );
+                            } else {
+                                j_img.remove();
 
-                            j_img.remove();
-
-                            if (pm.wait == "true") {
-                                that.kag.layer.showEventLayer();
-                                that.kag.ftag.nextOrder();
+                                if (pm.wait == "true") {
+                                    that.kag.layer.showEventLayer();
+                                    that.kag.ftag.nextOrder();
+                                }
                             }
-
-                        });
-
-                    } else {
-
-                        j_img.remove();
-
-                        if (pm.wait == "true") {
-                            that.kag.layer.showEventLayer();
-                            that.kag.ftag.nextOrder();
-                        }
-                    }
-                });
-
+                        },
+                    );
             } else {
-
                 //アニメーションの停止
-                $(".layer_fore").find("." + pm.name).stop(true, true);
+                $(".layer_fore")
+                    .find("." + pm.name)
+                    .stop(true, true);
 
-                $(".layer_fore").find("." + pm.name).find(".chara_img").attr("src", folder + storage_url);
+                $(".layer_fore")
+                    .find("." + pm.name)
+                    .find(".chara_img")
+                    .attr("src", folder + storage_url);
 
                 if (pm.wait == "true") {
                     that.kag.layer.showEventLayer();
@@ -2724,13 +2639,9 @@ tyrano.plugin.kag.tag.chara_mod = {
                 that.kag.layer.showEventLayer();
                 that.kag.ftag.nextOrder();
             }
-
         });
-
-    }
+    },
 };
-
-
 
 /*
  #[chara_move]
@@ -2790,11 +2701,9 @@ tyrano.plugin.kag.tag.chara_mod = {
  */
 
 tyrano.plugin.kag.tag.chara_move = {
-
     vital: ["name"],
 
     pm: {
-
         name: "",
         time: "600",
         anim: "false",
@@ -2803,16 +2712,16 @@ tyrano.plugin.kag.tag.chara_move = {
         width: "",
         height: "",
         effect: "",
-        wait: "true"
-
+        wait: "true",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         var target_obj = $(".layer_fore").find("." + pm.name + ".tyrano_chara");
-        var target_img = $(".layer_fore").find("." + pm.name + ".tyrano_chara").find("img");
+        var target_img = $(".layer_fore")
+            .find("." + pm.name + ".tyrano_chara")
+            .find("img");
 
         //存在しない場合は、即移動
         if (!target_obj.get(0)) {
@@ -2841,52 +2750,61 @@ tyrano.plugin.kag.tag.chara_move = {
         var target = "";
 
         if (pm.name != "") {
-
             if (pm.anim == "true") {
+                target_obj
+                    .stop(true, true)
+                    .animate(
+                        anim_style,
+                        parseInt(pm.time),
+                        pm.effect,
+                        function () {
+                            if (pm.wait == "true") {
+                                that.kag.ftag.nextOrder();
+                            }
+                        },
+                    );
 
-                target_obj.stop(true, true).animate(anim_style, parseInt(pm.time), pm.effect, function() {
-
-                    if (pm.wait == "true") {
-                        that.kag.ftag.nextOrder();
-                    }
-
-                });
-
-                target_img.stop(true, true).animate(img_anim_style, parseInt(pm.time), pm.effect, function() {
-
-                });
-
-
+                target_img
+                    .stop(true, true)
+                    .animate(
+                        img_anim_style,
+                        parseInt(pm.time),
+                        pm.effect,
+                        function () {},
+                    );
             } else {
+                target_obj
+                    .stop(true, true)
+                    .fadeTo(
+                        parseInt(that.kag.cutTimeWithSkip(pm.time)) / 2,
+                        0,
+                        function () {
+                            target_obj.css(anim_style);
+                            target_img.css(img_anim_style);
 
-                target_obj.stop(true, true).fadeTo(parseInt(that.kag.cutTimeWithSkip(pm.time)) / 2, 0, function() {
-
-                    target_obj.css(anim_style);
-                    target_img.css(img_anim_style);
-
-                    target_obj.stop(true, true).fadeTo(parseInt(that.kag.cutTimeWithSkip(pm.time)) / 2, 1, function() {
-                        if (pm.wait == "true") {
-                            that.kag.ftag.nextOrder();
-                        }
-                    });
-
-
-                });
-
-
-
+                            target_obj
+                                .stop(true, true)
+                                .fadeTo(
+                                    parseInt(
+                                        that.kag.cutTimeWithSkip(pm.time),
+                                    ) / 2,
+                                    1,
+                                    function () {
+                                        if (pm.wait == "true") {
+                                            that.kag.ftag.nextOrder();
+                                        }
+                                    },
+                                );
+                        },
+                    );
             }
-
         }
 
         if (pm.wait == "false") {
             this.kag.ftag.nextOrder();
         }
-
-    }
+    },
 };
-
-
 
 /*
  #[chara_face]
@@ -2918,19 +2836,15 @@ tyrano.plugin.kag.tag.chara_move = {
  */
 
 tyrano.plugin.kag.tag.chara_face = {
-
     vital: ["name", "face", "storage"],
 
     pm: {
-
         name: "",
         face: "",
-        storage: ""
-
+        storage: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var storage_url = "";
 
         if ($.isHTTP(pm.storage)) {
@@ -2941,10 +2855,8 @@ tyrano.plugin.kag.tag.chara_face = {
 
         this.kag.stat.charas[pm.name]["map_face"][pm.face] = storage_url;
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
 
 /*
  #[chara_layer]
@@ -2968,7 +2880,6 @@ tyrano.plugin.kag.tag.chara_face = {
  */
 
 tyrano.plugin.kag.tag.chara_layer = {
-
     vital: ["name", "part", "id", "storage"],
 
     pm: {
@@ -2976,15 +2887,18 @@ tyrano.plugin.kag.tag.chara_layer = {
         part: "",
         id: "",
         storage: "",
-        zindex: ""
+        zindex: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var cpm = this.kag.stat.charas[pm.name];
 
         if (cpm == null) {
-            this.kag.error("指定されたキャラクター「" + pm.name + "」は定義されていません。[chara_new]で定義してください");
+            this.kag.error(
+                "指定されたキャラクター「" +
+                    pm.name +
+                    "」は定義されていません。[chara_new]で定義してください",
+            );
             return;
         }
 
@@ -3003,14 +2917,13 @@ tyrano.plugin.kag.tag.chara_layer = {
         var init_part = false;
         if (chara_layer[pm.part]) {
             chara_part = chara_layer[pm.part];
-
         } else {
             init_part = true;
             //一つ上のレイヤに配置する
             cpm["_layer"][pm.part] = {
-                "default_part_id": pm.id,
-                "current_part_id": pm.id,
-                "zindex": pm.zindex
+                default_part_id: pm.id,
+                current_part_id: pm.id,
+                zindex: pm.zindex,
             };
         }
 
@@ -3020,10 +2933,9 @@ tyrano.plugin.kag.tag.chara_layer = {
         if (chara_part[pm.id]) {
             chara_obj = chara_part[pm.id];
         } else {
-
             chara_obj = {
                 storage: "",
-                zindex: ""
+                zindex: "",
             };
 
             //パーツ自体が初めての場合は、showにする。
@@ -3032,18 +2944,13 @@ tyrano.plugin.kag.tag.chara_layer = {
             } else {
                 chara_obj["visible"] = "false";
             }
-
         }
-
 
         cpm["_layer"][pm.part][pm.id] = $.extendParam(pm, chara_obj);
 
         this.kag.ftag.nextOrder();
-
-
-    }
+    },
 };
-
 
 /*
  #[chara_layer_mod]
@@ -3064,29 +2971,35 @@ tyrano.plugin.kag.tag.chara_layer = {
  */
 
 tyrano.plugin.kag.tag.chara_layer_mod = {
-
     vital: ["name", "part"],
 
     pm: {
         name: "",
         part: "",
-        zindex: ""
+        zindex: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         var cpm = this.kag.stat.charas[pm.name];
 
         if (cpm == null) {
-            this.kag.error("指定されたキャラクター「" + pm.name + "」は定義されていません。[chara_new]で定義してください");
+            this.kag.error(
+                "指定されたキャラクター「" +
+                    pm.name +
+                    "」は定義されていません。[chara_new]で定義してください",
+            );
             return;
         }
 
         //レイヤが登録されているかどうか
         if (!cpm["_layer"]) {
-            this.kag.error("指定されたキャラクター「" + pm.name + "」の差分パーツは設定されていません。[chara_layer]で定義してください");
+            this.kag.error(
+                "指定されたキャラクター「" +
+                    pm.name +
+                    "」の差分パーツは設定されていません。[chara_layer]で定義してください",
+            );
             return;
         }
 
@@ -3095,11 +3008,8 @@ tyrano.plugin.kag.tag.chara_layer_mod = {
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
-
 
 /*
  #[chara_part]
@@ -3126,30 +3036,36 @@ tyrano.plugin.kag.tag.chara_layer_mod = {
  */
 
 tyrano.plugin.kag.tag.chara_part = {
-
     vital: ["name"],
 
     pm: {
         name: "",
         allow_storage: "false",
         time: "",
-        wait: "true"
+        wait: "true",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         var cpm = this.kag.stat.charas[pm.name];
 
         if (cpm == null) {
-            this.kag.error("指定されたキャラクター「" + pm.name + "」は定義されていません。[chara_new]で定義してください");
+            this.kag.error(
+                "指定されたキャラクター「" +
+                    pm.name +
+                    "」は定義されていません。[chara_new]で定義してください",
+            );
             return;
         }
 
         //レイヤが登録されているかどうか
         if (!cpm["_layer"]) {
-            this.kag.error("指定されたキャラクター「" + pm.name + "」の差分パーツは設定されていません。[chara_layer]で定義してください");
+            this.kag.error(
+                "指定されたキャラクター「" +
+                    pm.name +
+                    "」の差分パーツは設定されていません。[chara_layer]で定義してください",
+            );
             return;
         }
 
@@ -3161,12 +3077,9 @@ tyrano.plugin.kag.tag.chara_part = {
         var part_num = 0;
 
         for (key in pm) {
-
             if (chara_part[key]) {
-
                 var part_id = pm[key];
                 if (chara_part[key][part_id]) {
-
                     var part = chara_part[key][part_id];
                     part.id = part_id;
                     map_part[key] = part;
@@ -3177,40 +3090,36 @@ tyrano.plugin.kag.tag.chara_part = {
                     }
 
                     //デフォルトのパートを変更する
-                    this.kag.stat.charas[pm.name]["_layer"][key]["current_part_id"] = part_id;
-
+                    this.kag.stat.charas[pm.name]["_layer"][key][
+                        "current_part_id"
+                    ] = part_id;
                 } else {
-
                     if (pm.allow_storage == "true") {
-
-                        map_part[key] = { "storage": part_id, "id": part_id };
+                        map_part[key] = { storage: part_id, id: part_id };
                         array_storage.push("./data/fgimage/" + part_id);
 
-                        this.kag.stat.charas[pm.name]["_layer"][key]["current_part_id"] = "allow_storage";
-                        this.kag.stat.charas[pm.name]["_layer"][key]["allow_storage"] = part_id;
-
+                        this.kag.stat.charas[pm.name]["_layer"][key][
+                            "current_part_id"
+                        ] = "allow_storage";
+                        this.kag.stat.charas[pm.name]["_layer"][key][
+                            "allow_storage"
+                        ] = part_id;
                     }
-
                 }
-
             }
-
         }
 
         var target_obj = $(".layer_fore").find("." + pm.name + ".tyrano_chara");
 
         //プリロード
-        this.kag.preloadAll(array_storage, function() {
-
+        this.kag.preloadAll(array_storage, function () {
             //指定された配列を回して、該当するオブジェクトを切り替える
             if (pm.time != "") {
-
                 var n = 0;
                 var cnt = 0;
 
                 for (key in map_part) {
-
-                    (function() {
+                    (function () {
                         cnt++;
                         var part = map_part[key];
                         var j_img = target_obj.find(".part" + "." + key + "");
@@ -3218,9 +3127,15 @@ tyrano.plugin.kag.tag.chara_part = {
                         j_new_img.css("opacity", 0);
 
                         if (part.storage != "none") {
-                            j_new_img.attr("src", "./data/fgimage/" + part.storage);
+                            j_new_img.attr(
+                                "src",
+                                "./data/fgimage/" + part.storage,
+                            );
                         } else {
-                            j_new_img.attr("src", "./tyrano/images/system/transparent.png");
+                            j_new_img.attr(
+                                "src",
+                                "./tyrano/images/system/transparent.png",
+                            );
                         }
 
                         //zindexの指定があった場合は、変更を行う
@@ -3233,39 +3148,40 @@ tyrano.plugin.kag.tag.chara_part = {
                         //イメージを追加
                         j_img.after(j_new_img);
 
-                        j_img.stop(true, true).fadeTo(parseInt(pm.time), 0, function() {
-                            j_img.remove();
-                        });
+                        j_img
+                            .stop(true, true)
+                            .fadeTo(parseInt(pm.time), 0, function () {
+                                j_img.remove();
+                            });
 
-                        j_new_img.stop(true, true).fadeTo(parseInt(pm.time), 1, function() {
-                            n++;
-                            if (pm.wait == "true") {
-                                if (cnt == n) {
-                                    that.kag.ftag.nextOrder();
+                        j_new_img
+                            .stop(true, true)
+                            .fadeTo(parseInt(pm.time), 1, function () {
+                                n++;
+                                if (pm.wait == "true") {
+                                    if (cnt == n) {
+                                        that.kag.ftag.nextOrder();
+                                    }
                                 }
-                            }
-                        });
+                            });
                     })();
-
                 }
-
 
                 if (pm.wait == "false") {
                     that.kag.ftag.nextOrder();
                 }
-
-
             } else {
-
                 for (key in map_part) {
-
                     var part = map_part[key];
                     var j_img = target_obj.find(".part" + "." + key + "");
 
                     if (part.storage != "none") {
                         j_img.attr("src", "./data/fgimage/" + part.storage);
                     } else {
-                        j_img.attr("src", "./tyrano/images/system/transparent.png");
+                        j_img.attr(
+                            "src",
+                            "./tyrano/images/system/transparent.png",
+                        );
                     }
 
                     //zindexの指定があった場合は、変更を行う
@@ -3274,21 +3190,13 @@ tyrano.plugin.kag.tag.chara_part = {
                     } else {
                         j_img.css("z-index", chara_part[key]["zindex"]);
                     }
-
                 }
 
                 that.kag.ftag.nextOrder();
-
-
             }
-
         });
-
-
-    }
+    },
 };
-
-
 
 /*
  #[chara_part_reset]
@@ -3308,28 +3216,34 @@ tyrano.plugin.kag.tag.chara_part = {
  */
 
 tyrano.plugin.kag.tag.chara_part_reset = {
-
     vital: ["name"],
 
     pm: {
         name: "",
-        part: ""
+        part: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         var cpm = this.kag.stat.charas[pm.name];
 
         if (cpm == null) {
-            this.kag.error("指定されたキャラクター「" + pm.name + "」は定義されていません。[chara_new]で定義してください");
+            this.kag.error(
+                "指定されたキャラクター「" +
+                    pm.name +
+                    "」は定義されていません。[chara_new]で定義してください",
+            );
             return;
         }
 
         //レイヤが登録されているかどうか
         if (!cpm["_layer"]) {
-            this.kag.error("指定されたキャラクター「" + pm.name + "」の差分パーツは設定されていません。[chara_layer]で定義してください");
+            this.kag.error(
+                "指定されたキャラクター「" +
+                    pm.name +
+                    "」の差分パーツは設定されていません。[chara_layer]で定義してください",
+            );
             return;
         }
 
@@ -3337,19 +3251,14 @@ tyrano.plugin.kag.tag.chara_part_reset = {
 
         //chara_part のタグをつくって、デフォルトに戻す
         var new_pm = {
-            "name": pm.name
+            name: pm.name,
         };
 
         if (pm.part == "") {
-
             for (key in chara_part) {
-
                 new_pm[key] = chara_part[key]["default_part_id"];
-
             }
-
         } else {
-
             //partが指定されている
             var array_part = pm.part.split(",");
             for (var i = 0; i < array_part.length; i++) {
@@ -3358,14 +3267,11 @@ tyrano.plugin.kag.tag.chara_part_reset = {
                     new_pm[key] = chara_part[key]["default_part_id"];
                 }
             }
-
         }
 
         this.kag.ftag.startTag("chara_part", new_pm);
-
-    }
+    },
 };
-
 
 /*
  #[showlog]
@@ -3382,20 +3288,13 @@ tyrano.plugin.kag.tag.chara_part_reset = {
  */
 
 tyrano.plugin.kag.tag.showlog = {
+    pm: {},
 
-    pm: {
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.menu.displayLog();
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
-
-
 
 /*
 #[filter]
@@ -3436,10 +3335,8 @@ blur=0(デフォルト)-任意の値[px] を指定することで、画像の表
 #[end]
 */
 
-
 //イメージ情報消去背景とか
 tyrano.plugin.kag.tag.filter = {
-
     vital: [],
 
     pm: {
@@ -3455,12 +3352,10 @@ tyrano.plugin.kag.tag.filter = {
         opacity: "",
         brightness: "",
         contrast: "",
-        blur: ""
-
+        blur: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var filter_str = "";
 
         var j_obj = {};
@@ -3470,7 +3365,6 @@ tyrano.plugin.kag.tag.filter = {
         } else {
             j_obj = this.kag.layer.getLayer(pm.layer, pm.page);
         }
-
 
         if (pm.name != "") {
             j_obj = j_obj.find("." + pm.name);
@@ -3512,16 +3406,13 @@ tyrano.plugin.kag.tag.filter = {
             filter_str += "blur(" + pm.blur + "px) ";
         }
 
-
-
         j_obj.css({
             "-webkit-filter": filter_str,
             "-ms-filter": filter_str,
-            "-moz-filter": filter_str
+            "-moz-filter": filter_str,
         });
 
         j_obj.addClass("tyrano_filter_effect");
-
 
         /*
         grayscale:"",
@@ -3535,14 +3426,9 @@ tyrano.plugin.kag.tag.filter = {
         blur:""
         */
 
-
         this.kag.ftag.nextOrder();
-
-
-
-    }
+    },
 };
-
 
 /*
 #[free_filter]
@@ -3573,21 +3459,17 @@ name=フィルターを打ち消したい、nameを指定します。レイヤ�
 #[end]
 */
 
-
 //イメージ情報消去背景とか
 tyrano.plugin.kag.tag.free_filter = {
-
     vital: [],
 
     pm: {
         layer: "",
         page: "fore",
-        name: ""
-
+        name: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var filter_str = "";
 
         var j_obj;
@@ -3602,26 +3484,17 @@ tyrano.plugin.kag.tag.free_filter = {
             j_obj = j_obj.find("." + pm.name);
         }
 
-
         j_obj.css({
             "-webkit-filter": "",
             "-ms-filter": "",
-            "-moz-filter": ""
+            "-moz-filter": "",
         });
-
 
         j_obj.removeClass("tyrano_filter_effect");
 
-
         this.kag.ftag.nextOrder();
-
-
-
-    }
+    },
 };
-
-
-
 
 /*
  #[web]
@@ -3653,48 +3526,32 @@ tyrano.plugin.kag.tag.free_filter = {
  */
 
 tyrano.plugin.kag.tag.web = {
-
     vital: ["url"],
 
     pm: {
-        url: ""
+        url: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         if (pm.url.indexOf("http") == -1) {
-
             //this.kag.log("error:[web] url is not correct " + pm.url);
             window.open(pm.url);
-
         } else {
-
             //PC nwjsの場合
             if ($.isNWJS()) {
-
-                var gui = require('nw.gui');
+                var gui = require("nw.gui");
                 gui.Shell.openExternal(pm.url);
-
             } else if ($.isElectron()) {
-
                 var shell = require("electron").shell;
                 shell.openExternal(pm.url);
-
             } else if ($.isTyranoPlayer()) {
-
                 //ティラノプレイヤーなら、上に伝える
                 $.openWebFromApp(pm.url);
-
             } else {
-
                 window.open(pm.url);
-
             }
         }
 
         this.kag.ftag.nextOrder();
-
-
-    }
-
+    },
 };

--- a/tyrano/plugins/kag/kag.tag_ext.js
+++ b/tyrano/plugins/kag/kag.tag_ext.js
@@ -1,25 +1,30 @@
 //スクリプトの評価
 
 /*
- #[loadjs]
- :group
- マクロ・変数・JS操作
- :title
- 外部JavaScriptファイル読み込み
- :exp
- 外部JavaScriptファイルをロードします
- 無制限な機能拡張が可能です
- JSファイルは/data/others フォルダ以下に格納してください
- :sample
- [loadjs storage="sample.js"  ]
- :param
- storage=ロードするJSファイルを指定します
+#[loadjs]
 
- :demo
- 2,kaisetsu/21_othello
+:group
+マクロ・変数・JS操作
 
- #[end]
- */
+:title
+外部JavaScriptファイル読み込み
+
+:exp
+外部JavaScriptファイルをロードします
+無制限な機能拡張が可能です
+JSファイルは/data/others フォルダ以下に格納してください
+
+:sample
+[loadjs storage="sample.js"  ]
+
+:param
+storage=ロードするJSファイルを指定します
+
+:demo
+2,kaisetsu/21_othello
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.loadjs = {
     vital: ["storage"],
@@ -38,26 +43,31 @@ tyrano.plugin.kag.tag.loadjs = {
 };
 
 /*
- #[movie]
- :group
- その他
- :title
- ムービーの再生
- :exp
- ogv webm mp4 などに対応します
- 提供するゲームによって対応するフォーマットが異なります。
- PCゲーム形式の場合は webm形式を使ってください。 mp4 に対応しません。
- ブラウザゲームの場合はmp4ファイルを使用します。ただし、FireFox Opera を含む全てのブラウザに対応させる場合は同名のwebmファイルも配置して下さい
+#[movie]
 
- :sample
- [movie storage="" skip=false ]
- :param
- storage=再生するogv webm mp4ファイルを指定してください,
- skip=動画再生中に途中でスキップ可能か否かを指定します true か false を指定してください,
- mute=true/falseを指定します。デフォルトはfalse。動画の音をミュートにできます。スマホブラウザの場合、動作が再生前のユーザアクションが必要ですが、trueを指定することでこの制限を無視できます。,
- volume=ビデオの音量を指定できます 0〜100の間で指定して下さい。デフォルトは100
- #[end]
- */
+:group
+その他
+
+:title
+ムービーの再生
+
+:exp
+ogv webm mp4 などに対応します
+提供するゲームによって対応するフォーマットが異なります。
+PCゲーム形式の場合は webm形式を使ってください。 mp4 に対応しません。
+ブラウザゲームの場合はmp4ファイルを使用します。ただし、FireFox Opera を含む全てのブラウザに対応させる場合は同名のwebmファイルも配置して下さい
+
+:sample
+[movie storage="" skip=false ]
+
+:param
+storage=再生するogv webm mp4ファイルを指定します,
+skip=動画再生中に途中でスキップ可能かどうかをtrueまたはfalseで指定します。,
+mute=true/falseを指定します。デフォルトはfalse。動画の音をミュートにできます。スマホブラウザの場合、動作が再生前のユーザアクションが必要ですが、trueを指定することでこの制限を無視できます。,
+volume=ビデオの音量を指定できます 0〜100の間で指定して下さい。デフォルトは100
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.movie = {
     vital: ["storage"],
@@ -287,32 +297,37 @@ tyrano.plugin.kag.tag.movie = {
 };
 
 /*
- #[bgmovie]
- :group
- その他
- :title
- 背景ムービーの再生
- :exp
- ogv webm mp4 などに対応します
- 提供するゲームによって対応するフォーマットが異なります。
- PCゲーム形式の場合は webm形式を使ってください。 mp4 に対応しません。
- ブラウザゲームの場合はmp4ファイルを使用します。ただし、FireFox Opera を含む全てのブラウザに対応させる場合は同名のwebmファイルも配置して下さい
- stop_bgmovie タグを指定すると再生が終わります。
+#[bgmovie]
+
+:group
+その他
+
+:title
+背景ムービーの再生
+
+:exp
+ogv webm mp4 などに対応します
+提供するゲームによって対応するフォーマットが異なります。
+PCゲーム形式の場合は webm形式を使ってください。 mp4 に対応しません。
+ブラウザゲームの場合はmp4ファイルを使用します。ただし、FireFox Opera を含む全てのブラウザに対応させる場合は同名のwebmファイルも配置して下さい
+stop_bgmovie タグを指定すると再生が終わります。
 
 bgmovieをループ中に別のbgmovieを重ねることで、ループが完了してから次の動画を再生させる事ができます。
 
- （注意）このタグはPC限定です。スマホでは利用できません。
+（注意）このタグはPC限定です。スマホでは利用できません。
 
- :sample
- [bgmovie storage="test.webm" ]
- :param
- storage=再生するogv webm mp4ファイルを指定してください,
- time=背景動画を表示するときにフェードアウト効果を与える時間を指定します。デフォルトは1000(ミリ秒),
- mute=true/falseを指定します。デフォルトはfalse。動画の音をミュートにできます。スマホブラウザの場合、動作が再生前のユーザアクションが必要ですが、trueを指定することでこの制限を無視できます。,
- volume=ビデオの音量を指定できます 0〜100の間で指定して下さい。デフォルトは100 ,
- loop=背景動画をループさせるかどうかを指定します。falseを指定すると動画の最後の状態で停止します。
- #[end]
- */
+:sample
+[bgmovie storage="test.webm" ]
+
+:param
+storage=再生するogv webm mp4ファイルを指定します,
+time=背景動画を表示するときにフェードアウト効果を与える時間を指定します。デフォルトは1000(ミリ秒),
+mute=true/falseを指定します。デフォルトはfalse。動画の音をミュートにできます。スマホブラウザの場合、動作が再生前のユーザアクションが必要ですが、trueを指定することでこの制限を無視できます。,
+volume=ビデオの音量を指定できます 0〜100の間で指定して下さい。デフォルトは100 ,
+loop=背景動画をループさせるかどうかを指定します。falseを指定すると動画の最後の状態で停止します。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.bgmovie = {
     vital: ["storage"],
@@ -354,17 +369,23 @@ tyrano.plugin.kag.tag.bgmovie = {
 };
 
 /*
- #[wait_bgmovie]
- :group
- その他
- :title
- 背景ムービーの再生完了を待つ
- :exp
- 再生中の背景ムービーの完了を待ちます。
- :sample
- :param
- #[end]
- */
+#[wait_bgmovie]
+
+:group
+その他
+
+:title
+背景ムービーの再生完了を待つ
+
+:exp
+再生中の背景ムービーの完了を待ちます。
+
+:sample
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.wait_bgmovie = {
     vital: [],
@@ -387,20 +408,26 @@ tyrano.plugin.kag.tag.wait_bgmovie = {
 };
 
 /*
- #[stop_bgmovie]
- :group
- その他
- :title
- 背景ムービーの停止
- :exp
- bgmovieで再生した背景動画を停止します。
- :sample
- [stop_bgmovie storage="" skip=false ]
- :param
- time=ミリ秒で指定すると、動画をフェードアウトして削除することが可能です。デフォルトは1000,
- wait=trueかfalse を指定します。動画のフェードアウトを待つかどうかを指定できます。デフォルトはtrue
- #[end]
- */
+#[stop_bgmovie]
+
+:group
+その他
+
+:title
+背景ムービーの停止
+
+:exp
+bgmovieで再生した背景動画を停止します。
+
+:sample
+[stop_bgmovie storage="" skip=false ]
+
+:param
+time=ミリ秒で指定すると、動画をフェードアウトして削除することが可能です。デフォルトは1000,
+wait=trueかfalse を指定します。動画のフェードアウトを待つかどうかを指定できます。デフォルトはtrue
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.stop_bgmovie = {
     vital: [],
@@ -446,18 +473,24 @@ tyrano.plugin.kag.tag.stop_bgmovie = {
 };
 
 /*
- #[showsave]
- :group
- システム操作
- :title
- セーブ画面を表示します
- :exp
- セーブ画面を表示します
- :sample
- [showsave]
- :param
- #[end]
- */
+#[showsave]
+
+:group
+システム操作
+
+:title
+セーブ画面を表示します
+
+:exp
+セーブ画面を表示します
+
+:sample
+[showsave]
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.showsave = {
     pm: {},
@@ -474,18 +507,24 @@ tyrano.plugin.kag.tag.showsave = {
 };
 
 /*
- #[showload]
- :group
- システム操作
- :title
- ロード画面を表示します
- :exp
- ロード画面を表示します
- :sample
- [showload]
- :param
- #[end]
- */
+#[showload]
+
+:group
+システム操作
+
+:title
+ロード画面を表示します
+
+:exp
+ロード画面を表示します
+
+:sample
+[showload]
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.showload = {
     pm: {},
@@ -499,18 +538,24 @@ tyrano.plugin.kag.tag.showload = {
 };
 
 /*
- #[showmenu]
- :group
- システム操作
- :title
- メニュー画面を表示します
- :exp
- メニュ＾画面を表示します
- :sample
- [showmenu]
- :param
- #[end]
- */
+#[showmenu]
+
+:group
+システム操作
+
+:title
+メニュー画面を表示します
+
+:exp
+メニュ＾画面を表示します
+
+:sample
+[showmenu]
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.showmenu = {
     pm: {},
@@ -522,18 +567,24 @@ tyrano.plugin.kag.tag.showmenu = {
 };
 
 /*
- #[showmenubutton]
- :group
- システム操作
- :title
- メニューボタンを表示
- :exp
- メニューボタンを表示します
- :sample
- [showmenubutton]
- :param
- #[end]
- */
+#[showmenubutton]
+
+:group
+システム操作
+
+:title
+メニューボタンを表示
+
+:exp
+メニューボタンを表示します
+
+:sample
+[showmenubutton]
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.showmenubutton = {
     pm: {},
@@ -547,18 +598,24 @@ tyrano.plugin.kag.tag.showmenubutton = {
 };
 
 /*
- #[hidemenubutton]
- :group
- システム操作
- :title
- メニューボタンを非表示
- :exp
- メニューボタンを非表示します
- :sample
- [hidemenubutton]
- :param
- #[end]
- */
+#[hidemenubutton]
+
+:group
+システム操作
+
+:title
+メニューボタンを非表示
+
+:exp
+メニューボタンを非表示します
+
+:sample
+[hidemenubutton]
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.hidemenubutton = {
     pm: {},
@@ -572,17 +629,23 @@ tyrano.plugin.kag.tag.hidemenubutton = {
 };
 
 /*
- #[skipstart]
- :group
- システム操作
- :title
- スキップ開始
- :exp
- 文字表示をスキップモードにします。
- :sample
- :param
- #[end]
- */
+#[skipstart]
+
+:group
+システム操作
+
+:title
+スキップ開始
+
+:exp
+文字表示をスキップモードにします。
+
+:sample
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.skipstart = {
     pm: {},
@@ -601,17 +664,23 @@ tyrano.plugin.kag.tag.skipstart = {
 };
 
 /*
- #[skipstop]
- :group
- システム操作
- :title
- スキップ停止
- :exp
- スキップモードを停止します。
- :sample
- :param
- #[end]
- */
+#[skipstop]
+
+:group
+システム操作
+
+:title
+スキップ停止
+
+:exp
+スキップモードを停止します。
+
+:sample
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.skipstop = {
     pm: {},
@@ -623,18 +692,24 @@ tyrano.plugin.kag.tag.skipstop = {
 };
 
 /*
- #[autostart]
- :group
- システム操作
- :title
- オート開始
- :exp
- 文字表示を一定間隔で自動的に進めます。
- 進行速度はconfig.tjsのautoSpeedを確認して下さい
- :sample
- :param
- #[end]
- */
+#[autostart]
+
+:group
+システム操作
+
+:title
+オート開始
+
+:exp
+文字表示を一定間隔で自動的に進めます。
+進行速度はconfig.tjsのautoSpeedを確認して下さい
+
+:sample
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.autostart = {
     pm: {},
@@ -653,17 +728,23 @@ tyrano.plugin.kag.tag.autostart = {
 };
 
 /*
- #[autostop]
- :group
- システム操作
- :title
- オート停止（）
- :exp
- オートモードを停止します。
- :sample
- :param
- #[end]
- */
+#[autostop]
+
+:group
+システム操作
+
+:title
+オート停止（）
+
+:exp
+オートモードを停止します。
+
+:sample
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.autostop = {
     pm: {
@@ -683,19 +764,25 @@ tyrano.plugin.kag.tag.autostop = {
 };
 
 /*
- #[autoconfig]
- :group
- システム操作
- :title
- オート設定
- :exp
- オートモードに関する設定
- :sample
- :param
- speed=オート時のスピードをミリ秒で指定して下さい,
- clickstop=画面クリック時にオートを停止するかどうかを指定します true(停止する デフォルト) false（停止しない）
- #[end]
- */
+#[autoconfig]
+
+:group
+システム操作
+
+:title
+オート設定
+
+:exp
+オートモードに関する設定
+
+:sample
+
+:param
+speed=オート時のスピードをミリ秒で指定して下さい,
+clickstop=画面クリック時にオートを停止するかどうかを指定します true(停止する デフォルト) false（停止しない）
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.autoconfig = {
     pm: {
@@ -725,85 +812,89 @@ tyrano.plugin.kag.tag.autoconfig = {
 };
 
 /*
- #[anim]
- :group
- アニメーション関連
- :title
- アニメーション
- :exp
- 画像やボタン、レイヤなどの中身をアニメーションさせることができます
- アニメーションさせる要素は[image][ptext][button]タグ作成時にname属性で指定した名前を利用できます。
- レイヤを指定するとレイヤの中にある要素全てを同時にアニメーションできます
- このタグはアニメーションの終了を待ちません。[wa]タグを使用すると実行中のすべてのアニメーションの完了を待つことができます。
- 位置のアニメーションは指定する値に+=100 -=100　と指定することで相対位置指定できます（今表示されているところから、右へ１００PX移動といった指定ができます）
- 透明度を指定すれば、アニメーションしながら非表示にすることもできます。
- :sample
- [ptext layer=1 page=fore text="文字列" size=30 x=0 y=0 color=red vertical=true]
+#[anim]
 
- [image layer=0 left=100 top=100  storage = yuko1.png page=fore visible=true name=yuko,chara ]
- [image layer=1 left=300 top=100 storage = haruko1.png page=fore visible=true name=haruko ]
+:group
+アニメーション関連
 
- ;name属性を指定してアニメーション
- [anim name=haruko left="+=100" time=10000 effect=easeInCirc opacity=0  ]
+:title
+アニメーション
 
- ;レイヤを指定してアニメーション
- [anim layer=1 left="+=100" effect=easeInCirc opacity=0  ]
+:exp
+画像やボタン、レイヤなどの中身をアニメーションさせることができます
+アニメーションさせる要素は[image][ptext][button]タグ作成時にname属性で指定した名前を利用できます。
+レイヤを指定するとレイヤの中にある要素全てを同時にアニメーションできます
+このタグはアニメーションの終了を待ちません。[wa]タグを使用すると実行中のすべてのアニメーションの完了を待つことができます。
+位置のアニメーションは指定する値に+=100 -=100　と指定することで相対位置指定できます（今表示されているところから、右へ１００PX移動といった指定ができます）
+透明度を指定すれば、アニメーションしながら非表示にすることもできます。
 
- ;すべてのアニメーション完了を待ちます
- [wa]
+:sample
+[ptext layer=1 page=fore text="文字列" size=30 x=0 y=0 color=red vertical=true]
 
- アニメーション終了
+[image layer=0 left=100 top=100  storage = yuko1.png page=fore visible=true name=yuko,chara ]
+[image layer=1 left=300 top=100 storage = haruko1.png page=fore visible=true name=haruko ]
 
- :param
- name=ここで指定した値が設定されている要素に対してアニメーションを開始します。name属性で指定した値です。,
- layer=name属性が指定されている場合は無視されます。前景レイヤを指定します。必ずforeページに対して実施されます。,
- left=指定した横位置にアニメーションで移動します。,
- top=指定した縦位置にアニメーションで移動します。,
- width=幅を指定します,
- height=高さを指定します,
- opacity=0～255の値を指定します。指定した透明度へアニメーションします,
- color=色指定,
- time=アニメーションにかける時間をミリ秒で指定して下さい。デフォルトは2000ミリ秒です,
- effect=変化のエフェクトを指定します。指定できる文字列は以下の種類です<br />
+;name属性を指定してアニメーション
+[anim name=haruko left="+=100" time=10000 effect=easeInCirc opacity=0  ]
 
- jswing
- ｜def
- ｜easeInQuad
- ｜easeOutQuad
- ｜easeInOutQuad
- ｜easeInCubic
- ｜easeOutCubic
- ｜easeInOutCubic
- ｜easeInQuart
- ｜easeOutQuart
- ｜easeInOutQuart
- ｜easeInQuint
- ｜easeOutQuint
- ｜easeInOutQuint
- ｜easeInSine
- ｜easeOutSine
- ｜easeInOutSine
- ｜easeInExpo
- ｜easeOutExpo
- ｜easeInOutExpo
- ｜easeInCirc
- ｜easeOutCirc
- ｜easeInOutCirc
- ｜easeInElastic
- ｜easeOutElastic
- ｜easeInOutElastic
- ｜easeInBack
- ｜easeOutBack
- ｜easeInOutBack
- ｜easeInBounce
- ｜easeOutBounce
- ｜easeInOutBounce
+;レイヤを指定してアニメーション
+[anim layer=1 left="+=100" effect=easeInCirc opacity=0  ]
+
+;すべてのアニメーション完了を待ちます
+[wa]
+
+アニメーション終了
+
+:param
+name=ここで指定した値が設定されている要素に対してアニメーションを開始します。name属性で指定した値です。,
+layer=name属性が指定されている場合は無視されます。前景レイヤを指定します。必ずforeページに対して実施されます。,
+left=指定した横位置にアニメーションで移動します。,
+top=指定した縦位置にアニメーションで移動します。,
+width=幅を指定します,
+height=高さを指定します,
+opacity=0～255の値を指定します。指定した透明度へアニメーションします,
+color=色指定,
+time=アニメーションにかける時間をミリ秒で指定して下さい。デフォルトは2000ミリ秒です,
+effect=変化のエフェクトを指定します。指定できる文字列は以下の種類です<br />
+
+jswing
+｜def
+｜easeInQuad
+｜easeOutQuad
+｜easeInOutQuad
+｜easeInCubic
+｜easeOutCubic
+｜easeInOutCubic
+｜easeInQuart
+｜easeOutQuart
+｜easeInOutQuart
+｜easeInQuint
+｜easeOutQuint
+｜easeInOutQuint
+｜easeInSine
+｜easeOutSine
+｜easeInOutSine
+｜easeInExpo
+｜easeOutExpo
+｜easeInOutExpo
+｜easeInCirc
+｜easeOutCirc
+｜easeInOutCirc
+｜easeInElastic
+｜easeOutElastic
+｜easeInOutElastic
+｜easeInBack
+｜easeOutBack
+｜easeInOutBack
+｜easeInBounce
+｜easeOutBounce
+｜easeInOutBounce
 
 :demo
- 1,kaisetsu/12_anim
+1,kaisetsu/12_anim
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.anim = {
     pm: {
@@ -896,14 +987,20 @@ tyrano.plugin.kag.tag.anim = {
 
 /*
 #[wa]
+
 :group
 アニメーション関連
+
 :title
 アニメーション終了待ち
+
 :exp
 実行中のアニメーションすべて終了するまで処理を待ちます
+
 :sample
+
 :param
+
 #[end]
 */
 
@@ -922,15 +1019,21 @@ tyrano.plugin.kag.tag.wa = {
 
 /*
 #[stopanim]
+
 :group
 アニメーション関連
+
 :title
 アニメーション強制停止
+
 :exp
 実行中のアニメーションを強制的に停止します。
+
 :sample
+
 :param
 name=ここで指定した値が設定されている要素に対してアニメーションを停止します
+
 #[end]
 */
 
@@ -952,33 +1055,37 @@ tyrano.plugin.kag.tag.stopanim = {
 //================キーフレームアニメーション系
 
 /*
- #[keyframe]
- :group
- アニメーション関連
- :title
- キーフレームアニメーション定義
- :exp
- キーフレームアニメーションを定義します。定義したアニメーションは[kanim]タグで指定することで使用できます
- :sample
+#[keyframe]
 
- ;----keyframeの定義
- [keyframe name="fuwafuwa"]
+:group
+アニメーション関連
 
- [frame p=40%  x="100" ]
- [frame p=100% y="-200" opacity=0 ]
+:title
+キーフレームアニメーション定義
 
- [endkeyframe]
+:exp
+キーフレームアニメーションを定義します。定義したアニメーションは[kanim]タグで指定することで使用できます
 
- ;-----定義したアニメーションを実行
+:sample
 
- :param
- name=キーブレームの名前を指定します。後に[kanim]タグを使用する際に指定する名前になります
+;----keyframeの定義
+[keyframe name="fuwafuwa"]
 
- :demo
- 2,kaisetsu/15_kanim
+[frame p=40%  x="100" ]
+[frame p=100% y="-200" opacity=0 ]
 
- #[end]
- */
+[endkeyframe]
+
+;-----定義したアニメーションを実行
+
+:param
+name=キーブレームの名前を指定します。後に[kanim]タグを使用する際に指定する名前になります
+
+:demo
+2,kaisetsu/15_kanim
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.keyframe = {
     vital: ["name"],
@@ -995,17 +1102,23 @@ tyrano.plugin.kag.tag.keyframe = {
 };
 
 /*
- #[endkeyframe]
- :group
- アニメーション関連
- :title
- キーフレームアニメーション定義を終了します
- :exp
- キーフレームアニメーション定義を終了します
- :sample
- :param
- #[end]
- */
+#[endkeyframe]
+
+:group
+アニメーション関連
+
+:title
+キーフレームアニメーション定義を終了します
+
+:exp
+キーフレームアニメーション定義を終了します
+
+:sample
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.endkeyframe = {
     pm: {},
@@ -1017,39 +1130,44 @@ tyrano.plugin.kag.tag.endkeyframe = {
 };
 
 /*
- #[frame]
- :group
- アニメーション関連
- :title
- キーフレームアニメーション定義
- :exp
- キーフレームアニメーションを定義します。定義したアニメーションは[kanim]タグで指定することで使用できます
- :sample
- :param
- p=パーセンテージを指定してください。例えば５秒かかるアニメーションに対して20%の位置という指定になります。0〜100%の間で指定してください。0%を省略することで前回のアニメーション状態を継承して新しいアニメーションを開始できます。,
- x=X軸方向へのアニメーション量をpxで指定して下さい。　また、*(アスタリスク)で始めることで、絶対位置として指定することができます。（例） x＝"100"（前へ100px移動する） x="*100" 画面左端から100pxの位置へ移動する,
- y=Y軸方向へのアニメーション量をpxで指定して下さい。　また、*(アスタリスク)で始めることで、絶対位置として指定することができます。（例） y＝"100"（前へ100px移動する） y="*100" 画面上端から100pxの位置へ移動する,
- z=Z軸方向へのアニメーション量をpxで指定して下さい。　また、*(アスタリスク)で始めることで、絶対位置として指定することができます。（例） z＝"100"（前へ100px移動する） z="*100" こちらのタグを使用すると三次元を表現できますが、現状一部ブラウザ（safari iphone系）で動作します,
- rotate=対象を回転させることができます。例　rotate＝"360deg"のような形で指定して下さい（３６０度回転）,
- rotateX=対象をX軸を軸として回転させることができます。例　rotateX＝"360deg"のような形で指定して下さい（３６０度回転）,
- rotateY=対象をY軸を軸として回転させることができます。例　rotateY＝"360deg"のような形で指定して下さい（３６０度回転）,
- rotateZ=対象をZ軸を軸として回転させることができます。例　rotateZ＝"360deg"のような形で指定して下さい（３６０度回転）,
- scale=対象を拡大、縮小することができます。例　scale＝"2" (２倍に拡大します) scale＝"0.5" 半分に縮小します,
- scaleX=X方向に拡大、縮小できます,
- scaleY=Y方向に拡大、縮小できます,
- scaleZ=Z方向に拡大、縮小できます,
- skew=傾斜,
- skewX=X傾斜,
- skewY=Y傾斜,
- perspective=遠近効果を付与することができます。一部ブラウザのみ,
- opacity=0～1を指定することで、各要素の透明度を指定することができます、非表示にしたりすることができます。0で完全に透明になります。
- その他=CSSのスタイルを各種指定することができます。
+#[frame]
+
+:group
+アニメーション関連
+
+:title
+キーフレームアニメーション定義
+
+:exp
+キーフレームアニメーションを定義します。定義したアニメーションは[kanim]タグで指定することで使用できます
+
+:sample
+
+:param
+p=パーセンテージを0〜100%の間で指定します。例えば５秒かかるアニメーションに対して20%の位置という指定になります。0%を省略することで前回のアニメーション状態を継承して新しいアニメーションを開始できます。,
+x=X軸方向へのアニメーション量をpxで指定して下さい。　また、*(アスタリスク)で始めることで、絶対位置として指定できます。（例） x＝"100"（前へ100px移動する） x="*100" 画面左端から100pxの位置へ移動する,
+y=Y軸方向へのアニメーション量をpxで指定して下さい。　また、*(アスタリスク)で始めることで、絶対位置として指定できます。（例） y＝"100"（前へ100px移動する） y="*100" 画面上端から100pxの位置へ移動する,
+z=Z軸方向へのアニメーション量をpxで指定して下さい。　また、*(アスタリスク)で始めることで、絶対位置として指定できます。（例） z＝"100"（前へ100px移動する） z="*100" こちらのタグを使用すると三次元を表現できますが、現状一部ブラウザ（safari iphone系）で動作します,
+rotate=対象を回転させることができます。例　rotate＝"360deg"のような形で指定して下さい（３６０度回転）,
+rotateX=対象をX軸を軸として回転させることができます。例　rotateX＝"360deg"のような形で指定して下さい（３６０度回転）,
+rotateY=対象をY軸を軸として回転させることができます。例　rotateY＝"360deg"のような形で指定して下さい（３６０度回転）,
+rotateZ=対象をZ軸を軸として回転させることができます。例　rotateZ＝"360deg"のような形で指定して下さい（３６０度回転）,
+scale=対象を拡大、縮小できます。例　scale＝"2" (２倍に拡大します) scale＝"0.5" 半分に縮小します,
+scaleX=X方向に拡大、縮小できます,
+scaleY=Y方向に拡大、縮小できます,
+scaleZ=Z方向に拡大、縮小できます,
+skew=傾斜,
+skewX=X傾斜,
+skewY=Y傾斜,
+perspective=遠近効果を付与できます。一部ブラウザのみ,
+opacity=0～1を指定することで、各要素の透明度を指定できます、非表示にしたりできます。0で完全に透明になります。
+その他=CSSのスタイルを各種指定できます。
 
 :demo
- 2,kaisetsu/15_kanim
+2,kaisetsu/15_kanim
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.frame = {
     vital: ["p"],
@@ -1125,38 +1243,43 @@ tyrano.plugin.kag.tag.frame = {
 };
 
 /*
- #[kanim]
- :group
- アニメーション関連
- :title
- キーフレームアニメーションの実行
- :exp
- キーフレームアニメーションを実行します。[keyframe]タグで定義した名前とアニメーションさせる画像やテキストを指定することで
- 複雑なアニメーションを実現できます。
- :sample
- :param
- name=アニメーションさせる画像やテキストのnameを指定してください,
- layer=nameを指定せずに、layerを指定することでそのlayerに属するエレメント全てにアニメーションを適用させることができます,
- keyframe=実行するキーフレームアニメーション名を指定してください。,
- time=アニメーションを実行する時間をミリ秒で指定してください。,
- easing=アニメーションの変化パターンを指定することができます。
- 指定できる値として
- ease(開始時点と終了時点を滑らかに再生する)　linear(一定の間隔で再生する)
- ease-in(開始時点をゆっくり再生する)
- ease-out(終了時点をゆっくり再生する)
- ease-in-out(開始時点と終了時点をゆっくり再生する)
- この他に、cubic-bezier関数を使って、イージングを独自に設定することも可能です
- ,
- count = 再生回数を指定できます。初期値は１。"infinite"を指定することで無限にアニメーションさせることもできます。,
- delay = 開始までの時間を指定できます。初期値は遅延なし(0)です。,
- direction = 偶数回のアニメーションを逆再生するか指定できます。 初期値は"normal" 偶数回逆再生させる場合は、"alternate"を指定します,
- mode = 再生前後の状態を指定できます。初期値は"forwards"で再生後の状態を維持します。 "none"を指定すると、再生後の状態を維持しません
+#[kanim]
+
+:group
+アニメーション関連
+
+:title
+キーフレームアニメーションの実行
+
+:exp
+キーフレームアニメーションを実行します。[keyframe]タグで定義した名前とアニメーションさせる画像やテキストを指定することで
+複雑なアニメーションを実現できます。
+
+:sample
+
+:param
+name=アニメーションさせる画像やテキストのnameを指定します,
+layer=nameを指定せずに、layerを指定することでそのlayerに属するエレメント全てにアニメーションを適用させることができます,
+keyframe=実行するキーフレームアニメーション名を指定します。,
+time=アニメーションを実行する時間をミリ秒で指定します。,
+easing=アニメーションの変化パターンを指定できます。
+指定できる値として
+ease(開始時点と終了時点を滑らかに再生する)　linear(一定の間隔で再生する)
+ease-in(開始時点をゆっくり再生する)
+ease-out(終了時点をゆっくり再生する)
+ease-in-out(開始時点と終了時点をゆっくり再生する)
+この他に、cubic-bezier関数を使って、イージングを独自に設定することも可能です
+,
+count = 再生回数を指定できます。初期値は１。"infinite"を指定することで無限にアニメーションさせることもできます。,
+delay = 開始までの時間を指定できます。初期値は遅延なし(0)です。,
+direction = 偶数回のアニメーションを逆再生するか指定できます。 初期値は"normal" 偶数回逆再生させる場合は、"alternate"を指定します,
+mode = 再生前後の状態を指定できます。初期値は"forwards"で再生後の状態を維持します。 "none"を指定すると、再生後の状態を維持しません
 
 :demo
- 2,kaisetsu/15_kanim
+2,kaisetsu/15_kanim
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.kanim = {
     vital: ["keyframe"],
@@ -1223,19 +1346,25 @@ tyrano.plugin.kag.tag.kanim = {
 };
 
 /*
- #[stop_kanim]
- :group
- アニメーション関連
- :title
- キーフレームアニメーションの停止
- :exp
- キーフレームアニメーションを停止します。
- :sample
- :param
- name=アニメーションさせる停止する画像やテキストのnameを指定してください,
- layer=nameを指定せずに、layerを指定することでそのlayerに属するエレメント全てにアニメーション停止を適用させることができます
- #[end]
- */
+#[stop_kanim]
+
+:group
+アニメーション関連
+
+:title
+キーフレームアニメーションの停止
+
+:exp
+キーフレームアニメーションを停止します。
+
+:sample
+
+:param
+name=アニメーションさせる停止する画像やテキストのnameを指定します,
+layer=nameを指定せずに、layerを指定することでそのlayerに属するエレメント全てにアニメーション停止を適用させることができます
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.stop_kanim = {
     pm: {
@@ -1279,25 +1408,31 @@ tyrano.plugin.kag.tag.stop_kanim = {
 //=====================================
 
 /*
- #[chara_ptext]
- :group
- キャラクター操作
- :title
- キャラクターの発言名前欄表示と表情変更
- :exp
- [chara_config ptext="hogehoge"]という形式で定義した発言者のメッセージボックスにnameで指定した名前を設定できます。
- さらに、faceパラメータを指定することで、同時に表情も変更できます。
- このタグには省略して書くことができます。
- #chara_name:face_name と　[ptext name="chara_name" face="face_name"] は同じ動作をします。
- [chara_new]時に登録した画像ファイルはface="default"で指定できます。
- [chara_new name="yuko" storage="yuko.png"  jname="ゆうこ"]
- :param
- name=[chara_new]で定義したnameを指定します。紐づいたjnameがptext欄に表示されます,
- face=[chara_face]で定義したface名を指定してください
- :sample
+#[chara_ptext]
 
- #[end]
- */
+:group
+キャラクター操作
+
+:title
+キャラクターの発言名前欄表示と表情変更
+
+:exp
+[chara_config ptext="hogehoge"]という形式で定義した発言者のメッセージボックスにnameで指定した名前を設定できます。
+さらに、faceパラメータを指定することで、同時に表情も変更できます。
+このタグには省略して書くことができます。
+#chara_name:face_name と　[ptext name="chara_name" face="face_name"] は同じ動作をします。
+[chara_new]時に登録した画像ファイルはface="default"で指定できます。
+[chara_new name="yuko" storage="yuko.png"  jname="ゆうこ"]
+
+:param
+name=[chara_new]で定義したnameを指定します。紐づいたjnameがptext欄に表示されます,
+face=[chara_face]で定義したface名を指定します
+
+:sample
+
+#[end]
+*/
+
 tyrano.plugin.kag.tag.chara_ptext = {
     pm: {
         name: "",
@@ -1494,66 +1629,71 @@ tyrano.plugin.kag.tag.chara_ptext = {
 };
 
 /*
- #[chara_config]
- :group
- キャラクター操作
- :title
- キャラクター操作タグの基本設定
- :exp
- キャラクター操作タグの基本設定を変更できます
- :sample
- :param
- pos_mode=true か false　を指定します。デフォルトはtrueです。trueの場合は、[chara_show]タグなどで追加した時の立ち位置を自動的に計算し、配置します。,
- ptext=発言者の名前領域のptextを指定できます。例えば[ptext name=name_space] のように定義されていた場合、その後 #yuko のように指定するだけで、ptext領域キャラクターの名前を表示することができます。,
- time=0以上の数値をミリ秒で指定することで、[chara_mod]タグで表情を変える際に、クロスフェードの効果を与えることができます。指定時間かけて切り替わります。デフォルトは600ミリ秒です。0を指定すると即時に切り替わります,
- memory=true か false を指定します。デフォルトはfalseです。キャラクターを非表示にして再度表示した時に、表情を維持するかどうかをしていできます。falseをしていすると、[chara_new]で指定してデフォルトの表情で表示されます,
- anim=キャラクターを自動配置する場合、キャラクターの立ち位置が変わるときにアニメーションを行うか否かを指定できます。デフォルトは true です。falseを指定するとじんわりと入れ替わる効果に切り替わります。,
- pos_change_time=キャラクターの位置を変更する際のスピードを調整できます。ミリ秒で指定して下さい。デフォルトは600,
- talk_focus=現在話しているキャラクターの立ち絵に対して、目立たせる演出が可能になります。指定できるのは brightness（明度） blur（ぼかし） none （無効）です。デフォルトはnone　どのキャラクターが話しているかの指定は #yuko のように指定すると、chara_new時の名前とひも付きます。 ,
- brightness_value=brightnessの値を指定できます。話しているキャラクター以外の明度を指定します。0〜100 で指定して下さい。デフォルトは60,
- blur_value=blurの値を指定できます。話しているキャラクター以外のぼかし方を指定します。0〜100 で指定して下さい。デフォルトは2 値がおおきいほどぼかしが強くなります,
- talk_anim=現在話しているキャラクターの立ち絵に対して、ピョンと跳ねるような効果を与えることができます。指定できるのは up（上に跳ねる） down（下に沈む） none （無効）です。デフォルトはnone　どのキャラクターが話しているかの指定は #yuko のように指定すると、chara_new時の名前とひも付きます。,
- talk_anim_time=talk_animが有効な場合のアニメーション速度を指定できます。デフォルトは230ミリ秒。,
- talk_anim_value=talk_animが有効な場合のアニメーション量を指定できます。デフォルトは30。数値で指定してください。,
- effect=キャラクターが位置を入れ替わる際のエフェクト（動き方）を指定できます。
- jswing
- ｜def
- ｜easeInQuad
- ｜easeOutQuad
- ｜easeInOutQuad
- ｜easeInCubic
- ｜easeOutCubic
- ｜easeInOutCubic
- ｜easeInQuart
- ｜easeOutQuart
- ｜easeInOutQuart
- ｜easeInQuint
- ｜easeOutQuint
- ｜easeInOutQuint
- ｜easeInSine
- ｜easeOutSine
- ｜easeInOutSine
- ｜easeInExpo
- ｜easeOutExpo
- ｜easeInOutExpo
- ｜easeInCirc
- ｜easeOutCirc
- ｜easeInOutCirc
- ｜easeInElastic
- ｜easeOutElastic
- ｜easeInOutElastic
- ｜easeInBack
- ｜easeOutBack
- ｜easeInOutBack
- ｜easeInBounce
- ｜easeOutBounce
- ｜easeInOutBounce
+#[chara_config]
+
+:group
+キャラクター操作
+
+:title
+キャラクター操作タグの基本設定
+
+:exp
+キャラクター操作タグの基本設定を変更できます
+
+:sample
+
+:param
+pos_mode=true か false　を指定します。デフォルトはtrueです。trueの場合は、[chara_show]タグなどで追加した時の立ち位置を自動的に計算し、配置します。,
+ptext=発言者の名前領域のptextを指定できます。例えば[ptext name=name_space] のように定義されていた場合、その後 #yuko のように指定するだけで、ptext領域キャラクターの名前を表示できます。,
+time=0以上の数値をミリ秒で指定することで、[chara_mod]タグで表情を変える際に、クロスフェードの効果を与えることができます。指定時間かけて切り替わります。デフォルトは600ミリ秒です。0を指定すると即時に切り替わります,
+memory=true か false を指定します。デフォルトはfalseです。キャラクターを非表示にして再度表示した時に、表情を維持するかどうかをしていできます。falseをしていすると、[chara_new]で指定してデフォルトの表情で表示されます,
+anim=キャラクターを自動配置する場合、キャラクターの立ち位置が変わるときにアニメーションを行うか否かを指定できます。デフォルトは true です。falseを指定するとじんわりと入れ替わる効果に切り替わります。,
+pos_change_time=キャラクターの位置を変更する際のスピードを調整できます。ミリ秒で指定して下さい。デフォルトは600,
+talk_focus=現在話しているキャラクターの立ち絵に対して、目立たせる演出が可能になります。指定できるのは brightness（明度） blur（ぼかし） none （無効）です。デフォルトはnone　どのキャラクターが話しているかの指定は #yuko のように指定すると、chara_new時の名前とひも付きます。 ,
+brightness_value=brightnessの値を指定できます。話しているキャラクター以外の明度を指定します。0〜100 で指定して下さい。デフォルトは60,
+blur_value=blurの値を指定できます。話しているキャラクター以外のぼかし方を指定します。0〜100 で指定して下さい。デフォルトは2 値がおおきいほどぼかしが強くなります,
+talk_anim=現在話しているキャラクターの立ち絵に対して、ピョンと跳ねるような効果を与えることができます。指定できるのは up（上に跳ねる） down（下に沈む） none （無効）です。デフォルトはnone　どのキャラクターが話しているかの指定は #yuko のように指定すると、chara_new時の名前とひも付きます。,
+talk_anim_time=talk_animが有効な場合のアニメーション速度を指定できます。デフォルトは230ミリ秒。,
+talk_anim_value=talk_animが有効な場合のアニメーション量を指定できます。デフォルトは30。数値で指定します。,
+effect=キャラクターが位置を入れ替わる際のエフェクト（動き方）を指定できます。
+jswing
+｜def
+｜easeInQuad
+｜easeOutQuad
+｜easeInOutQuad
+｜easeInCubic
+｜easeOutCubic
+｜easeInOutCubic
+｜easeInQuart
+｜easeOutQuart
+｜easeInOutQuart
+｜easeInQuint
+｜easeOutQuint
+｜easeInOutQuint
+｜easeInSine
+｜easeOutSine
+｜easeInOutSine
+｜easeInExpo
+｜easeOutExpo
+｜easeInOutExpo
+｜easeInCirc
+｜easeOutCirc
+｜easeInOutCirc
+｜easeInElastic
+｜easeOutElastic
+｜easeInOutElastic
+｜easeInBack
+｜easeOutBack
+｜easeInOutBack
+｜easeInBounce
+｜easeOutBounce
+｜easeInOutBounce
 
 :demo
 1,kaisetsu/08_character
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.chara_config = {
     pm: {
@@ -1620,31 +1760,36 @@ tyrano.plugin.kag.tag.chara_config = {
 };
 
 /*
- #[chara_new]
- :group
- キャラクター操作
- :title
- キャラクターの定義
- :exp
- 登場するキャラクターの情報を定義します。その後[chara_show ]で指定した名称で表示したり、画像を変更したりできます。
- また、ここで定義したname属性は[anim]タグなどからも指定可能です。
- つまり、キャラクターを追加したあとアニメーションすることも自由にできます。
- :sample
- [chara_new name="yuko" storage="yuko.png"  jname="ゆうこ"]
- :param
- name=キャラクターを以後操作するための名前を半角英数で指定します。このnameは他のタグを含めて必ずユニークでなければなりません,
- storage=キャラクター画像を指定してください。画像ファイルはプロジェクトフォルダのfgimageフォルダに配置してください,
- width=画像の横幅を指定できます,
- height=画像の高さを指定できます。,
- reflect=画像を反転します,
- color=キャラクターの名前を表示するときの色を指定できます。0xRRGGBB 形式で指定します。,
- jname=このキャラクターをネームスペースに表示する場合、適用する名称を指定できます。例えば、#yuko と指定すると　メッセージエリアに　ゆうこ　と表示できます
+#[chara_new]
 
- :demo
- 1,kaisetsu/08_character
+:group
+キャラクター操作
 
- #[end]
- */
+:title
+キャラクターの定義
+
+:exp
+登場するキャラクターの情報を定義します。その後[chara_show ]で指定した名称で表示したり、画像を変更したりできます。
+また、ここで定義したname属性は[anim]タグなどからも指定可能です。
+つまり、キャラクターを追加したあとアニメーションすることも自由にできます。
+
+:sample
+[chara_new name="yuko" storage="yuko.png"  jname="ゆうこ"]
+
+:param
+name=キャラクターを以後操作するための名前を半角英数で指定します。このnameは他のタグを含めて必ずユニークでなければなりません,
+storage=キャラクター画像を指定します。画像ファイルはプロジェクトフォルダのfgimageフォルダに配置してください,
+width=画像の横幅を指定できます,
+height=画像の高さを指定できます。,
+reflect=画像を反転します,
+color=キャラクターの名前を表示するときの色を指定できます。0xRRGGBB 形式で指定します。,
+jname=このキャラクターをネームスペースに表示する場合、適用する名称を指定できます。例えば、#yuko と指定すると　メッセージエリアに　ゆうこ　と表示できます
+
+:demo
+1,kaisetsu/08_character
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.chara_new = {
     vital: ["name", "storage"],
@@ -1705,37 +1850,41 @@ tyrano.plugin.kag.tag.chara_new = {
 };
 
 /*
- #[chara_show]
- :group
- キャラクター操作
- :title
- キャラクターの登場
- :exp
- 定義しておいたキャラクターを画面に表示します
- :sample
- [chara_show name="yuko" ]
- :param
- name=[chara_new]で定義したname属性を指定してください。,
- time="ミリ秒で指定します。指定した時間をかけて登場します。デフォルトは1000ミリ秒です",
- layer="キャラクターを配置するレイヤーを指定できます。デフォルトは前景レイヤ layer=0 です",
- zindex="キャラクターの重なりを指定できます。ここで指定した値が大きいほうが前に表示することができます。指定しない場合は後に登場するキャラクターが前に表示されます",
- depth="zindexが同一な場合の重なりを指定できます。front（最前面）/back（最後面）で指定します。デフォルトはfront",
- page="foreかbackを指定します。デフォルトはforeです",
- wait="trueを指定すると、キャラクターの登場完了を待ちます。デフォルトはtrue です。",
- face=[chara_face]で定義したface属性を指定してください。,
- storage=変更する画像ファイルを指定してください。ファイルはプロジェクトフォルダのfgimageフォルダに配置します。,
- reflect="trueを指定すると左右反転します",
- width="キャラクターの横幅を指定できます。",
- height="キャラクターの縦幅を指定できます。",
- left="キャラクターの横位置を指定できます。指定した場合、自動配置が有効であっても無効になります。",
- top="キャラクターの縦位置を指定できます。指定した場合、自動配置が有効であっても無効になります。"
+#[chara_show]
+
+:group
+キャラクター操作
+
+:title
+キャラクターの登場
+
+:exp
+定義しておいたキャラクターを画面に表示します
+
+:sample
+[chara_show name="yuko" ]
+
+:param
+name=[chara_new]で定義したname属性を指定します。,
+time="ミリ秒で指定します。指定した時間をかけて登場します。デフォルトは1000ミリ秒です",
+layer="キャラクターを配置するレイヤーを指定できます。デフォルトは前景レイヤ layer=0 です",
+zindex="キャラクターの重なりを指定できます。ここで指定した値が大きいほうが前に表示できます。省略すると、後に登場するキャラクターが前に表示されます",
+depth="zindexが同一な場合の重なりを指定できます。front（最前面）/back（最後面）で指定します。デフォルトはfront",
+page="foreかbackを指定します。デフォルトはforeです",
+wait="trueを指定すると、キャラクターの登場完了を待ちます。デフォルトはtrue です。",
+face=[chara_face]で定義したface属性を指定します。,
+storage=変更する画像ファイルを指定します。ファイルはプロジェクトフォルダのfgimageフォルダに配置します。,
+reflect="trueを指定すると左右反転します",
+width="キャラクターの横幅を指定できます。",
+height="キャラクターの縦幅を指定できます。",
+left="キャラクターの横位置を指定できます。指定した場合、自動配置が有効であっても無効になります。",
+top="キャラクターの縦位置を指定できます。指定した場合、自動配置が有効であっても無効になります。"
 
 :demo
- 1,kaisetsu/08_character
+1,kaisetsu/08_character
 
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.chara_show = {
     vital: ["name"],
@@ -2114,27 +2263,32 @@ tyrano.plugin.kag.tag.chara_show = {
 };
 
 /*
- #[chara_hide]
- :group
- キャラクター操作
- :title
- キャラクターの退場
- :exp
- [chara_show]タグで表示したキャラクターを退場させます。
- :sample
- [chara_hide name="yuko" ]
- :param
- name=[chara_new]で定義したname属性を指定してください。,
- wait=trueを指定すると、キャラクターの退場を待ちます。デフォルトはtrueです。,
- time=ミリ秒で指定します。指定した時間をかけて退場します。デフォルトは1000ミリ秒です,
- layer=削除対象のレイヤ。chara_showの時にレイヤ指定した場合は、指定します。デフォルトは０,
- pos_mode=キャラクターの立ち位置自動調整が有効な場合にこの値にfalseを指定すると退場後に立ち位置の調整を行いません。デフォルトはtrueです,
+#[chara_hide]
 
- :demo
- 1,kaisetsu/08_character
+:group
+キャラクター操作
 
- #[end]
- */
+:title
+キャラクターの退場
+
+:exp
+[chara_show]タグで表示したキャラクターを退場させます。
+
+:sample
+[chara_hide name="yuko" ]
+
+:param
+name=[chara_new]で定義したname属性を指定します。,
+wait=trueを指定すると、キャラクターの退場を待ちます。デフォルトはtrueです。,
+time=ミリ秒で指定します。指定した時間をかけて退場します。デフォルトは1000ミリ秒です,
+layer=削除対象のレイヤ。chara_showの時にレイヤ指定した場合は、指定します。デフォルトは０,
+pos_mode=キャラクターの立ち位置自動調整が有効な場合にこの値にfalseを指定すると退場後に立ち位置の調整を行いません。デフォルトはtrueです,
+
+:demo
+1,kaisetsu/08_character
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.chara_hide = {
     vital: ["name"],
@@ -2318,22 +2472,27 @@ tyrano.plugin.kag.tag.chara_hide = {
 };
 
 /*
- #[chara_hide_all]
- :group
- キャラクター操作
- :title
- キャラクターを全員退場
- :exp
- [chara_show]タグで表示したキャラクターを全員退場させます。
- :sample
- [chara_hide_all time=1000 wait=true]
- :param
- wait=trueを指定すると、キャラクターの退場を待ちます。デフォルトはtrueです。,
- time=ミリ秒で指定します。指定した時間をかけて退場します。デフォルトは1000ミリ秒です,
- layer=削除対象のレイヤ。chara_showの時にレイヤ指定した場合は、指定します。デフォルトは０
+#[chara_hide_all]
 
- #[end]
- */
+:group
+キャラクター操作
+
+:title
+キャラクターを全員退場
+
+:exp
+[chara_show]タグで表示したキャラクターを全員退場させます。
+
+:sample
+[chara_hide_all time=1000 wait=true]
+
+:param
+wait=trueを指定すると、キャラクターの退場を待ちます。デフォルトはtrueです。,
+time=ミリ秒で指定します。指定した時間をかけて退場します。デフォルトは1000ミリ秒です,
+layer=削除対象のレイヤ。chara_showの時にレイヤ指定した場合は、指定します。デフォルトは０
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.chara_hide_all = {
     vital: [],
@@ -2408,20 +2567,25 @@ tyrano.plugin.kag.tag.chara_hide_all = {
 };
 
 /*
- #[chara_delete]
- :group
- キャラクター操作
- :title
- キャラクター情報の削除
- :exp
- 定義しておいたキャラクター情報を削除します。（画面から消す場合は[chara_hide]を使用してください）
- :sample
- [chara_delete="yuko" ]
- :param
- name=[chara_new]で定義したname属性を指定してください。
+#[chara_delete]
 
- #[end]
- */
+:group
+キャラクター操作
+
+:title
+キャラクター情報の削除
+
+:exp
+定義しておいたキャラクター情報を削除します。（画面から消す場合は[chara_hide]を使用してください）
+
+:sample
+[chara_delete="yuko" ]
+
+:param
+name=[chara_new]で定義したname属性を指定します。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.chara_delete = {
     vital: ["name"],
@@ -2438,29 +2602,34 @@ tyrano.plugin.kag.tag.chara_delete = {
 };
 
 /*
- #[chara_mod]
- :group
- キャラクター操作
- :title
- キャラクター画像変更
- :exp
- 画面のキャラクター画像を変更します。表情を変更する場合などに便利でしょう
- :sample
- [chara_mod name="yuko" storage="newface.png"]
- :param
- name=[chara_new]で定義したname属性を指定してください。,
- face=[chara_face]で定義したface属性を指定してください,
- time=0以上の数値をミリ秒で指定することで、[chara_mod]タグで表情を変える際に、クロスフェードの効果を与えることができます。指定時間かけて切り替わります。デフォルトは600ミリ秒です。0を指定すると即時に切り替わります,
- reflect=trueを指定すると左右反転します,
- storage=変更する画像ファイルを指定してください。ファイルはプロジェクトフォルダのfgimageフォルダに配置します。,
- wait=表情の変更完了を待つか否かを指定します。true or falseで指定。デフォルトは true,
- cross=true or false を指定します。デフォルトはtrue。trueを指定すると２つの画像が同じタイミングで透明になりながら入れ替わります。falseを指定すると、古い表情を残しながら上に重なる形で新しい表情を表示します。
+#[chara_mod]
+
+:group
+キャラクター操作
+
+:title
+キャラクター画像変更
+
+:exp
+画面のキャラクター画像を変更します。表情を変更する場合などに便利でしょう
+
+:sample
+[chara_mod name="yuko" storage="newface.png"]
+
+:param
+name=[chara_new]で定義したname属性を指定します。,
+face=[chara_face]で定義したface属性を指定します,
+time=0以上の数値をミリ秒で指定することで、[chara_mod]タグで表情を変える際に、クロスフェードの効果を与えることができます。指定時間かけて切り替わります。デフォルトは600ミリ秒です。0を指定すると即時に切り替わります,
+reflect=trueを指定すると左右反転します,
+storage=変更する画像ファイルを指定します。ファイルはプロジェクトフォルダのfgimageフォルダに配置します。,
+wait=表情の変更完了を待つか否かを指定します。true or falseで指定。デフォルトは true,
+cross=true or false を指定します。デフォルトはtrue。trueを指定すると２つの画像が同じタイミングで透明になりながら入れ替わります。falseを指定すると、古い表情を残しながら上に重なる形で新しい表情を表示します。
 
 :demo
 1,kaisetsu/08_character
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.chara_mod = {
     vital: ["name"],
@@ -2644,61 +2813,66 @@ tyrano.plugin.kag.tag.chara_mod = {
 };
 
 /*
- #[chara_move]
- :group
- キャラクター操作
- :title
- キャラクターの位置変更
- :exp
- 画面のキャラクター立ち位置を変更します。
- :sample
- [chara_move name="yuko" time=100 left=20 top=100 ]
- :param
- name=[chara_new]で定義したname属性を指定してください。,
- time=0以上の数値をミリ秒で指定することで、指定時間かけて位置を移動します切り替わります。600ミリ秒です。,
- anim=trueかfalseを指定します。デフォルトはfalse。trueを指定すると、位置を変える時にアニメーションさせることができます。アニメーション効果は[chara_config]のeffectパラメータを参照します,
- left=移動先のヨコ位置を指定できます。「left="+=200"」「left="-=200"」のように指定すると今いる位置を基準にできます（相対指定）,
- top=移動先のタテ位置を指定できます。「top="+=100"」「top="-=100"」のように指定すると今いる位置を基準にできます（相対指定）,
- width=変更後の横幅を指定できます,
- height=変更後の高さを指定できます,
- wait=位置変更を待つか否かを指定します。true or falseで指定。デフォルトは true,
- effect=変化のエフェクトを指定します。指定できる文字列は以下の種類です<br />
+#[chara_move]
 
- jswing
- ｜def
- ｜easeInQuad
- ｜easeOutQuad
- ｜easeInOutQuad
- ｜easeInCubic
- ｜easeOutCubic
- ｜easeInOutCubic
- ｜easeInQuart
- ｜easeOutQuart
- ｜easeInOutQuart
- ｜easeInQuint
- ｜easeOutQuint
- ｜easeInOutQuint
- ｜easeInSine
- ｜easeOutSine
- ｜easeInOutSine
- ｜easeInExpo
- ｜easeOutExpo
- ｜easeInOutExpo
- ｜easeInCirc
- ｜easeOutCirc
- ｜easeInOutCirc
- ｜easeInElastic
- ｜easeOutElastic
- ｜easeInOutElastic
- ｜easeInBack
- ｜easeOutBack
- ｜easeInOutBack
- ｜easeInBounce
- ｜easeOutBounce
- ｜easeInOutBounce
+:group
+キャラクター操作
 
- #[end]
- */
+:title
+キャラクターの位置変更
+
+:exp
+画面のキャラクター立ち位置を変更します。
+
+:sample
+[chara_move name="yuko" time=100 left=20 top=100 ]
+
+:param
+name=[chara_new]で定義したname属性を指定します。,
+time=0以上の数値をミリ秒で指定することで、指定時間かけて位置を移動します切り替わります。600ミリ秒です。,
+anim=trueかfalseを指定します。デフォルトはfalse。trueを指定すると、位置を変える時にアニメーションさせることができます。アニメーション効果は[chara_config]のeffectパラメータを参照します,
+left=移動先のヨコ位置を指定できます。「left="+=200"」「left="-=200"」のように指定すると今いる位置を基準にできます（相対指定）,
+top=移動先のタテ位置を指定できます。「top="+=100"」「top="-=100"」のように指定すると今いる位置を基準にできます（相対指定）,
+width=変更後の横幅を指定できます,
+height=変更後の高さを指定できます,
+wait=位置変更を待つか否かを指定します。true or falseで指定。デフォルトは true,
+effect=変化のエフェクトを指定します。指定できる文字列は以下の種類です<br />
+
+jswing
+｜def
+｜easeInQuad
+｜easeOutQuad
+｜easeInOutQuad
+｜easeInCubic
+｜easeOutCubic
+｜easeInOutCubic
+｜easeInQuart
+｜easeOutQuart
+｜easeInOutQuart
+｜easeInQuint
+｜easeOutQuint
+｜easeInOutQuint
+｜easeInSine
+｜easeOutSine
+｜easeInOutSine
+｜easeInExpo
+｜easeOutExpo
+｜easeInOutExpo
+｜easeInCirc
+｜easeOutCirc
+｜easeInOutCirc
+｜easeInElastic
+｜easeOutElastic
+｜easeInOutElastic
+｜easeInBack
+｜easeOutBack
+｜easeInOutBack
+｜easeInBounce
+｜easeOutBounce
+｜easeInOutBounce
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.chara_move = {
     vital: ["name"],
@@ -2807,33 +2981,37 @@ tyrano.plugin.kag.tag.chara_move = {
 };
 
 /*
- #[chara_face]
- :group
- キャラクター操作
- :title
- キャラクター表情登録
- :exp
- キャラクターの表情画像を名称と共に登録できます
- :sample
+#[chara_face]
 
- ;表情の登録
- [chara_face name="yuko" face="angry" storage="newface.png"]
- ;表情の適応
- [chara_mod name="yuko" face="angry"]
- ;発言者の名前も同時にかえたい場合
- [chara_ptext name="yuko" face="angry"]
- ;短縮して書けます。以下も同じ意味
- #yuko:angry
- ;chara_new で登録した画像はdefaultという名前で指定可能
- #yuko:default
+:group
+キャラクター操作
 
- :param
- name=[chara_new]で定義したname属性を指定してください。,
- face=登録する表情の名前を指定してください,
- storage=変更する画像ファイルを指定してください。ファイルはプロジェクトフォルダのfgimageフォルダに配置します。
+:title
+キャラクター表情登録
 
- #[end]
- */
+:exp
+キャラクターの表情画像を名称と共に登録できます
+
+:sample
+
+;表情の登録
+[chara_face name="yuko" face="angry" storage="newface.png"]
+;表情の適応
+[chara_mod name="yuko" face="angry"]
+;発言者の名前も同時にかえたい場合
+[chara_ptext name="yuko" face="angry"]
+;短縮して書けます。以下も同じ意味
+#yuko:angry
+;chara_new で登録した画像はdefaultという名前で指定可能
+#yuko:default
+
+:param
+name=[chara_new]で定義したname属性を指定します。,
+face=登録する表情の名前を指定します,
+storage=変更する画像ファイルを指定します。ファイルはプロジェクトフォルダのfgimageフォルダに配置します。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.chara_face = {
     vital: ["name", "face", "storage"],
@@ -2859,25 +3037,30 @@ tyrano.plugin.kag.tag.chara_face = {
 };
 
 /*
- #[chara_layer]
- :group
- キャラクター操作
- :title
- キャラクターの差分パーツ定義
- :exp
- キャラクターの表情を差分パーツを定義します。
- デフォルトのパーツは一番最初に登録したものになります。
- :sample
- [chara_layer name="yuko" part=mouse id=egao storage="image/egao.png" ]
- :param
- name=[chara_new]で定義したname属性を指定してください。,
- part=パーツとして登録する名を指定します。例えば「目」というpartを登録しておいて、このpartの中で他の差分をいくつも登録することができます。,
- id=パーツの中で差分にidを登録できます。例えば「目」というpartの中で「笑顔の目」「泣いてる目」のようにidを分けてstorageを登録してください,
- storage=差分として登録する画像を指定します。画像はfgimageフォルダの中に配置します。noneを指定するとデフォルトそのパーツがない状態を表現することができます,
- zindex=数値を指定します。このpartが他のパーツ重なった時にどの位置に表示されるかを指定します。数値が大きい程、前面に表示されます。一度登録しておけば該当するpartに適応されます。
+#[chara_layer]
 
- #[end]
- */
+:group
+キャラクター操作
+
+:title
+キャラクターの差分パーツ定義
+
+:exp
+キャラクターの表情を差分パーツを定義します。
+デフォルトのパーツは一番最初に登録したものになります。
+
+:sample
+[chara_layer name="yuko" part=mouse id=egao storage="image/egao.png" ]
+
+:param
+name=[chara_new]で定義したname属性を指定します。,
+part=パーツとして登録する名を指定します。例えば「目」というpartを登録しておいて、このpartの中で他の差分をいくつも登録できます。,
+id=パーツの中で差分にidを登録できます。例えば「目」というpartの中で「笑顔の目」「泣いてる目」のようにidを分けてstorageを登録してください,
+storage=差分として登録する画像を指定します。画像はfgimageフォルダの中に配置します。noneを指定するとデフォルトそのパーツがない状態を表現できます,
+zindex=数値を指定します。このpartが他のパーツ重なった時にどの位置に表示されるかを指定します。数値が大きい程、前面に表示されます。一度登録しておけば該当するpartに適応されます。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.chara_layer = {
     vital: ["name", "part", "id", "storage"],
@@ -2953,22 +3136,27 @@ tyrano.plugin.kag.tag.chara_layer = {
 };
 
 /*
- #[chara_layer_mod]
- :group
- キャラクター操作
- :title
- キャラクターの差分の定義を変更
- :exp
- chara_layerで定義した設定を変更することができます。
- :sample
- [chara_layer_mod name="yuko" part=mouse zindex=20 ]
- :param
- name=[chara_new]で定義したname属性を指定してください。,
- part=変更したいパーツとして登録した名を指定します。,
- zindex=数値を指定します。このpartが他のパーツ重なった時にどの位置に表示されるかを指定します。数値が大きい程、前面に表示されます。この設定は即時反映されず、次回表示時、反映されます。
+#[chara_layer_mod]
 
- #[end]
- */
+:group
+キャラクター操作
+
+:title
+キャラクターの差分の定義を変更
+
+:exp
+chara_layerで定義した設定を変更できます。
+
+:sample
+[chara_layer_mod name="yuko" part=mouse zindex=20 ]
+
+:param
+name=[chara_new]で定義したname属性を指定します。,
+part=変更したいパーツとして登録した名を指定します。,
+zindex=数値を指定します。このpartが他のパーツ重なった時にどの位置に表示されるかを指定します。数値が大きい程、前面に表示されます。この設定は即時反映されず、次回表示時、反映されます。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.chara_layer_mod = {
     vital: ["name", "part"],
@@ -3012,28 +3200,34 @@ tyrano.plugin.kag.tag.chara_layer_mod = {
 };
 
 /*
- #[chara_part]
- :group
- キャラクター操作
- :title
- キャラクターの差分パーツ変更
- :exp
- [chara_layer]で指定した差分を実際に表示切り替えする
- このタグは特殊なパラメータ指定で[chara_layer]で定義したpart と id の組み合わせをパラメータとして自由に指定できます。
- （例）eye=sample1
- 同時に複数のpartを変更することも可能です。
- また、id登録していない、画像を直接指定することもできます。この場合パラメータのallow_storageにtrueに指定してください。
- 特定部位のzindexを変更して出力したい場合はpart名+_zindex という名前のパラメータに数値を代入することができます。
- （例）eye_zindex=10
- :sample
- [chara_part name="yuko" mouse=aaa eye=bbb ]
- :param
- name=[chara_new]で指定したキャラクター名を指定してください。,
- time=パーツが表示されるまでの時間を指定できます。ミリ秒で指定してください。指定するとフェードインしながら表示できます。デフォルトは指定なしです。,
- wait=true or false を指定します。trueを指定するとtimeで指定したフェードインの完了を待ちます。デフォルトはtrueです。,
- allow_storage=true or false 。partの指定にidではなく直接画像ファイルを指定できます。画像はfgimageフォルダに配置してください。デフォルトはfalseです。
- #[end]
- */
+#[chara_part]
+
+:group
+キャラクター操作
+
+:title
+キャラクターの差分パーツ変更
+
+:exp
+[chara_layer]で指定した差分を実際に表示切り替えする
+このタグは特殊なパラメータ指定で[chara_layer]で定義したpart と id の組み合わせをパラメータとして自由に指定できます。
+（例）eye=sample1
+同時に複数のpartを変更することも可能です。
+また、id登録していない、画像を直接指定することもできます。この場合パラメータのallow_storageにtrueに指定してください。
+特定部位のzindexを変更して出力したい場合はpart名+_zindex という名前のパラメータに数値を代入できます。
+（例）eye_zindex=10
+
+:sample
+[chara_part name="yuko" mouse=aaa eye=bbb ]
+
+:param
+name=[chara_new]で指定したキャラクター名を指定します。,
+time=パーツが表示されるまでの時間を指定できます。ミリ秒で指定します。指定するとフェードインしながら表示できます。デフォルトは指定なしです。,
+wait=true or false を指定します。trueを指定するとtimeで指定したフェードインの完了を待ちます。デフォルトはtrueです。,
+allow_storage=true or false 。partの指定にidではなく直接画像ファイルを指定できます。画像はfgimageフォルダに配置してください。デフォルトはfalseです。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.chara_part = {
     vital: ["name"],
@@ -3199,21 +3393,27 @@ tyrano.plugin.kag.tag.chara_part = {
 };
 
 /*
- #[chara_part_reset]
- :group
- キャラクター操作
- :title
- キャラクターの差分パーツをデフォルトに戻す
- :exp
- [chara_part]で差分を変更した際、デフォルトの表情に戻すことができます。
- キャラクターが表示されている場合は即時デフォルトに戻ります。
- :sample
- [chara_part_reset name="yuko" ]
- :param
- name=[chara_new]で指定したキャラクター名を指定してください。,
- part=特定のpartに絞ってリセットすることが可能です。デフォルトはすべてをデフォルトに戻します。ここに記述することで指定したpartのみリセットされます。カンマで区切ると複数指定することが可能です
- #[end]
- */
+#[chara_part_reset]
+
+:group
+キャラクター操作
+
+:title
+キャラクターの差分パーツをデフォルトに戻す
+
+:exp
+[chara_part]で差分を変更した際、デフォルトの表情に戻すことができます。
+キャラクターが表示されている場合は即時デフォルトに戻ります。
+
+:sample
+[chara_part_reset name="yuko" ]
+
+:param
+name=[chara_new]で指定したキャラクター名を指定します。,
+part=特定のpartに絞ってリセットすることが可能です。デフォルトはすべてをデフォルトに戻します。ここに記述することで指定したpartのみリセットされます。カンマで区切ると複数指定することが可能です
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.chara_part_reset = {
     vital: ["name"],
@@ -3274,18 +3474,24 @@ tyrano.plugin.kag.tag.chara_part_reset = {
 };
 
 /*
- #[showlog]
- :group
- システム操作
- :title
- バックログを表示します
- :exp
- バックログを表示します
- :sample
- [showlog]
- :param
- #[end]
- */
+#[showlog]
+
+:group
+システム操作
+
+:title
+バックログを表示します
+
+:exp
+バックログを表示します
+
+:sample
+[showlog]
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.showlog = {
     pm: {},
@@ -3298,35 +3504,34 @@ tyrano.plugin.kag.tag.showlog = {
 
 /*
 #[filter]
+
 :group
 レイヤ関連
+
 :title
 フィルター効果演出
-:exp
-レイヤやオブジェクトを指定して、様々なフィルター効果を追加することができます。
 
+:exp
+レイヤやオブジェクトを指定して、様々なフィルター効果を追加できます。
 
 :sample
-
 ;特定のオブジェクトを指定して、フィルター効果。
 [filter layer="0" name="chara_a" grayscale=50 ]
 
 ;レイヤを指定してフィルター効果
 [filter layer="0" grayscale=50 ]
 
-
 :param
-layer=効果を追加するレイヤを指定します。指定しない場合、もしくは「all」と指定するとゲーム画面全てに効果がかかります,
+layer=効果を追加するレイヤを指定します。省略すると、もしくは「all」と指定するとゲーム画面全てに効果がかかります,
 name=削除する要素のnameを指定します。レイヤの中のあらゆるオブジェクトに適応できます。,
-
-grayscale=0(デフォルト)-100 を指定することで、画像の表示をグレースケールに変換することができます,
-sepia=0(デフォルト)-100を指定することで、画像の表示をセピア調に変換することができます,
-saturate=0-100(デフォルト)を指定してあげることで、画像の表示の彩度（色の鮮やかさ）を変更することができます,
-hue=0(デフォルト)-360を指定することで、画像の表示の色相を変更することができます,
+grayscale=0(デフォルト)-100 を指定することで、画像の表示をグレースケールに変換できます,
+sepia=0(デフォルト)-100を指定することで、画像の表示をセピア調に変換できます,
+saturate=0-100(デフォルト)を指定してあげることで、画像の表示の彩度（色の鮮やかさ）を変更できます,
+hue=0(デフォルト)-360を指定することで、画像の表示の色相を変更できます,
 invert=0(デフォルト)-100を指定することで、画像の表示の階調を反転させることができます,
-opacity=0-100(デフォルト)を指定することで、画像の表示の透過度を変更することができます,
-brightness=0-100(デフォルト)を指定することで、画像の表示の明るさを変更することができます。元画像より暗くしたい場合に使えます,
-contrast=0-100(デフォルト)を指定することで、画像の表示のコントラストを変更することができます,
+opacity=0-100(デフォルト)を指定することで、画像の表示の透過度を変更できます,
+brightness=0-100(デフォルト)を指定することで、画像の表示の明るさを変更できます。元画像より暗くしたい場合に使えます,
+contrast=0-100(デフォルト)を指定することで、画像の表示のコントラストを変更できます,
 blur=0(デフォルト)-任意の値[px] を指定することで、画像の表示をぼかすことができます
 
 :demo
@@ -3432,22 +3637,23 @@ tyrano.plugin.kag.tag.filter = {
 
 /*
 #[free_filter]
+
 :group
 レイヤ関連
+
 :title
 フィルター効果削除
+
 :exp
 レイヤやオブジェクトを指定して、filter効果を無効にします。
 指定されない場合はすべてのフィルター効果が無効化されます。
 
 :sample
-
 ;特定のオブジェクトを指定して、フィルターを打ち消す。
 [free_filter layer="0" name="chara_a"]
 
 ;全部のフィルターを打ち消す
 [free_filter  ]
-
 
 :param
 layer=フィルターを打ち消すレイヤを指定します。指定がない場合、すべての効果が消されます,
@@ -3497,33 +3703,35 @@ tyrano.plugin.kag.tag.free_filter = {
 };
 
 /*
- #[web]
- :group
- その他
- :title
- Webサイトを開く
- :exp
- 指定したWebサイトをブラウザで開くことができます。
- ただし、このタグを配置する直前にクリック待ちを配置する必要があります。
- 多くの環境で、ユーザーアクションなしにブラウザが開くことを禁止しています。
- :sample
+#[web]
 
- ;クリック待ちを挟む
- 公式サイトを開きます[p]
- [web url="http://tyrano.jp"]
+:group
+その他
 
- ;ローカルのファイルを開きたい場合
- [web url="./data/bgimage/room.jpg"]
+:title
+Webサイトを開く
 
- :param
- url=開きたいWebサイトのURLを入れてください。
+:exp
+指定したWebサイトをブラウザで開くことができます。
+ただし、このタグを配置する直前にクリック待ちを配置する必要があります。
+多くの環境で、ユーザーアクションなしにブラウザが開くことを禁止しています。
 
- :demo
+:sample
+;クリック待ちを挟む
+公式サイトを開きます[p]
+[web url="http://tyrano.jp"]
+
+;ローカルのファイルを開きたい場合
+[web url="./data/bgimage/room.jpg"]
+
+:param
+url=開きたいWebサイトのURLを入れてください。
+
+:demo
 2,kaisetsu/11_html
 
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.web = {
     vital: ["url"],

--- a/tyrano/plugins/kag/kag.tag_system.js
+++ b/tyrano/plugins/kag/kag.tag_system.js
@@ -1,12 +1,16 @@
 /*
 #[eval]
+
 :group
 マクロ・変数・JS操作
+
 :title
 式の評価
+
 :exp
 expで示された式を評価します。変数への値の代入などに使用されます。
 exp には任意の TJS(JS) 式を指定できるので、TJS(JS) として有効な式であれば 何でも評価できます。
+
 :sample
 [eval exp="f.test=500"]
 ;↑ゲーム変数 test に数値を代入している
@@ -16,6 +20,7 @@ exp には任意の TJS(JS) 式を指定できるので、TJS(JS) として有�
 ;↑システム変数 test に数値を代入している
 [eval exp="f.test2=f.test*3"]
 ;↑ゲーム変数 test2 に ゲーム変数 test の 3 倍の数値を代入している
+
 :param
 exp=評価するTJS式を指定します。
 
@@ -45,16 +50,21 @@ tyrano.plugin.kag.tag.eval = {
 
 /*
 #[clearvar]
+
 :group
 マクロ・変数・JS操作
+
 :title
 変数の消去
+
 :exp
 ゲーム変数を消去します。
-パラメータを指定しない場合はすべての編集が消去されます。
+
 :sample
+
 :param
-exp=変数名を指定できます。変数名を指定した場合はその変数だけを消去します。例えば「f.name」「sf.flag」のように指定します。省略した場合はすべての変数が消去されます。
+exp=変数名を指定できます。変数名を指定した場合はその変数だけを消去します。例えば「f.name」「sf.flag」のように指定します。省略すると、すべての変数が消去されます。
+
 #[end]
 */
 
@@ -78,14 +88,20 @@ tyrano.plugin.kag.tag.clearvar = {
 
 /*
 #[clearsysvar]
+
 :group
 マクロ・変数・JS操作
+
 :title
 システム変数の全消去
+
 :exp
 システム変数を全消去します
+
 :sample
+
 :param
+
 #[end]
 */
 
@@ -100,23 +116,29 @@ tyrano.plugin.kag.tag.clearsysvar = {
 
 /*
 #[clearstack]
+
 :group
 マクロ・変数・JS操作
+
 :title
 スタックの消去
+
 :exp
 システムが管理するスタックを消去します。
-スタックとはゲームを進める中で Call、マクロ呼び出し、 if 文などを通過した時に
-呼び出し元に帰ってくるために保持するメモリ領域です。
-通常のノベルゲームであれば、特に問題はおきませんが
-Call の途中でジャンプ。if文の中でジャンプ
-などを繰り返した場合、回収されないスタックが溜まっていきます。
-これらは、セーブデータの肥大化などを引き起こす場合ばあるので
-戻るべきスタックが無い場面でこのタグを配置しておくことをオススメします。
-きりの良い場所などです。（タイトル 章の始まり）
+
+帰るべきスタックがない場面（タイトルや章の始まりなど、きりの良い場面）でこのタグを配置しておくことをオススメします。
+
+スタックとは、ゲームを進める中で`[call]`、`[if]`、マクロを通過したさいに呼び出し元に帰ってくるために記憶しておくメモリ領域です。
+
+`[call]`先で`[return]`することなくジャンプしたり、`[if]`やマクロの中でジャンプしたりすることを繰り返した場合、回収されないスタックが溜まっていきます。
+
+スタックが溜まりすぎると、セーブデータの肥大化やマシンのパフォーマンスの低下を引き起こす恐れがあります。
+
 :sample
+
 :param
-stack=call if macro のいづれかを指定できます。特定のスタックのみ削除することができます。指定しなければ全てのスタックを削除します。
+stack=`call`、`if`、`macro`のいずれかを指定できます。特定のスタックのみ削除できます。省略すると、全てのスタックを削除します。
+
 #[end]
 */
 
@@ -141,16 +163,22 @@ tyrano.plugin.kag.tag.clearstack = {
 
 /*
 #[close]
+
 :group
 システム操作
+
 :title
 ウィンドウを閉じる
+
 :exp
-ウィンドウを閉じます。
-ブラウザから閲覧している場合は、ブラウザが終了します
+アプリ版の場合、ウィンドウを閉じます。
+ブラウザ版の場合、タブを閉じます。
+
 :sample
+
 :param
-ask=true を指定すると、終了するかどうかの確認をします。false を 指定するとこの確認はありません。この属性を省略 すると、 true を指定したとみなされます。
+ask=終了の確認をするかどうか。`true`または`false`で指定します。デフォルトは`true`。
+
 #[end]
 */
 
@@ -198,21 +226,28 @@ tyrano.plugin.kag.tag["close"] = {
 
 /*
 #[trace]
+
 :group
 その他
+
 :title
 コンソールへの値の出力
+
 :exp
-expで指定された式を評価し、結果をコンソールに出力します。
-【KAG3吉里吉里の場合】
-コンソールは Shift+F4 で表示されるほか、Config.tjs 内で logMode を設定することに より、ファイルに記録することもできます。
-【ティラノスクリプト　ブラウザの場合】
-ブラウザのウェブインスペクタからコンソールを確認してください
+`exp`パラメータで指定された式を評価し、結果をコンソールに出力します。
+
+ブラウザ版の場合、コンソールを確認するにはデベロッパーツールを開いてください。
+
 :sample
+;ゲーム変数testに1を入れる
+[eval exp="f.test=1"]
+
+;ゲーム変数testの内容をコンソールに出力する
 [trace exp="f.test"]
-; ↑ ゲーム変数 test の内容を コンソール に出力する
+
 :param
-exp=評価するTJS（JS）式を指定します
+exp=評価するJS式を指定します。
+
 #[end]
 */
 
@@ -233,28 +268,32 @@ tyrano.plugin.kag.tag["trace"] = {
 };
 
 /*
- #[body]
- :group
- システム操作
- :title
- ゲーム画面外の設定
- :exp
- ゲーム描画領域の外側をカスタマイズすることができます。
- 例えば、背景画像を設定するなど。
- 重要な点として必ずfirst.ksなど、ゲーム起動時に通過する場所で設定してください。このタグはロード時は復元されません。
- :sample
- [body bgimage="back.png" bgcolor="black" ]
- :param
- bgimage=ゲーム画面外の背景に画像を設定することができます。bgimageフォルダに配置してください。,
- bgrepeat=背景に画像を指定した際の表示パターンを指定します。デフォルトは縦横に繰り返し表示されます。repeat-x:水平方向のみ繰り返し。repeat-y:垂直方向のみ繰り返し。round:比率を崩して覆うように全画面繰り返し。no-repeat:繰り返しなし,
- bgcolor=背景色を指定できます。0x000000形式で指定してください。なお、bgimageが設定されている場合は無視されます。,
- bgcover= true or false。デフォルトはfalse 。trueを指定すると１枚が全画面に引き伸ばして配置されます,
- scWidth=ゲーム画面のオリジナル横幅サイズをゲーム中に変更できます。レスポンシブ対応を想定したタグです。Config.tjsのscWidthに対応します。,
- scHeight=ゲーム画面のオリジナル縦幅サイズをゲーム中に変更できます。レスポンシブ対応を想定したタグです。Config.tjsのscHeightに対応します。
+#[body]
 
+:group
+システム操作
 
- #[end]
- */
+:title
+ゲーム画面外の設定
+
+:exp
+ゲーム描画領域の外側をカスタマイズできます。
+例えば、背景画像を設定するなど。
+重要な点として必ずfirst.ksなど、ゲーム起動時に通過する場所で設定してください。このタグはロード時は復元されません。
+
+:sample
+[body bgimage="back.png" bgcolor="black" ]
+
+:param
+bgimage=ゲーム画面外の背景に設定する画像を指定します。bgimageフォルダに配置してください。,
+bgrepeat=背景に画像を指定した際の表示パターンを指定します。デフォルトは縦横に繰り返し表示されます。repeat-x:水平方向のみ繰り返し。repeat-y:垂直方向のみ繰り返し。round:比率を崩して覆うように全画面繰り返し。no-repeat:繰り返しなし,
+bgcolor=背景色を0xRRGGBB形式で指定します。なお、bgimageが設定されている場合は無視されます。,
+bgcover= true or false。デフォルトはfalse 。trueを指定すると１枚が全画面に引き伸ばして配置されます,
+scWidth=ゲーム画面のオリジナル横幅サイズをゲーム中に変更できます。レスポンシブ対応を想定したタグです。Config.tjsのscWidthに対応します。,
+scHeight=ゲーム画面のオリジナル縦幅サイズをゲーム中に変更できます。レスポンシブ対応を想定したタグです。Config.tjsのscHeightに対応します。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag["body"] = {
     vital: [],
@@ -331,22 +370,28 @@ tyrano.plugin.kag.tag["body"] = {
 };
 
 /*
- #[title]
- :group
- システム操作
- :title
- タイトル指定
- :exp
- ゲームタイトルを指定します。
- 例えば、章ごとにタイトルを変えるとプレイヤーからわかりやすくなります。
- 吉里吉里の場合、アプリのウィンドウタイトル。
- ティラノスクリプトの場合、ブラウザタイトルが変わります
- :sample
- [title name="変更後のタイトル"]
- :param
- name=表示したいタイトルを指定してください
- #[end]
- */
+#[title]
+
+:group
+システム操作
+
+:title
+タイトル指定
+
+:exp
+ゲームタイトルを指定します。
+例えば、章ごとにタイトルを変えるとプレイヤーからわかりやすくなります。
+吉里吉里の場合、アプリのウィンドウタイトル。
+ティラノスクリプトの場合、ブラウザタイトルが変わります
+
+:sample
+[title name="変更後のタイトル"]
+
+:param
+name=表示したいタイトルを指定します
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag["title"] = {
     vital: ["name"],
@@ -367,13 +412,17 @@ tyrano.plugin.kag.tag["title"] = {
 
 /*
 #[iscript]
+
 :group
 マクロ・変数・JS操作
+
 :title
 JavaScriptの記述
+
 :exp
-[iscript]と[endscript]に囲まれた箇所にJavaScriptを記述することができます。
+[iscript]と[endscript]に囲まれた箇所にJavaScriptを記述できます。
 TJSの式にも適応できますが、ティラノスクリプトとの動作互換はありません
+
 :sample
 [iscript]
 
@@ -384,6 +433,7 @@ alert("javascriptの関数にもアクセス可能");
 $("body").html();
 
 [endscript]
+
 :param
 
 :demo
@@ -403,15 +453,21 @@ tyrano.plugin.kag.tag.iscript = {
 
 /*
 #[endscript]
+
 :group
 マクロ・変数・JS操作
+
 :title
 JavaScriptの終了
+
 :exp
 JavaScriptの記述を終了します
+
 :sample
+
 :param
 stop=endscriptに到達した時、ここにtrueを指定すると次のタグに進ませない。scriptの中でjumpした時などに指定する。デフォルトはfalse
+
 #[end]
 */
 
@@ -435,12 +491,15 @@ tyrano.plugin.kag.tag.endscript = {
 
 /*
 #[html]
+
 :group
 その他
+
 :title
 HTMLをレイヤ追加
+
 :exp
-[html]と[endhtml]の間に記述したHTMLを表示することができます。
+[html]と[endhtml]の間に記述したHTMLを表示できます。
 この機能は非常に強力です。もちろんJavaScriptタグ。Canvasなど次世代Web表現を全てサポートします。
 例えば、Youtubeのビデオプレイヤーを挿入したり、無数に公開されているWebAPIとの連携なども可能です。
 このタグで挿入した場合は最前面にHTML要素が挿入されます
@@ -448,6 +507,7 @@ cmタグなどで画面をクリアしない限り、クリックしてもゲー
 必ずグラフィックボタンなども配置して、ジャンプでゲームを進める状態にしておくことが必要です。
 タグの中に、ティラノスクリプトの変数を挿入することもできます。
 従来通りHTMLの中で[emb]タグを使用してください
+
 :sample
 
 ;youtubeのプレイヤーを指定した位置に挿入します
@@ -463,10 +523,11 @@ cmタグなどで画面をクリアしない限り、クリックしてもゲー
 </embed></object>
 
 [endhtml]
+
 :param
 left=HTMLタグの左端位置を指定します。（ピクセル）,
 top=HTMLの上端位置を指定します。（ピクセル）,
-name=HTML領域に名前を指定することができます。この名前を使って、HTML領域に対してアニメーションなども実行できます。
+name=HTML領域に名前を指定できます。この名前を使って、HTML領域に対してアニメーションなども実行できます。
 
 :demo
 2,kaisetsu/11_html
@@ -493,14 +554,20 @@ tyrano.plugin.kag.tag.html = {
 
 /*
 #[endhtml]
+
 :group
 その他
+
 :title
 HTMLの終了
+
 :exp
 HTMLの記述を終了します
+
 :sample
+
 :param
+
 #[end]
 */
 //htmlの終了
@@ -544,24 +611,29 @@ tyrano.plugin.kag.tag.endhtml = {
 };
 
 /*
- #[emb]
- :group
- マクロ・変数・JS操作
- :title
- 式評価結果の埋め込み
- :exp
- exp で示された式を評価(実行)し、その結果を埋め込みます。
- 変数をシナリオ中に表示させたい場合に使います。
- :sample
- [eval exp="f.value1='変数の値だよ～ん'"]
- とどこかで書いておいて、
- [emb exp="f.value1"]
- と書くと、この emb タグが 変数の値だよ～ん という内容に置き換わります。
- :param
- exp=評価するTJS（JS）式を指定します。ここで評価された式がembタグと置き換わります
+#[emb]
 
- #[end]
- */
+:group
+マクロ・変数・JS操作
+
+:title
+式評価結果の埋め込み
+
+:exp
+exp で示された式を評価(実行)し、その結果を埋め込みます。
+変数をシナリオ中に表示させたい場合に使います。
+
+:sample
+[eval exp="f.value1='変数の値だよ～ん'"]
+とどこかで書いておいて、
+[emb exp="f.value1"]
+と書くと、この emb タグが 変数の値だよ～ん という内容に置き換わります。
+
+:param
+exp=評価するTJS（JS）式を指定します。ここで評価された式がembタグと置き換わります
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.emb = {
     vital: ["exp"],
@@ -584,21 +656,25 @@ tyrano.plugin.kag.tag.emb = {
 
 /*
 #[if]
+
 :group
 マクロ・変数・JS操作
+
 :title
 条件分岐
+
 :exp
 式を評価し、その結果が true ( または 0 以外 ) ならば、 elsif・else・endif のいずれかまでにある文章やタグを実行し、 そうでない場合は無視します。
+
 :sample
-; 例1
+;例1
 [if exp="false"]
 ここは表示されない
 [else]
 ここは表示される
 [endif]
 
-; 例2
+;例2
 [if exp="false"]
 ここは表示されない
 [elsif exp="false"]
@@ -607,7 +683,7 @@ tyrano.plugin.kag.tag.emb = {
 ここは表示される
 [endif]
 
-; 例3
+;例3
 [if exp="false"]
 ここは表示されない
 [elsif exp="true"]
@@ -616,7 +692,7 @@ tyrano.plugin.kag.tag.emb = {
 ここは表示されない
 [endif]
 
-; 例4
+;例4
 [if exp="true"]
 ここは表示される
 [elsif exp="true"]
@@ -624,12 +700,12 @@ tyrano.plugin.kag.tag.emb = {
 [else]
 ここは表示されない
 [endif]
+
 :param
 exp=評価する TJS 式を指定します。この式の結果が false ( または 0 な らば、elsif・else・endif タグまでの文章やタグが無視されます。
 
 :demo
 1,kaisetsu/20_variable_2
-
 
 #[end]
 */
@@ -682,23 +758,28 @@ tyrano.plugin.kag.tag["if"] = {
 };
 
 /*
- #[elsif]
- :group
- マクロ・変数・JS操作
- :title
- それまでの if の中身が実行されていなかったときに、条件付きで実行
- :exp
- if タグと endif タグの間で用いられます。 それまでの if タグまたは elsif タグの中身がひとつも実行されていないときに 式を評価し、その結果が真ならば elsif から次の elsif・else・endif までの間を実行します。
- 使い方の例については、if タグの項目を参照してください。
- :sample
- :param
- exp=評価する JS 式を指定します。
+#[elsif]
 
- :demo
+:group
+マクロ・変数・JS操作
+
+:title
+それまでの if の中身が実行されていなかったときに、条件付きで実行
+
+:exp
+if タグと endif タグの間で用いられます。 それまでの if タグまたは elsif タグの中身がひとつも実行されていないときに 式を評価し、その結果が真ならば elsif から次の elsif・else・endif までの間を実行します。
+使い方の例については、if タグの項目を参照してください。
+
+:sample
+
+:param
+exp=評価する JS 式を指定します。
+
+:demo
 1,kaisetsu/20_variable_2
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["elsif"] = {
     vital: ["exp"],
@@ -742,23 +823,27 @@ tyrano.plugin.kag.tag["elsif"] = {
 };
 
 /*
- #[else]
- :group
- マクロ・変数・JS操作
- :title
- if の中身が実行されなかったときに実行
- :exp
- if タグもしくは elsif タグ と endif タグの間で用いられます。 if または elsif ブロックの中身がひとつも実行されていないとき、 else から endif までの間を実行します。
- 使い方の例については、if タグの項目を参照してください。
- :sample
- :param
+#[else]
 
- :demo
+:group
+マクロ・変数・JS操作
+
+:title
+if の中身が実行されなかったときに実行
+
+:exp
+if タグもしくは elsif タグ と endif タグの間で用いられます。 if または elsif ブロックの中身がひとつも実行されていないとき、 else から endif までの間を実行します。
+使い方の例については、if タグの項目を参照してください。
+
+:sample
+
+:param
+
+:demo
 1,kaisetsu/20_variable_2
 
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["else"] = {
     pm: {
@@ -796,18 +881,24 @@ tyrano.plugin.kag.tag["else"] = {
 };
 
 /*
- #[endif]
- :group
- マクロ・変数・JS操作
- :title
- if文を終了します
- :exp
- if文を終了します。必ずif文の終わりに記述する必要があります
- :sample
- :param
- exp=評価する TJS 式を指定します。
- #[end]
- */
+#[endif]
+
+:group
+マクロ・変数・JS操作
+
+:title
+if文を終了します
+
+:exp
+if文を終了します。必ずif文の終わりに記述する必要があります
+
+:sample
+
+:param
+exp=評価する TJS 式を指定します。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag["endif"] = {
     log_join: "true",
@@ -821,24 +912,29 @@ tyrano.plugin.kag.tag["endif"] = {
 };
 
 /*
- #[call]
- :group
- マクロ・変数・JS操作
- :title
- サブルーチンの呼び出し
- :exp
- 指定されたシナリオファイルの指定されたラベルで示される サブルーチンを呼び出します。
- 呼び出されたサブルーチンは、 return タグで 呼び出し元や任意の場所に戻ることができます。
- :sample
- :param
- storage=呼び出したいサブルーチンのあるのシナリオファイルを 指定します。省略すると、現在 のシナリオファイル内であると見なされます。,
- target=呼び出すサブルーチンのラベルを指定します。省略すると、ファイルの先頭から実行されます。
+#[call]
 
- :demo
- 1,kaisetsu/21_macro
+:group
+マクロ・変数・JS操作
 
- #[end]
- */
+:title
+サブルーチンの呼び出し
+
+:exp
+指定されたシナリオファイルの指定されたラベルで示される サブルーチンを呼び出します。
+呼び出されたサブルーチンは、 return タグで 呼び出し元や任意の場所に戻ることができます。
+
+:sample
+
+:param
+storage=呼び出したいサブルーチンのあるのシナリオファイルを 指定します。省略すると、現在 のシナリオファイル内であるとみなされます。,
+target=呼び出すサブルーチンのラベルを指定します。省略すると、ファイルの先頭から実行されます。
+
+:demo
+1,kaisetsu/21_macro
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag["call"] = {
     pm: {
@@ -869,15 +965,20 @@ tyrano.plugin.kag.tag["call"] = {
 
 /*
 #[return]
+
 :group
 マクロ・変数・JS操作
+
 :title
 サブルーチンから戻る
+
 :exp
 サブルーチンから呼び出し元に戻ります。
 KAG３の任意の場所へのリターンは廃止しました。
 （必要な場合はCallで代用してください）
+
 :sample
+
 :param
 
 :demo
@@ -923,31 +1024,35 @@ tyrano.plugin.kag.tag["return"] = {
 
 /*
 #[macro]
+
 :group
 マクロ・変数・JS操作
+
 :title
 マクロの記述
+
 :exp
 マクロ記述を開始します。新しいタグを定義することが出来ます。
 このタグから、endmacro タグまでにある文章やタグは、 name 属性で指定されたタグとして登録され、以後使用できるようになります。
-マクロ中に書かれたタグには、特別に % を頭につけた属性の値を指定することができます。 % 以降にはマクロに渡された属性名を指定します。すると、マクロに渡された属性の値をその属性の値とすることができます。このとき、| を使って属性の省略値を指定することもできます ( 下の例参照 )。 属性名には小文字を用いてください。
+マクロ中に書かれたタグには、特別に % を頭につけた属性の値を指定できます。 % 以降にはマクロに渡された属性名を指定します。すると、マクロに渡された属性の値をその属性の値とできます。このとき、| を使って属性の省略値を指定することもできます ( 下の例参照 )。 属性名には小文字を用いてください。
 また、属性の代わりに * を書くと、マクロに渡されたすべての属性をそのタグに渡すこと ができます。
+
 :sample
 [macro name="newtag"][font color=0xff0000]新しいタグです[resetfont][endmacro]
 [newtag]
 [macro name="colortag"][font color=%iro]iro 属性付きのタグ[resetfont][endmacro]
 [colortag iro=0x332211]
-; ↑ colotag に渡された iro 属性の値が font タグの color 属性に渡される
+;↑ colotag に渡された iro 属性の値が font タグの color 属性に渡される
 [macro name="transwait"][trans *][wt][endmacro]
-; ↑ この transwait に渡されたすべての属性が trans タグに渡される
+;↑ この transwait に渡されたすべての属性が trans タグに渡される
 [macro name="colortag"][font color=%iro|0xff0000]iro 属性付きで省略値をしていしたタグ[resetfont][endmacro]
-; ↑ % の属性の値では、 | のあとに続けて、その属性の省略値を指定することができます
+;↑ % の属性の値では、 | のあとに続けて、その属性の省略値を指定できます
+
 :param
-name=マクロの名前を指定してください。以後この名前で新しいタグが定義され呼び出せるようになります。
+name=マクロの名前を指定します。以後この名前で新しいタグが定義され呼び出せるようになります。
 
 :demo
  1,kaisetsu/21_macro
-
 
 #[end]
 */
@@ -995,14 +1100,20 @@ tyrano.plugin.kag.tag.macro = {
 
 /*
 #[endmacro]
+
 :group
 マクロ・変数・JS操作
+
 :title
 マクロを終了します
+
 :exp
 マクロの終了タグです
+
 :sample
+
 :param
+
 #[end]
 */
 
@@ -1044,15 +1155,21 @@ tyrano.plugin.kag.tag.endmacro = {
 
 /*
 #[erasemacro]
+
 :group
 マクロ・変数・JS操作
+
 :title
 マクロの削除
+
 :exp
 登録したマクロを削除します
+
 :sample
+
 :param
 name=削除するマクロ名を記述してください
+
 #[end]
 */
 
@@ -1072,15 +1189,21 @@ tyrano.plugin.kag.tag.erasemacro = {
 
 /*
 #[savesnap]
+
 :group
 システム操作
+
 :title
 セーブスナップの作成
+
 :exp
 現在のプレイ状況を一時保存します。その後、tyrano.ks　拡張の[setsave]を行うことで、ここで記録したセーブデータが保存されます。
+
 :sample
+
 :param
 title=セーブデータのタイトルを指定します。
+
 #[end]
 */
 
@@ -1101,45 +1224,50 @@ tyrano.plugin.kag.tag.savesnap = {
 };
 
 /*
- #[autosave]
- :group
- システム操作
- :title
- オートセーブ機能
- :exp
- このタグに到達した際、自動的にプレイ状況を保存します。自動セーブ機能に活用ください。
- [autosave]されたデータが存在する場合、sf.system.autosaveにtrueが格納されます。
- タイトル画面より前に、サンプルのような判定ロジックを用意しておくことで、
- スマートフォンなどで、復帰後に事前にプレイしていた状態からゲームを開始することができるようになります。
- :sample
+#[autosave]
 
- [autosave]
+:group
+システム操作
 
- ;autosaveされたデータが存在する場合、sf.system.autosave に trueが入ります
- [if exp="sf.system.autosave ==true"]
- 自動的に保存されたデータが存在します。ロードしますか？[l][r]
+:title
+オートセーブ機能
 
- [link target=*select1]【１】はい[endlink][r]
- [link target=*select2]【２】いいえ[endlink][r]
+:exp
+このタグに到達した際、自動的にプレイ状況を保存します。自動セーブ機能に活用ください。
+[autosave]されたデータが存在する場合、sf.system.autosaveにtrueが格納されます。
+タイトル画面より前に、サンプルのような判定ロジックを用意しておくことで、
+スマートフォンなどで、復帰後に事前にプレイしていた状態からゲームを開始することができるようになります。
 
- [s]
+:sample
 
- *select1
- ;ロードを実行します
- [autoload]
+[autosave]
 
- *select2
- [cm]
- ロードをやめました[l]
- @jump target=*noload
- [else]
- 自動的に保存されたデータはありません。[l][r]
- [endif]
+;autosaveされたデータが存在する場合、sf.system.autosave に trueが入ります
+[if exp="sf.system.autosave ==true"]
+自動的に保存されたデータが存在します。ロードしますか？[l][r]
 
- :param
- title=セーブデータのタイトルを指定します。
- #[end]
- */
+[link target=*select1]【１】はい[endlink][r]
+[link target=*select2]【２】いいえ[endlink][r]
+
+[s]
+
+*select1
+;ロードを実行します
+[autoload]
+
+*select2
+[cm]
+ロードをやめました[l]
+@jump target=*noload
+[else]
+自動的に保存されたデータはありません。[l][r]
+[endif]
+
+:param
+title=セーブデータのタイトルを指定します。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.autosave = {
     vital: [],
@@ -1164,17 +1292,23 @@ tyrano.plugin.kag.tag.autosave = {
 };
 
 /*
- #[autoload]
- :group
- システム操作
- :title
- オートロード機能
- :exp
- [autosave]タグで保存されたデータを読み込みます
- :sample
- :param
- #[end]
- */
+#[autoload]
+
+:group
+システム操作
+
+:title
+オートロード機能
+
+:exp
+[autosave]タグで保存されたデータを読み込みます
+
+:sample
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.autoload = {
     vital: [],
@@ -1193,18 +1327,24 @@ tyrano.plugin.kag.tag.autoload = {
 };
 
 /*
- #[ignore]
- :group
- マクロ・変数・JS操作
- :title
- 条件によりシナリオを無視
- :exp
- 式を評価し、その結果が true ( または 0 以外 ) ならば、endignore タグまでにある文章 やタグが無視されます。
- :sample
- :param
- exp=評価する TJS 式を指定します。この式の結果が true ( または 0 以外 )ならば、endignore タグまでの文章やタグが無視されます。
- #[end]
- */
+#[ignore]
+
+:group
+マクロ・変数・JS操作
+
+:title
+条件によりシナリオを無視
+
+:exp
+式を評価し、その結果が true ( または 0 以外 ) ならば、endignore タグまでにある文章 やタグが無視されます。
+
+:sample
+
+:param
+exp=評価する TJS 式を指定します。この式の結果が true ( または 0 以外 )ならば、endignore タグまでの文章やタグが無視されます。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.ignore = {
     vital: ["exp"],
@@ -1235,17 +1375,23 @@ tyrano.plugin.kag.tag.ignore = {
 };
 
 /*
- #[endignore]
- :group
- マクロ・変数・JS操作
- :title
- ignoreの終了
- :exp
- ignoreを終了します
- :sample
- :param
- #[end]
- */
+#[endignore]
+
+:group
+マクロ・変数・JS操作
+
+:title
+ignoreの終了
+
+:exp
+ignoreを終了します
+
+:sample
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.endignore = {
     start: function () {
@@ -1255,16 +1401,20 @@ tyrano.plugin.kag.tag.endignore = {
 
 /*
 #[edit]
+
 :group
 入力フォーム関連
+
 :title
 テキストボックス
+
 :exp
 テキストボックスを表示します。
 入力された値はcommitタグのタイミングで指定した変数名に格納されます
 フォーム表示中はシナリオは停止します。（クリックしてもストーリーが進まない）
 必ず、グラフィックボタンなどを配置してラベルへジャンプしてください。
 こまかい表示方法の変更はtyrano.css内を編集することで可能です。
+
 :sample
 [edit name="f.test"]
 
@@ -1283,7 +1433,7 @@ tyrano.plugin.kag.tag.endignore = {
 :param
 name=格納する変数名を指定して下さい,
 length=横幅です,
-initial=初期値を設定することができます,
+initial=初期値を設定できます,
 color=文字の色を指定して下さい　デフォルトは黒です,
 left=テキストボックスの横位置を指定します,
 top=テキストボックスの縦位置を指定します,
@@ -1295,7 +1445,6 @@ maxchars=最大入力文字数
 
 :demo
  1,kaisetsu/15_input_1
-
 
 #[end]
 */
@@ -1392,16 +1541,20 @@ tyrano.plugin.kag.tag.edit = {
 
 /*
 #[preload]
+
 :group
 システム操作
+
 :title
 画像ファイルの事前読み込み
+
 :exp
 preloadタグを使用することで、素材ファイル（画像や音楽）を事前に読み込んでおくことができます。
 実際に素材を使用する際に表示がスムーズになります。
+
 :sample
 
-;画像ファイルはフルパス（プロジェクトファイル以下）で指定してください
+;画像ファイルはフルパス（プロジェクトファイル以下）で指定します
 [preload storage="data/fgimage/girl.jpg"]
 
 ;配列を渡すと、まとめてロードすることもできます。
@@ -1474,26 +1627,30 @@ tyrano.plugin.kag.tag.preload = {
 };
 
 /*
- #[clearfix]
- :group
- レイヤ関連
- :title
- Fixレイヤーをクリアします。
- :exp
- name属性を指定することで、該当する要素のみを削除することもできます。
- :sample
+#[clearfix]
 
- ;fixレイヤーへの追加
- [ptext name="sample" layer=fix page=fore text="テキストテキスト" size=30 x=200 y=100 color=red ]
+:group
+レイヤ関連
 
- ;fixレイヤーのクリア
- [clearfix name="sample"]
+:title
+Fixレイヤーをクリアします。
 
- :param
- name=fixレイヤーへ追加した時に名前を指定した場合、適応できます。
+:exp
+name属性を指定することで、該当する要素のみを削除することもできます。
 
- #[end]
- */
+:sample
+
+;fixレイヤーへの追加
+[ptext name="sample" layer=fix page=fore text="テキストテキスト" size=30 x=200 y=100 color=red ]
+
+;fixレイヤーのクリア
+[clearfix name="sample"]
+
+:param
+name=fixレイヤーへ追加した時に名前を指定した場合、適応できます。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.clearfix = {
     pm: {
@@ -1512,23 +1669,27 @@ tyrano.plugin.kag.tag.clearfix = {
 };
 
 /*
- #[commit]
- :group
- 入力フォーム関連
- :title
- フォームの確定
- :exp
- テキストボックスの値を確定して指定したname属性で指定した変数に値を格納します。
- 注意点としてcommitが実行された段階で、テキストボックスなどのフォームが表示されている必要があります。
- :sample
- :param
+#[commit]
 
- :demo
- 1,kaisetsu/15_input_1
+:group
+入力フォーム関連
 
+:title
+フォームの確定
 
- #[end]
- */
+:exp
+テキストボックスの値を確定して指定したname属性で指定した変数に値を格納します。
+注意点としてcommitが実行された段階で、テキストボックスなどのフォームが表示されている必要があります。
+
+:sample
+
+:param
+
+:demo
+1,kaisetsu/15_input_1
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.commit = {
     start: function () {
@@ -1553,21 +1714,27 @@ tyrano.plugin.kag.tag.commit = {
 };
 
 /*
- #[cursor]
- :group
- システム操作
- :title
- マウスカーソルに画像を設定できいます
- :exp
- storageに指定した画像ファイルがマウスカーソルに指定されます。data/imageフォルダ以下に配置してください。ファイルは形式は gif png jpg です。
- ゲーム中に何度でも変更することが可能です。ゲームでの標準カーソルを指定する場合はsystem/Config.tjsのcursorDefaultを指定してください。
- システムの標準カーソルに戻す場合はdefaultを指定します
- :sample
- [cursor storage="my_cursor.gif"]
- :param
- storage=カーソルに指定したい画像ファイルを指定します。画像はdata/imageフォルダに配置してください。
- #[end]
- */
+#[cursor]
+
+:group
+システム操作
+
+:title
+マウスカーソルに画像を設定
+
+:exp
+storageに指定した画像ファイルがマウスカーソルに指定されます。data/imageフォルダ以下に配置してください。ファイルは形式は gif png jpg です。
+ゲーム中に何度でも変更することが可能です。ゲームでの標準カーソルを指定したい場合は、system/Config.tjsのcursorDefaultを変更します。
+システムの標準カーソルに戻す場合はdefaultを指定します
+
+:sample
+[cursor storage="my_cursor.gif"]
+
+:param
+storage=マウスカーソルに指定したい画像ファイルを指定します。画像はdata/imageフォルダに配置します。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.cursor = {
     vital: ["storage"],
@@ -1584,19 +1751,25 @@ tyrano.plugin.kag.tag.cursor = {
 };
 
 /*
- #[screen_full]
- :group
- システム操作
- :title
- フルスクリーン
- :exp
- ゲーム画面をフルスクリーンにします。PCゲームのみ動作します
- ウィンドウに戻す場合は再度呼び出すことでウィンドウに戻ります
- :sample
- [screen_full]
- :param
- #[end]
- */
+#[screen_full]
+
+:group
+システム操作
+
+:title
+フルスクリーン
+
+:exp
+ゲーム画面をフルスクリーンにします。PCゲームのみ動作します
+ウィンドウに戻す場合は再度呼び出すことでウィンドウに戻ります
+
+:sample
+[screen_full]
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.screen_full = {
     vital: [],
@@ -1611,44 +1784,46 @@ tyrano.plugin.kag.tag.screen_full = {
 };
 
 /*
- #[sleepgame]
- :group
- システム操作
- :title
- ゲームの一時停止
- :exp
+#[sleepgame]
 
- このタグに到達した時点でゲームの状態を保存した上で、他のシナリオへ移動することができます。
- そして遷移先で[awakegame]が実行されたらゲームに復帰できます。
+:group
+システム操作
 
- このタグはゲームから一時的に画面を遷移したい場合に非常に強力に機能します。
+:title
+ゲームの一時停止
 
- 例えば、ゲームの途中でコンフィグの設定を行いたい場合などは
- sleepgameで進行状態を保持した上で、コンフィグ画面に移動します。[awakegame]タグでゲームに復帰します
+:exp
 
- sleepgameは複数実行することはできません。必ず[awakegame]を実行して下さい。
- [awakegame]を実行しない場合は[breakgame]で休止中の状態を破棄します。
+このタグに到達した時点でゲームの状態を保存した上で、他のシナリオへ移動できます。
+そして遷移先で[awakegame]が実行されたらゲームに復帰できます。
 
- [button]で呼びたす場合、roleにsleepgameを指定すると、押された時にsleepgameを適応することができます。
+このタグはゲームから一時的に画面を遷移したい場合に非常に強力に機能します。
 
- :sample
+例えば、ゲームの途中でコンフィグの設定を行いたい場合などは
+sleepgameで進行状態を保持した上で、コンフィグ画面に移動します。[awakegame]タグでゲームに復帰します
 
- [sleepgame storage="scene3.ks" target="*start" ]
+sleepgameは複数実行することはできません。必ず[awakegame]を実行して下さい。
+[awakegame]を実行しない場合は[breakgame]で休止中の状態を破棄します。
 
- ;buttonに紐付ける方法
- [button name="button" role="sleepgame" fix="true" graphic="button/skip.gif" x=450 y=400 storage="scene3.ks" ]
+[button]で呼びたす場合、roleにsleepgameを指定すると、押された時にsleepgameを適応できます。
 
- :param
- storage=ゲームを中断して処理を始めるシナリオ名を記述します。省略された場合は、現在のファイル名と解釈されます,
- target=ジャンプする先のラベル名を指定できます。省略されている場合は先頭位置からと解釈されます,
- next=true か　falseを指定。 falseを指定するとawakegameで戻ってくる時に次の命令へ移らなくなります。デフォルトはtrue
+:sample
+
+[sleepgame storage="scene3.ks" target="*start" ]
+
+;buttonに紐付ける方法
+[button name="button" role="sleepgame" fix="true" graphic="button/skip.gif" x=450 y=400 storage="scene3.ks" ]
+
+:param
+storage=ゲームを中断して処理を始めるシナリオ名を記述します。省略された場合は、現在のファイル名と解釈されます,
+target=ジャンプする先のラベル名を指定できます。省略されている場合は先頭位置からと解釈されます,
+next=true か　falseを指定。 falseを指定するとawakegameで戻ってくる時に次の命令へ移らなくなります。デフォルトはtrue
 
 :demo
- 2,kaisetsu/09_sleepgame
+2,kaisetsu/09_sleepgame
 
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.sleepgame = {
     vital: [],
@@ -1679,24 +1854,31 @@ tyrano.plugin.kag.tag.sleepgame = {
 };
 
 /*
- #[awakegame]
- :group
- システム操作
- :title
- ゲームの一時停止からの復帰
- :exp
- [gamesleep]タグで一時停止していたゲームを再開します。
- ジャンプ先での変数操作 （f）については、ゲーム復旧後も反映されます。
- ゲームに戻る前にmake.ksを通過します。ジャンプ先での操作に対して戻る前に設定を行いたい場合は
- make.ksで変数fに対して、[awakegame]からの復帰かどうかの判定をいれるとよいでしょう。
- :sample
- :param
- variable_over=trueかfalseを指定します。trueを指定するとsleepgame中のゲーム変数への変更を引き継ぎます。デフォルトはtrue,
- bgm_over=trueかfalseを指定します。trueを指定するとsleepgame中のBGMを再生し続けます。デフォルトはtrue。falseだとsleepgame時のBGMに切り替わります。
- :demo
- 2,kaisetsu/09_sleepgame
- #[end]
- */
+#[awakegame]
+
+:group
+システム操作
+
+:title
+ゲームの一時停止からの復帰
+
+:exp
+[gamesleep]タグで一時停止していたゲームを再開します。
+ジャンプ先での変数操作 （f）については、ゲーム復旧後も反映されます。
+ゲームに戻る前にmake.ksを通過します。ジャンプ先での操作に対して戻る前に設定を行いたい場合は
+make.ksで変数fに対して、[awakegame]からの復帰かどうかの判定をいれるとよいでしょう。
+
+:sample
+
+:param
+variable_over=trueかfalseを指定します。trueを指定するとsleepgame中のゲーム変数への変更を引き継ぎます。デフォルトはtrue,
+bgm_over=trueかfalseを指定します。trueを指定するとsleepgame中のBGMを再生し続けます。デフォルトはtrue。falseだとsleepgame時のBGMに切り替わります。
+
+:demo
+2,kaisetsu/09_sleepgame
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.awakegame = {
     vital: [],
@@ -1737,20 +1919,24 @@ tyrano.plugin.kag.tag.awakegame = {
 };
 
 /*
- #[breakgame]
- :group
- システム操作
- :title
- ゲームの停止データの削除
- :exp
- [gamesleep]タグで一時停止していたゲームを削除します。
- [gameawake]しない場合、このタグで削除してください。
+#[breakgame]
 
- :sample
- :param
+:group
+システム操作
 
- #[end]
- */
+:title
+ゲームの停止データの削除
+
+:exp
+[gamesleep]タグで一時停止していたゲームを削除します。
+[gameawake]しない場合、このタグで削除してください。
+
+:sample
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.breakgame = {
     vital: [],
@@ -1766,39 +1952,43 @@ tyrano.plugin.kag.tag.breakgame = {
 };
 
 /*
- #[dialog]
- :group
- システム操作
- :title
- ダイアログ表示
- :exp
- 確認用のダイアログを表示します。
- ダイアログは以下のタイプがあります。
- alert confirm input
- inputはv470以降、廃止します。使用しないでください
- :sample
- ;警告ウィンドウのメッセージ表示
- [dialog type="alert" text="メッセージ内容" ]
+#[dialog]
 
- ;確認ダイアログの表示
- [dialog type="confirm" text="メッセージ内容" storage="scene2" target="ok_label" storage_cancel="" target_cancel="" ]
+:group
+システム操作
 
- ;V470から廃止です。使用しないでください
- ;テキスト入力ダイアログの表示
- [dialog type="input" text="名前を教えて下さい" storage="scene2" target="ok_label" ]
+:title
+ダイアログ表示
 
- :param
- name=confirmを指定した時に格納する変数名を指定して下さい。,
- type=ダイアログの種類を指定します。alert confirm ,
- text=メッセージとして表示するてテキストを指定して下さい,
- storage=指定されている場合はダイアログのボタンを押した後のジャンプ先シナリオファイルを指定します。省略すると、現在 のシナリオファイル内であると見なされます。,
- target=指定されている場合はダイアログのボタンを押した後のジャンプ先ラベルを指定します。,
- storage_cancel=指定されている場合はダイアログのキャンセルボタンを押した後のジャンプ先シナリオファイルを指定します。,
- target_cancel=指定されている場合はダイアログのキャンセルボタンを押した後のジャンプ先ラベルを指定します。,
- label_ok=OKボタンの名前を好きなものに指定できます。デフォルトはOKです　,
- label_cancel=キャンセルボタンの名前を好きなものに指定できます。デフォルトはCancelです　
- #[end]
- */
+:exp
+確認用のダイアログを表示します。
+ダイアログは以下のタイプがあります。
+alert confirm input
+inputはv470以降、廃止します。使用しないでください
+
+:sample
+;警告ウィンドウのメッセージ表示
+[dialog type="alert" text="メッセージ内容" ]
+
+;確認ダイアログの表示
+[dialog type="confirm" text="メッセージ内容" storage="scene2" target="ok_label" storage_cancel="" target_cancel="" ]
+
+;V470から廃止です。使用しないでください
+;テキスト入力ダイアログの表示
+[dialog type="input" text="名前を教えて下さい" storage="scene2" target="ok_label" ]
+
+:param
+name=confirmを指定した時に格納する変数名を指定して下さい。,
+type=ダイアログの種類を指定します。alert confirm ,
+text=メッセージとして表示するてテキストを指定して下さい,
+storage=指定されている場合はダイアログのボタンを押した後のジャンプ先シナリオファイルを指定します。省略すると、現在 のシナリオファイル内であるとみなされます。,
+target=指定されている場合はダイアログのボタンを押した後のジャンプ先ラベルを指定します。,
+storage_cancel=指定されている場合はダイアログのキャンセルボタンを押した後のジャンプ先シナリオファイルを指定します。,
+target_cancel=指定されている場合はダイアログのキャンセルボタンを押した後のジャンプ先ラベルを指定します。,
+label_ok=OKボタンの名前を好きなものに指定できます。デフォルトはOKです　,
+label_cancel=キャンセルボタンの名前を好きなものに指定できます。デフォルトはCancelです　
+#[end]
+*/
 
 tyrano.plugin.kag.tag.dialog = {
     vital: [],
@@ -1880,43 +2070,46 @@ tyrano.plugin.kag.tag.dialog = {
 };
 
 /*
- #[plugin]
- :group
- システム操作
- :title
- プラグイン読み込み
- :exp
- 外部プラグインを読み込むことができます。
- プラグインはdata/others/plugin/　フォルダに配置します。
+#[plugin]
 
- また、pluginタグは引数を自由に渡すことができます。
- 例えば
- [plugin name="original1" font_color="black" myname="シケモク" ]
+:group
+システム操作
 
- のようにすると、プラグイン先のinit.ks 内で
- mp.font_color
- mp.myname
- のような形で引数を利用できます。
+:title
+プラグイン読み込み
 
- これを &mp.font_color のように使うことで、カスタマイズ可能なプラグインが作れます。
- ただ、マクロで使用可能だった%font_color のような形の使用はできませんので注意。
+:exp
+外部プラグインを読み込むことができます。
+プラグインはdata/others/plugin/　フォルダに配置します。
 
- :sample
- ;テーマ変更
- [plugin name="original1" ]
+また、pluginタグは引数を自由に渡すことができます。
+例えば
+[plugin name="original1" font_color="black" myname="シケモク" ]
 
- ;自由に引数を渡すことも可能
- [plugin name="original1" font_color="black" arg2="aaaaaa" ]
+のようにすると、プラグイン先のinit.ks 内で
+mp.font_color
+mp.myname
+のような形で引数を利用できます。
 
- :param
- name=data/othres/plugin以下の配置したフォルダ名（プラグイン名）を指定する,
- storage=最初に読み込むシナリオファイルを変更できます。デフォルトはinit.ks です。
+これを &mp.font_color のように使うことで、カスタマイズ可能なプラグインが作れます。
+ただ、マクロで使用可能だった%font_color のような形の使用はできませんので注意。
+
+:sample
+;テーマ変更
+[plugin name="original1" ]
+
+;自由に引数を渡すことも可能
+[plugin name="original1" font_color="black" arg2="aaaaaa" ]
+
+:param
+name=data/othres/plugin以下の配置したフォルダ名（プラグイン名）を指定する,
+storage=最初に読み込むシナリオファイルを変更できます。デフォルトはinit.ks です。
 
 :demo
 2,kaisetsu/06_plugin
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.plugin = {
     vital: ["name"],
@@ -1940,26 +2133,29 @@ tyrano.plugin.kag.tag.plugin = {
 };
 
 /*
- #[sysview]
- :group
- システム操作
- :title
- システム画面変更
+#[sysview]
 
- :exp
- システム系機能で使用するHTMLファイルを変更できます。
+:group
+システム操作
 
- :sample
- [sysview type="save" storage="./data/others/plugin/mytheme/html/save.html" ]
- [sysview type="load" storage="./data/others/plugin/mytheme/html/load.html" ]
- [sysview type="backlog" storage="./data/others/plugin/mytheme/html/backlog.html" ]
- [sysview type="menu" storage="./data/others/plugin/mytheme/html/menu.html]
+:title
+システム画面変更
 
- :param
- type=save load backlog menu が指定可能 ,
- storage=HTMLファイルのパスを指定します。
- #[end]
- */
+:exp
+システム系機能で使用するHTMLファイルを変更できます。
+
+:sample
+[sysview type="save" storage="./data/others/plugin/mytheme/html/save.html" ]
+[sysview type="load" storage="./data/others/plugin/mytheme/html/load.html" ]
+[sysview type="backlog" storage="./data/others/plugin/mytheme/html/backlog.html" ]
+[sysview type="menu" storage="./data/others/plugin/mytheme/html/menu.html]
+
+:param
+type=save load backlog menu が指定可能 ,
+storage=HTMLファイルのパスを指定します。
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.sysview = {
     vital: ["type", "storage"],
@@ -1986,26 +2182,29 @@ tyrano.plugin.kag.tag.sysview = {
 };
 
 /*
- #[loadcss]
- :group
- システム操作
- :title
- CSS反映
+#[loadcss]
 
- :exp
- ゲームの途中でCSSを読み込むことができます。
- :sample
- ;CSSファイルの読み込み
- [loadcss file="./data/others/css/mystyle.css" ]
+:group
+システム操作
 
- :param
- file=読み込みたいCSSファイルを指定します
+:title
+CSS反映
 
- :demo
+:exp
+ゲームの途中でCSSを読み込むことができます。
+
+:sample
+;CSSファイルの読み込み
+[loadcss file="./data/others/css/mystyle.css" ]
+
+:param
+file=読み込みたいCSSファイルを指定します
+
+:demo
 1,kaisetsu/22_font
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag.loadcss = {
     vital: ["file"],
@@ -2032,31 +2231,33 @@ tyrano.plugin.kag.tag.loadcss = {
 };
 
 /*
- #[save_img]
- :group
- システム操作
- :title
- セーブ時のキャプチャイメージ変更
+#[save_img]
 
- :exp
- セーブデータのサムネイルをキャプチャを変更することができます。
- このタグで設定したイメージがセーブ時の画像として適応されます。
- セーブ画像は「bgimage」フォルダから指定します。
- storageに「default」と指定することで、従来の画面自動キャプチャに戻せます。
+:group
+システム操作
 
- :sample
- ;サムネイル画像の変更
- [save_img storage="my_capture.png" ]
+:title
+セーブ時のキャプチャイメージ変更
 
- :param
- storage=設定したいセーブ用画像を設定します。bgimageフォルダに配置してください。「default」を指定するとオートキャプチャに戻ります。,
- folder=bgimageフォルダ以外から取得したい場合は、ここに指定します。例えば、othersやfgimage、imageなどです。
+:exp
+セーブデータのサムネイルをキャプチャを変更できます。
+このタグで設定したイメージがセーブ時の画像として適応されます。
+セーブ画像は「bgimage」フォルダから指定します。
+storageに「default」と指定することで、従来の画面自動キャプチャに戻せます。
 
- :demo
- 2,kaisetsu/10_save_img
+:sample
+;サムネイル画像の変更
+[save_img storage="my_capture.png" ]
 
- #[end]
- */
+:param
+storage=設定したいセーブ用画像を設定します。bgimageフォルダに配置してください。「default」を指定するとオートキャプチャに戻ります。,
+folder=bgimageフォルダ以外から取得したい場合は、ここに指定します。例えば、othersやfgimage、imageなどです。
+
+:demo
+2,kaisetsu/10_save_img
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.save_img = {
     vital: [],
@@ -2100,32 +2301,33 @@ tyrano.plugin.kag.tag.save_img = {
 };
 
 /*
- #[nolog]
- :group
- システム操作
- :title
- バックログ記録停止
+#[nolog]
 
- :exp
- このタグに到達すると、バックログへ一切追加されなくなります。
- [endnolog]タグに到達すると、バックログへの記録が再開されます。
+:group
+システム操作
 
- :sample
- ここはログに記録される[p]
- [nolog]
- ログに記録されない[p]
- ここもログに記録されない[p]
- [endnolog]
- ここから、ログ記録再開[p]
+:title
+バックログ記録停止
 
- :param
+:exp
+このタグに到達すると、バックログへ一切追加されなくなります。
+[endnolog]タグに到達すると、バックログへの記録が再開されます。
 
- :demo
- 2,kaisetsu/07_pushlog
+:sample
+ここはログに記録される[p]
+[nolog]
+ログに記録されない[p]
+ここもログに記録されない[p]
+[endnolog]
+ここから、ログ記録再開[p]
 
+:param
 
- #[end]
- */
+:demo
+2,kaisetsu/07_pushlog
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.nolog = {
     vital: [],
@@ -2140,32 +2342,33 @@ tyrano.plugin.kag.tag.nolog = {
 };
 
 /*
- #[endnolog]
- :group
- システム操作
- :title
- バックログ記録を再開する
+#[endnolog]
 
- :exp
- [nolog]タグでログ記録を停止している場合
- この[endnolog]タグで記録を再開する必要があります。
+:group
+システム操作
 
- :sample
- ここはログに記録される[p]
- [nolog]
- ログに記録されない[p]
- ここもログに記録されない[p]
- [endnolog]
- ここから、ログ記録再開[p]
+:title
+バックログ記録を再開する
 
- :param
+:exp
+[nolog]タグでログ記録を停止している場合
+この[endnolog]タグで記録を再開する必要があります。
 
- :demo
- 2,kaisetsu/07_pushlog
+:sample
+ここはログに記録される[p]
+[nolog]
+ログに記録されない[p]
+ここもログに記録されない[p]
+[endnolog]
+ここから、ログ記録再開[p]
 
+:param
 
- #[end]
- */
+:demo
+2,kaisetsu/07_pushlog
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.endnolog = {
     vital: [],
@@ -2180,30 +2383,32 @@ tyrano.plugin.kag.tag.endnolog = {
 };
 
 /*
- #[pushlog]
- :group
- システム操作
- :title
- バックログに文字列記録
+#[pushlog]
 
- :exp
- バックログに任意の文字列を追加できます。
- 例えば [mtext]などは通常バックログに記録されませんが
- このタグを内包したマクロなどにしておくと、バックログに追加した
- 演出テキストなどが可能です。
+:group
+システム操作
 
- :sample
- [pushlog text="ここに好きなログ文字列を記述できます"]
+:title
+バックログに文字列記録
 
- :param
- text=バックログに追加する文字列を追加できます,
- join=バックログを前の文字列に連結するか否かを指定できます。trueを指定すると前の文字列につなげます。デフォルトはfalse
+:exp
+バックログに任意の文字列を追加できます。
+例えば [mtext]などは通常バックログに記録されませんが
+このタグを内包したマクロなどにしておくと、バックログに追加した
+演出テキストなどが可能です。
 
- :demo
- 2,kaisetsu/07_pushlog
+:sample
+[pushlog text="ここに好きなログ文字列を記述できます"]
 
- #[end]
- */
+:param
+text=バックログに追加する文字列を追加できます,
+join=バックログを前の文字列に連結するか否かを指定できます。trueを指定すると前の文字列につなげます。デフォルトはfalse
+
+:demo
+2,kaisetsu/07_pushlog
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.pushlog = {
     vital: ["text"],
@@ -2225,22 +2430,24 @@ tyrano.plugin.kag.tag.pushlog = {
 };
 
 /*
- #[start_keyconfig]
- :group
- システム操作
- :title
- キーコンフィグ操作の有効化
+#[start_keyconfig]
 
- :exp
- キーコンフィグが無効の場合、再開することができます。
+:group
+システム操作
 
- :sample
- [start_keyconfig]
+:title
+キーコンフィグ操作の有効化
 
- :param
+:exp
+キーコンフィグが無効の場合、再開できます。
 
- #[end]
- */
+:sample
+[start_keyconfig]
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.start_keyconfig = {
     pm: {},
@@ -2252,32 +2459,34 @@ tyrano.plugin.kag.tag.start_keyconfig = {
 };
 
 /*
- #[stop_keyconfig]
- :group
- システム操作
- :title
- キーコンフィグ操作の無効化
+#[stop_keyconfig]
 
- :exp
- キーコンフィグを一時的に無効にすることができます。
- 再開させる場合は[start_keyconfig]タグを使用してください。
+:group
+システム操作
 
- 無効になるのは
- ・マウス操作
- ・キーボード操作
- ・マウスのスワイプ操作
+:title
+キーコンフィグ操作の無効化
 
- :sample
- [stop_keyconfig]
- ここは無効。
- ここも無効。
- [start_keyconfig]
- ここから、キーコンフィグ設定が有効。
+:exp
+キーコンフィグを一時的に無効にできます。
+再開させる場合は[start_keyconfig]タグを使用してください。
 
- :param
+無効になるのは
+・マウス操作
+・キーボード操作
+・マウスのスワイプ操作
 
- #[end]
- */
+:sample
+[stop_keyconfig]
+ここは無効。
+ここも無効。
+[start_keyconfig]
+ここから、キーコンフィグ設定が有効。
+
+:param
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.stop_keyconfig = {
     pm: {},
@@ -2289,30 +2498,31 @@ tyrano.plugin.kag.tag.stop_keyconfig = {
 };
 
 /*
- #[apply_local_patch]
- :group
- システム操作
- :title
- パッチファイルを手動で反映します
+#[apply_local_patch]
 
- :exp
- V470以降で使用可
- パッケージングして配布している場合のみ有効。
- このタグに到達した時点で、パッチファイルをゲームに反映することが可能。
- dataフォルダ以外、tyrano本体をアップデートするときは
- このタグではなく、起動時のアップデートで対応してください。
- パッチファイルの容量が大きい場合は一時的にゲームが停止します。ロード中といった表記を表示すると親切です。
+:group
+システム操作
 
- :sample
- [apply_local_patch file="test.tpatch" ]
+:title
+パッチファイルを手動で反映します
 
- :param
- file=パッチファイルのパスを指定してください。exeファイルの階層を起点として指定します,
- reload=true or false を指定。trueを指定すると反映後にゲームが再読込されます。デフォルトはfalse
+:exp
+V470以降で使用可
+パッケージングして配布している場合のみ有効。
+このタグに到達した時点で、パッチファイルをゲームに反映することが可能。
+dataフォルダ以外、tyrano本体をアップデートするときは
+このタグではなく、起動時のアップデートで対応してください。
+パッチファイルの容量が大きい場合は一時的にゲームが停止します。ロード中といった表記を表示すると親切です。
 
+:sample
+[apply_local_patch file="test.tpatch" ]
 
- #[end]
- */
+:param
+file=パッチファイルのパスを指定します。exeファイルの階層を起点として指定します,
+reload=true or false を指定。trueを指定すると反映後にゲームが再読込されます。デフォルトはfalse
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.apply_local_patch = {
     vital: ["file"],
@@ -2339,27 +2549,29 @@ tyrano.plugin.kag.tag.apply_local_patch = {
 };
 
 /*
- #[check_web_patch]
- :group
- システム操作
- :title
- サーバーからアップデートをチェックして反映させることができます。
+#[check_web_patch]
 
- :exp
- V470以降で使用可
- サーバーにアップデートパッチを配置して更新がある場合
- 自動的にメッセージを表示して、パッチの適応を促すことができます。
- サーバーをレンタルして json ファイルと tpatch ファイルを配置します。
- また、反映するためには、一度ゲームを再起動する必要があります。
+:group
+システム操作
 
- :sample
- [check_web_patch url="http://tyrano.jp/patch/mygame.json" ]
+:title
+サーバーからアップデートをチェックして反映させることができます。
 
- :param
- url=サーバのjsonファイルのURLをhttp:// から指定してください
+:exp
+V470以降で使用可
+サーバーにアップデートパッチを配置して更新がある場合
+自動的にメッセージを表示して、パッチの適応を促すことができます。
+サーバーをレンタルして json ファイルと tpatch ファイルを配置します。
+また、反映するためには、一度ゲームを再起動する必要があります。
 
- #[end]
- */
+:sample
+[check_web_patch url="http://tyrano.jp/patch/mygame.json" ]
+
+:param
+url=サーバのjsonファイルのURLをhttp:// から指定します
+
+#[end]
+*/
 
 tyrano.plugin.kag.tag.check_web_patch = {
     vital: ["url"],
@@ -2482,10 +2694,13 @@ tyrano.plugin.kag.tag.check_web_patch = {
 
 /*
 #[set_resizecall]
+
 :group
 システム操作
+
 :title
 レスポンシブデザイン対応
+
 :exp
 プレイ端末の画面比率が入れ替わったタイミングでシナリオを呼び出すことができます。
 例えば、縦持ち→横持ちになったタイミングで、横持ち用の座標へ変更するスクリプトを実行。
@@ -2507,7 +2722,8 @@ tyrano.plugin.kag.tag.check_web_patch = {
 [set_resizecall storage="resize.ks" ]
 
 :param
-storage=呼び出すシナリオファイル名を指定します。省略された場合は現在のシナリオファイルと見なされます
+storage=呼び出すシナリオファイル名を指定します。省略された場合は現在のシナリオファイルとみなされます
+
 :demo
 
 #[end]

--- a/tyrano/plugins/kag/kag.tag_system.js
+++ b/tyrano/plugins/kag/kag.tag_system.js
@@ -27,23 +27,20 @@ exp=評価するTJS式を指定します。
 
 //スクリプトの評価
 tyrano.plugin.kag.tag.eval = {
-
     vital: ["exp"],
 
     pm: {
         exp: "",
-        next: "true"
+        next: "true",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.evalScript(pm.exp);
 
         if (pm.next == "true") {
             this.kag.ftag.nextOrder();
         }
-
-    }
+    },
 };
 
 /*
@@ -63,13 +60,12 @@ exp=変数名を指定できます。変数名を指定した場合はその変�
 
 //すべての編集を初期化
 tyrano.plugin.kag.tag.clearvar = {
-
     //すべての変数を削除
     pm: {
         exp: "",
     },
 
-    start: function(pm) {
+    start: function (pm) {
         if (pm.exp == "") {
             this.kag.clearVariable();
         } else {
@@ -77,8 +73,7 @@ tyrano.plugin.kag.tag.clearvar = {
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -96,12 +91,11 @@ tyrano.plugin.kag.tag.clearvar = {
 
 //システム変数の初期化
 tyrano.plugin.kag.tag.clearsysvar = {
-
-    start: function() {
+    start: function () {
         this.kag.variable.sf = {};
         //システム変数
         this.kag.ftag.nextOrder();
-    }
+    },
 };
 
 /*
@@ -129,20 +123,20 @@ stack=call if macro のいづれかを指定できます。特定のスタック
 //システム変数の初期化
 tyrano.plugin.kag.tag.clearstack = {
     pm: {
-        stack: ""
+        stack: "",
     },
-    start: function(pm) {
+    start: function (pm) {
         if (pm.stack == "") {
             this.kag.stat.stack = {
-                "if": [],
-                "call": [],
-                "macro": []
+                if: [],
+                call: [],
+                macro: [],
             };
         } else {
             this.kag.stat.stack[pm.stack] = [];
         }
         this.kag.ftag.nextOrder();
-    }
+    },
 };
 
 /*
@@ -162,40 +156,44 @@ ask=true を指定すると、終了するかどうかの確認をします。fa
 
 //ウィンドウを閉じる命令
 tyrano.plugin.kag.tag["close"] = {
-
     pm: {
-        ask: "true"
+        ask: "true",
     },
 
-    start: function(pm) {
+    start: function (pm) {
         var that = this;
         if (pm.ask == "true") {
-
-            $.confirm($.lang("exit_game"), function() {
-                that.close();
-            }, function() {
-                that.kag.ftag.nextOrder();
-            });
-
+            $.confirm(
+                $.lang("exit_game"),
+                function () {
+                    that.close();
+                },
+                function () {
+                    that.kag.ftag.nextOrder();
+                },
+            );
         } else {
             this.close();
         }
     },
 
-    close: function() {
+    close: function () {
         window.close();
-        if (typeof navigator.app != 'undefined') {
+        if (typeof navigator.app != "undefined") {
             navigator.app.exitApp();
         }
-        if (typeof require != 'undefined' && typeof require('nw.gui') != 'undefined') {
-            require('nw.gui').Window.get().close();
+        if (
+            typeof require != "undefined" &&
+            typeof require("nw.gui") != "undefined"
+        ) {
+            require("nw.gui").Window.get().close();
         }
 
         //最新のブラウザは、window.closeで閉じないので以下を実行。
         //※ただし、Firefoxや最新のChromeは、blankページが残る。
         //（新規で開いたページでないと、セキュリティポリシーで閉じれない）
         //window.open('about:blank','_self').close();
-    }
+    },
 };
 
 /*
@@ -220,21 +218,18 @@ exp=評価するTJS（JS）式を指定します
 
 //変数をコンソールに出力
 tyrano.plugin.kag.tag["trace"] = {
-
     pm: {
-        exp: ""
+        exp: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var val = this.kag.embScript(pm.exp);
         //評価された値を代入
         //this.kag.ftag.startTag("text",{"val":val});
 
         this.kag.log("trace出力：" + val);
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -262,38 +257,29 @@ tyrano.plugin.kag.tag["trace"] = {
  */
 
 tyrano.plugin.kag.tag["body"] = {
-
     vital: [],
 
     pm: {
-
         bgimage: "",
         bgrepeat: "",
         bgcolor: "",
         bgcover: "false",
         scWidth: "",
         scHeight: "",
-
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         if (pm.bgcolor != "") {
             $("body").css("background-color", $.convertColor(pm.bgcolor));
         }
 
         if (pm.bgimage != "") {
-
             if (pm.bgimage == "transparent") {
-
                 //背景透過設定
                 this.kag.layer.getLayer("base", "fore").hide();
                 $("body").css("background-color", "transparent");
                 $(".tyrano_base").css("background-color", "transparent");
-
             } else {
-
                 var img_url = "";
                 //画像指定
                 if ($.isHTTP(pm.bgimage)) {
@@ -303,9 +289,7 @@ tyrano.plugin.kag.tag["body"] = {
                 }
 
                 $("body").css("background-image", 'url("' + img_url + '")');
-
             }
-
         }
 
         if (pm.bgrepeat != "") {
@@ -318,14 +302,20 @@ tyrano.plugin.kag.tag["body"] = {
 
         let flag_resize = false;
 
-        if (pm.scWidth != "" && parseInt(pm.scWidth) != parseInt(this.kag.config.scWidth)) {
+        if (
+            pm.scWidth != "" &&
+            parseInt(pm.scWidth) != parseInt(this.kag.config.scWidth)
+        ) {
             flag_resize = true;
             this.kag.config.scWidth = parseInt(pm.scWidth);
             $(".tyrano_base").css("width", parseInt(pm.scWidth));
             $(".layer").css("width", parseInt(pm.scWidth));
         }
 
-        if (pm.scHeight != "" && parseInt(pm.scHeight) != parseInt(this.kag.config.scHeight)) {
+        if (
+            pm.scHeight != "" &&
+            parseInt(pm.scHeight) != parseInt(this.kag.config.scHeight)
+        ) {
             flag_resize = true;
             this.kag.config.scHeight = parseInt(pm.scHeight);
             $(".tyrano_base").css("height", parseInt(pm.scHeight));
@@ -333,14 +323,11 @@ tyrano.plugin.kag.tag["body"] = {
         }
 
         if (flag_resize) {
-
             $(window).trigger("resize");
-
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -362,21 +349,20 @@ tyrano.plugin.kag.tag["body"] = {
  */
 
 tyrano.plugin.kag.tag["title"] = {
-
     vital: ["name"],
 
     pm: {
-        name: ""
+        name: "",
     },
 
     //タイトルの設定
-    start: function(pm) {
+    start: function (pm) {
         if (pm.name != "") {
             //タイトルの設定
             this.kag.setTitle(pm.name);
             this.kag.ftag.nextOrder();
         }
-    }
+    },
 };
 
 /*
@@ -408,13 +394,11 @@ $("body").html();
 
 //スクリプト開始
 tyrano.plugin.kag.tag.iscript = {
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.is_script = true;
         this.kag.stat.buff_script = "";
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -433,13 +417,11 @@ stop=endscriptに到達した時、ここにtrueを指定すると次のタグ�
 
 //スクリプト終了
 tyrano.plugin.kag.tag.endscript = {
-
     pm: {
-        stop: "false"
+        stop: "false",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.is_script = false;
         //スクリプトを実行する
         this.kag.evalScript(this.kag.stat.buff_script);
@@ -448,7 +430,7 @@ tyrano.plugin.kag.tag.endscript = {
         if (pm.stop == "false") {
             this.kag.ftag.nextOrder();
         }
-    }
+    },
 };
 
 /*
@@ -493,23 +475,20 @@ name=HTML領域に名前を指定することができます。この名前を�
 */
 //htmlの表示、そして、格納だわな。
 tyrano.plugin.kag.tag.html = {
-
     pm: {
         layer: "",
         top: 0,
-        left: 0
+        left: 0,
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.is_html = true;
         this.kag.stat.map_html = {};
         this.kag.stat.map_html.buff_html = "";
         this.kag.stat.map_html.buff_pm = pm;
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -526,9 +505,7 @@ HTMLの記述を終了します
 */
 //htmlの終了
 tyrano.plugin.kag.tag.endhtml = {
-
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         var tpm = this.kag.stat.map_html.buff_pm;
@@ -563,8 +540,7 @@ tyrano.plugin.kag.tag.endhtml = {
         this.kag.stat.is_html = false;
         this.kag.stat.map_html = {};
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -588,25 +564,22 @@ tyrano.plugin.kag.tag.endhtml = {
  */
 
 tyrano.plugin.kag.tag.emb = {
-
     vital: ["exp"],
 
     pm: {
-        exp: ""
+        exp: "",
     },
 
     log_join: "true",
 
-    start: function(pm) {
-
+    start: function (pm) {
         var val = "" + this.kag.embScript(pm.exp);
         //評価された値を代入
         this.kag.ftag.startTag("text", {
-            "val": val,
-            "backlog": "join"
+            val: val,
+            backlog: "join",
         });
-
-    }
+    },
 };
 
 /*
@@ -663,21 +636,17 @@ exp=評価する TJS 式を指定します。この式の結果が false ( ま�
 
 //条件分岐
 tyrano.plugin.kag.tag["if"] = {
-
     vital: ["exp"],
 
     pm: {
-        "exp": ""
+        exp: "",
     },
 
     log_join: "true",
 
-
-    start: function(pm) {
-
+    start: function (pm) {
         //条件合格
         if (this.kag.embScript(pm.exp)) {
-
             //実行済み、次にels elsif が出てきても、無視する
             //this.kag.pushStack("if", true);
             this.kag.pushStack("if", { bool: true, deep: pm.deep_if });
@@ -692,11 +661,10 @@ tyrano.plugin.kag.tag["if"] = {
             this.kag.pushStack("if", { bool: false, deep: pm.deep_if });
 
             for (var i = 0; i < 2000; i++) {
-
                 var r = this.kag.ftag.nextOrderWithTag({
-                    "else": "",
-                    "elsif": "",
-                    "endif": ""
+                    else: "",
+                    elsif: "",
+                    endif: "",
                 });
 
                 if (r == true) {
@@ -704,15 +672,13 @@ tyrano.plugin.kag.tag["if"] = {
                     break;
                     //指定の命令へ処理が写っていることでしょう
                 }
-
             }
 
             if (i > 1900) {
                 this.kag.error("If文に誤りがあります");
             }
-
         }
-    }
+    },
 };
 
 /*
@@ -735,48 +701,44 @@ tyrano.plugin.kag.tag["if"] = {
  */
 
 tyrano.plugin.kag.tag["elsif"] = {
-
     vital: ["exp"],
 
     pm: {
-        "exp": ""
+        exp: "",
     },
 
     log_join: "true",
 
-    start: function(pm) {
-
+    start: function (pm) {
         //条件合格
-        if (this.kag.getStack("if").bool == false && this.kag.embScript(pm.exp)) {
+        if (
+            this.kag.getStack("if").bool == false &&
+            this.kag.embScript(pm.exp)
+        ) {
             this.kag.setStack("if", { bool: true, deep: pm.deep_if });
 
             this.kag.ftag.nextOrder();
 
             //条件ミス
         } else {
-
             for (var i = 0; i < 2000; i++) {
-
                 var r = this.kag.ftag.nextOrderWithTag({
-                    "else": "",
-                    "elsif": "",
-                    "endif": ""
+                    else: "",
+                    elsif: "",
+                    endif: "",
                 });
 
                 if (r == true) {
                     //alert("処理が見つかった!")
                     break;
-
                 }
-
             }
 
             if (i > 1900) {
                 this.kag.error("If文に誤りがあります");
             }
-
         }
-    }
+    },
 };
 
 /*
@@ -799,15 +761,13 @@ tyrano.plugin.kag.tag["elsif"] = {
  */
 
 tyrano.plugin.kag.tag["else"] = {
-
     pm: {
-        "exp": ""
+        exp: "",
     },
 
     log_join: "true",
 
-    start: function(pm) {
-
+    start: function (pm) {
         //条件合格
         if (this.kag.getStack("if").bool == false) {
             this.kag.setStack("if", { bool: true, deep: pm.deep_if });
@@ -816,11 +776,9 @@ tyrano.plugin.kag.tag["else"] = {
 
             //条件ミス
         } else {
-
             for (var i = 0; i < 2000; i++) {
-
                 var r = this.kag.ftag.nextOrderWithTag({
-                    "endif": ""
+                    endif: "",
                 });
 
                 if (r == true) {
@@ -828,15 +786,13 @@ tyrano.plugin.kag.tag["else"] = {
                     break;
                     //指定の命令へ処理が写っていることでしょう
                 }
-
             }
 
             if (i > 1900) {
                 this.kag.error("If文に誤りがあります");
             }
-
         }
-    }
+    },
 };
 
 /*
@@ -854,17 +810,14 @@ tyrano.plugin.kag.tag["else"] = {
  */
 
 tyrano.plugin.kag.tag["endif"] = {
-
     log_join: "true",
 
-    start: function() {
-
+    start: function () {
         //普通に次の処理を実行すればいいんじゃないか
         this.kag.popStack("if");
         //スタック取り出し
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -888,23 +841,20 @@ tyrano.plugin.kag.tag["endif"] = {
  */
 
 tyrano.plugin.kag.tag["call"] = {
-
     pm: {
         storage: null,
         target: null, //ラベル名
         countpage: true,
-        auto_next: "yes"
+        auto_next: "yes",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var back_pm = {};
         back_pm.index = this.kag.ftag.current_order_index;
         back_pm.storage = this.kag.stat.current_scenario;
         back_pm.auto_next = pm.auto_next;
 
         back_pm.caller = pm;
-
 
         //コールはラベルに対して行われる
         this.kag.pushStack("call", back_pm);
@@ -914,9 +864,7 @@ tyrano.plugin.kag.tag["call"] = {
         } else {
             this.kag.ftag.nextOrderWithLabel(pm.target, pm.storage);
         }
-
-
-    }
+    },
 };
 
 /*
@@ -940,9 +888,7 @@ KAG３の任意の場所へのリターンは廃止しました。
 
 //呼び出し元に戻る
 tyrano.plugin.kag.tag["return"] = {
-
-    start: function() {
-
+    start: function () {
         //マクロからの場合、ここから、呼び出さないとだめ。だからmacro で return は使えない
         var pm = this.kag.getStack("call");
         //最新のコールスタックを取得
@@ -950,7 +896,10 @@ tyrano.plugin.kag.tag["return"] = {
 
         //make.ksが終わるときの判定用
         if (pm.caller && pm.caller.storage) {
-            if (pm.caller.storage == "make.ks" || pm.caller.storage == this.kag.stat.resizecall["storage"]) {
+            if (
+                pm.caller.storage == "make.ks" ||
+                pm.caller.storage == this.kag.stat.resizecall["storage"]
+            ) {
                 if (this.kag.tmp.loading_make_ref == true) {
                     this.kag.stat.flag_ref_page = true;
                     this.kag.tmp.loading_make_ref = false;
@@ -961,10 +910,15 @@ tyrano.plugin.kag.tag["return"] = {
         var auto_next = pm.auto_next;
         this.kag.popStack("call");
 
-        this.kag.ftag.nextOrderWithIndex(pm.index, pm.storage, undefined, undefined, auto_next);
+        this.kag.ftag.nextOrderWithIndex(
+            pm.index,
+            pm.storage,
+            undefined,
+            undefined,
+            auto_next,
+        );
         //スタックを奪い取る
-
-    }
+    },
 };
 
 /*
@@ -1000,41 +954,35 @@ name=マクロの名前を指定してください。以後この名前で新し
 
 //マクロの定義
 tyrano.plugin.kag.tag.macro = {
-
     vital: ["name"],
 
     pm: {
-        name: ""
+        name: "",
     },
 
     log_join: "true",
 
-
-    start: function(pm) {
-
+    start: function (pm) {
         var index = this.kag.ftag.current_order_index;
         var storage = this.kag.stat.current_scenario;
         this.kag.stat.map_macro[pm.name] = {
-            "storage": storage,
-            "index": index
+            storage: storage,
+            index: index,
         };
 
         this.kag.tmp.checking_macro = true;
 
         //endmacroが出るまで、無視される
         for (var i = 0; i < 2000; i++) {
-
             var r = this.kag.ftag.nextOrderWithTag({
-                "endmacro": ""
+                endmacro: "",
             });
 
             if (r == true) {
                 //alert("endacroが見つかった");
                 break;
                 //指定の命令へ処理が写っていることでしょう
-
             }
-
         }
 
         if (i > 1900) {
@@ -1042,8 +990,7 @@ tyrano.plugin.kag.tag.macro = {
         }
 
         //this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -1061,11 +1008,9 @@ tyrano.plugin.kag.tag.macro = {
 
 //マクロ終了
 tyrano.plugin.kag.tag.endmacro = {
-
     log_join: "true",
 
-    start: function(pm) {
-
+    start: function (pm) {
         //解析チェック中にここに来た場合は、なにもしない
         if (this.kag.tmp.checking_macro == true) {
             this.kag.tmp.checking_macro = false;
@@ -1078,25 +1023,23 @@ tyrano.plugin.kag.tag.endmacro = {
 
         //もし、スタックが溜まっている状態なら、
         if (map_obj) {
-
             //呼び出し元に戻る
             this.kag.popStack("macro");
             this.kag.stat.mp = this.kag.getStack("macro");
             //参照用パラメータを設定
 
-            this.kag.ftag.nextOrderWithIndex(map_obj.index, map_obj.storage, true);
+            this.kag.ftag.nextOrderWithIndex(
+                map_obj.index,
+                map_obj.storage,
+                true,
+            );
             //スタックを奪い取る
-
-
         } else {
-
             //呼び出し元がない場合、普通に次の処理を行えば良い
             //endmacroの場合はだめじゃないでしょうか。。。
             //this.kag.ftag.nextOrder();
-
         }
-
-    }
+    },
 };
 
 /*
@@ -1115,17 +1058,16 @@ name=削除するマクロ名を記述してください
 
 //マクロの削除
 tyrano.plugin.kag.tag.erasemacro = {
-
     vital: ["name"],
 
     pm: {
-        name: ""
+        name: "",
     },
 
-    start: function(pm) {
+    start: function (pm) {
         delete this.kag.stat.map_macro[pm.name];
         this.kag.ftag.nextOrder();
-    }
+    },
 };
 
 /*
@@ -1144,21 +1086,18 @@ title=セーブデータのタイトルを指定します。
 
 //セーブスナップの保存
 tyrano.plugin.kag.tag.savesnap = {
-
     vital: ["title"],
 
     pm: {
-        title: ""
+        title: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
-        this.kag.menu.snapSave(pm.title, function() {
+        this.kag.menu.snapSave(pm.title, function () {
             that.kag.ftag.nextOrder();
         });
-
-    }
+    },
 };
 
 /*
@@ -1203,15 +1142,13 @@ tyrano.plugin.kag.tag.savesnap = {
  */
 
 tyrano.plugin.kag.tag.autosave = {
-
     vital: [],
 
     pm: {
-        title: ""
+        title: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         //タイトルが設定されいない場合は現在のテキストを設定
@@ -1219,12 +1156,11 @@ tyrano.plugin.kag.tag.autosave = {
             pm.title = this.kag.stat.current_save_str;
         }
 
-        this.kag.menu.snapSave(pm.title, function() {
+        this.kag.menu.snapSave(pm.title, function () {
             that.kag.menu.doSetAutoSave();
             that.kag.ftag.nextOrder();
         });
-
-    }
+    },
 };
 
 /*
@@ -1241,19 +1177,19 @@ tyrano.plugin.kag.tag.autosave = {
  */
 
 tyrano.plugin.kag.tag.autoload = {
-
     vital: [],
 
     pm: {
-        title: ""
+        title: "",
     },
 
-    start: function(pm) {
-
-        var game_data = $.getStorage(this.kag.config.projectID + "_tyrano_auto_save", this.kag.config.configSave);
+    start: function (pm) {
+        var game_data = $.getStorage(
+            this.kag.config.projectID + "_tyrano_auto_save",
+            this.kag.config.configSave,
+        );
         this.kag.menu.loadAutoSave();
-
-    }
+    },
 };
 
 /*
@@ -1271,21 +1207,17 @@ tyrano.plugin.kag.tag.autoload = {
  */
 
 tyrano.plugin.kag.tag.ignore = {
-
     vital: ["exp"],
 
     pm: {
-        exp: ""
+        exp: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         if (this.kag.embScript(pm.exp)) {
-
             for (var i = 0; i < 2000; i++) {
-
                 var r = this.kag.ftag.nextOrderWithTag({
-                    "endignore": ""
+                    endignore: "",
                 });
 
                 if (r == true) {
@@ -1297,11 +1229,9 @@ tyrano.plugin.kag.tag.ignore = {
                 this.kag.error("ignoreが閉じていません");
             }
         } else {
-
             this.kag.ftag.nextOrder();
-
         }
-    }
+    },
 };
 
 /*
@@ -1318,10 +1248,9 @@ tyrano.plugin.kag.tag.ignore = {
  */
 
 tyrano.plugin.kag.tag.endignore = {
-
-    start: function() {
+    start: function () {
         this.kag.ftag.nextOrder();
-    }
+    },
 };
 
 /*
@@ -1373,7 +1302,6 @@ maxchars=最大入力文字数
 
 //テキストボックス、ティラノスクリプト
 tyrano.plugin.kag.tag.edit = {
-
     vital: ["name"],
 
     pm: {
@@ -1389,12 +1317,15 @@ tyrano.plugin.kag.tag.edit = {
         width: "200",
         autocomplete: "false",
         height: "40",
-        maxchars: "1000"
+        maxchars: "1000",
     },
 
-    start: function(pm) {
-
-        var j_text = $("<input class='text_box form' name='" + pm.name + "' type='text' value='' />");
+    start: function (pm) {
+        var j_text = $(
+            "<input class='text_box form' name='" +
+                pm.name +
+                "' type='text' value='' />",
+        );
 
         //指定がない場合はデフォルトフォントを適応する
         if (pm.face == "") {
@@ -1404,21 +1335,21 @@ tyrano.plugin.kag.tag.edit = {
         pm = $.minifyObject(pm);
 
         var new_style = {
-            color: $.convertColor(pm.color),
-            left: parseInt(pm.left),
-            top: parseInt(pm.top),
-            placeholder: pm.placeholder,
-            width: pm.width,
-            height: pm.height,
+            "color": $.convertColor(pm.color),
+            "left": parseInt(pm.left),
+            "top": parseInt(pm.top),
+            "placeholder": pm.placeholder,
+            "width": pm.width,
+            "height": pm.height,
             "font-size": parseInt(pm.size),
-            "font-family": pm.face
+            "font-family": pm.face,
         };
 
         //クラスとイベントを登録する
         this.kag.event.addEventElement({
-            "tag": "edit",
-            "j_target": j_text,
-            "pm": pm
+            tag: "edit",
+            j_target: j_text,
+            pm: pm,
         });
         this.setEvent(j_text, pm);
 
@@ -1428,40 +1359,35 @@ tyrano.plugin.kag.tag.edit = {
         j_text.attr("maxlength", pm.maxchars);
 
         if (pm.autocomplete == "true") {
-            j_text.attr('autocomplete', 'on');
+            j_text.attr("autocomplete", "on");
         } else {
-            j_text.attr('autocomplete', 'off');
+            j_text.attr("autocomplete", "off");
         }
 
         this.kag.layer.getFreeLayer().append(j_text);
         this.kag.layer.getFreeLayer().show();
 
         this.kag.ftag.nextOrder();
-
     },
 
-    setEvent: function(j_text, pm) {
-
+    setEvent: function (j_text, pm) {
         var that = TYRANO;
         var _pm = pm;
 
-        (function() {
-
+        (function () {
             //初期値の設定
             j_text.val(_pm.initial);
 
-            j_text.click(function() {
+            j_text.click(function () {
                 j_text.focus();
             });
 
-            j_text.on("keydown", function(e) {
+            j_text.on("keydown", function (e) {
                 //バブリング停止
                 e.stopPropagation();
             });
-
         })();
-
-    }
+    },
 };
 
 /*
@@ -1494,16 +1420,14 @@ wait=trueを指定すると、全ての読み込みが完了するまでゲー�
 
 //画像ファイルの事前読み込み
 tyrano.plugin.kag.tag.preload = {
-
     vital: ["storage"],
 
     pm: {
         storage: "",
-        wait: "false"
+        wait: "false",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         if (pm.wait == "true") {
@@ -1514,12 +1438,10 @@ tyrano.plugin.kag.tag.preload = {
 
         //配列で指定された場合
         if (typeof storage == "object" && storage.length > 0) {
-
             var sum = 0;
 
             for (var i = 0; i < storage.length; i++) {
-
-                that.kag.preload(storage[i], function() {
+                that.kag.preload(storage[i], function () {
                     sum++;
                     if (storage.length == sum) {
                         //すべてのプリロードが完了
@@ -1527,40 +1449,29 @@ tyrano.plugin.kag.tag.preload = {
                             that.kag.layer.showEventLayer();
                             that.kag.ftag.nextOrder();
                         }
-
                     }
                 });
-
             }
 
             if (pm.wait == "false") {
                 that.kag.layer.showEventLayer();
                 that.kag.ftag.nextOrder();
             }
-
-
         } else {
-
-            this.kag.preload(pm.storage, function() {
-
+            this.kag.preload(pm.storage, function () {
                 if (pm.wait == "true") {
                     that.kag.layer.showEventLayer();
                     that.kag.ftag.nextOrder();
                 }
-
             });
 
             if (pm.wait == "false") {
                 that.kag.layer.showEventLayer();
                 that.kag.ftag.nextOrder();
             }
-
         }
-
-    }
+    },
 };
-
-
 
 /*
  #[clearfix]
@@ -1585,13 +1496,11 @@ tyrano.plugin.kag.tag.preload = {
  */
 
 tyrano.plugin.kag.tag.clearfix = {
-
     pm: {
-        name: ""
+        name: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         if (pm.name != "") {
             $(".fixlayer." + pm.name).remove();
         } else {
@@ -1599,8 +1508,7 @@ tyrano.plugin.kag.tag.clearfix = {
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -1623,27 +1531,25 @@ tyrano.plugin.kag.tag.clearfix = {
  */
 
 tyrano.plugin.kag.tag.commit = {
-
-    start: function() {
-
+    start: function () {
         var that = this;
 
-        this.kag.layer.getFreeLayer().find(".form").each(function() {
+        this.kag.layer
+            .getFreeLayer()
+            .find(".form")
+            .each(function () {
+                var name = $(this).attr("name");
+                var val = $(this).val();
 
-            var name = $(this).attr("name");
-            var val = $(this).val();
+                var str = name + " = '" + val + "'";
 
-            var str = name + " = '" + val + "'";
+                that.kag.evalScript(str);
 
-            that.kag.evalScript(str);
-
-            //console.log($(this));
-
-        });
+                //console.log($(this));
+            });
 
         that.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -1664,20 +1570,17 @@ tyrano.plugin.kag.tag.commit = {
  */
 
 tyrano.plugin.kag.tag.cursor = {
-
     vital: ["storage"],
 
     pm: {
-        storage: "default"
+        storage: "default",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         //評価された値を代入
         this.kag.setCursor(pm.storage);
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -1696,19 +1599,15 @@ tyrano.plugin.kag.tag.cursor = {
  */
 
 tyrano.plugin.kag.tag.screen_full = {
-
     vital: [],
 
-    pm: {
-    },
+    pm: {},
 
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.menu.screenFull();
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -1752,31 +1651,31 @@ tyrano.plugin.kag.tag.screen_full = {
  */
 
 tyrano.plugin.kag.tag.sleepgame = {
-
     vital: [],
 
     pm: {
         storage: "",
         target: "",
-        next: true
+        next: true,
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         //タイトルが設定されていない場合は現在のテキストを設定
         var title = this.kag.stat.current_save_str;
 
         //スナップを保存。サムネは不要
-        this.kag.menu.snapSave(title, function() {
-            //保存したスナップを、sleep領域に配置したうえで、ジャンプする
-            that.kag.menu.setGameSleep(pm.next);
-            that.kag.ftag.startTag("jump", pm);
-
-        }, "false");
-
-    }
+        this.kag.menu.snapSave(
+            title,
+            function () {
+                //保存したスナップを、sleep領域に配置したうえで、ジャンプする
+                that.kag.menu.setGameSleep(pm.next);
+                that.kag.ftag.startTag("jump", pm);
+            },
+            "false",
+        );
+    },
 };
 
 /*
@@ -1800,18 +1699,14 @@ tyrano.plugin.kag.tag.sleepgame = {
  */
 
 tyrano.plugin.kag.tag.awakegame = {
-
     vital: [],
 
     pm: {
-
         variable_over: "true",
-        bgm_over: "true"
-
+        bgm_over: "true",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         if (this.kag.tmp.sleep_game == null) {
@@ -1819,7 +1714,6 @@ tyrano.plugin.kag.tag.awakegame = {
             //データがない場合はそのまま次の命令へ
             this.kag.ftag.nextOrder();
         } else {
-
             var sleep_data = this.kag.tmp.sleep_game;
 
             //f変数を継承する
@@ -1828,7 +1722,7 @@ tyrano.plugin.kag.tag.awakegame = {
             }
 
             var options = {
-                bgm_over: pm.bgm_over
+                bgm_over: pm.bgm_over,
             };
 
             if (this.kag.tmp.sleep_game_next == true) {
@@ -1838,9 +1732,8 @@ tyrano.plugin.kag.tag.awakegame = {
             this.kag.menu.loadGameData($.extend(true, {}, sleep_data), options);
 
             this.kag.tmp.sleep_game = null;
-
         }
-    }
+    },
 };
 
 /*
@@ -1860,20 +1753,16 @@ tyrano.plugin.kag.tag.awakegame = {
  */
 
 tyrano.plugin.kag.tag.breakgame = {
-
     vital: [],
 
-    pm: {
-    },
+    pm: {},
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         this.kag.tmp.sleep_game = null;
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -1912,7 +1801,6 @@ tyrano.plugin.kag.tag.breakgame = {
  */
 
 tyrano.plugin.kag.tag.dialog = {
-
     vital: [],
 
     pm: {
@@ -1924,77 +1812,71 @@ tyrano.plugin.kag.tag.dialog = {
         storage_cancel: "",
         target_cancel: "",
         label_ok: "OK",
-        label_cancel: "Cancel"
+        label_cancel: "Cancel",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         $(".remodal").find(".remodal-confirm").html(pm.label_ok);
         $(".remodal").find(".remodal-cancel").html(pm.label_cancel);
 
         if (pm.type == "confirm") {
-            $.confirm(pm.text, function() {
-                that.finish(pm);
-            }, function() {
-                pm.storage = pm.storage_cancel;
-                pm.target = pm.target_cancel;
-                that.finish(pm);
-            });
+            $.confirm(
+                pm.text,
+                function () {
+                    that.finish(pm);
+                },
+                function () {
+                    pm.storage = pm.storage_cancel;
+                    pm.target = pm.target_cancel;
+                    that.finish(pm);
+                },
+            );
         } else if (pm.type == "input") {
-
             alertify.set({
                 buttonFocus: "none",
                 labels: {
                     ok: pm.label_ok,
-                    cancel: pm.label_cancel
-                }
+                    cancel: pm.label_cancel,
+                },
             });
-            alertify.prompt(pm.text, function(flag, text) {
+            alertify.prompt(pm.text, function (flag, text) {
                 if (flag) {
-
                     var name = pm.name;
                     var val = text;
                     var str = name + " = '" + val + "'";
 
                     that.kag.evalScript(str);
-
                 } else {
                     pm.storage = pm.storage_cancel;
                     pm.target = pm.target_cancel;
                 }
 
                 that.finish(pm);
-
             });
 
-            $(".alertify-text").on("keydown", function(e) {
+            $(".alertify-text").on("keydown", function (e) {
                 e.stopPropagation();
             });
-
         } else {
             //alert
-            $.alert(pm.text, function() {
+            $.alert(pm.text, function () {
                 that.finish(pm);
             });
-
         }
 
         //this.kag.ftag.nextOrder();
-
     },
 
     //終わった後どうするか
-    finish: function(pm) {
-
+    finish: function (pm) {
         if (pm.storage != "" || pm.target != "") {
             this.kag.ftag.startTag("jump", pm);
         } else {
             this.kag.ftag.nextOrder();
         }
-
-    }
+    },
 };
 
 /*
@@ -2037,18 +1919,14 @@ tyrano.plugin.kag.tag.dialog = {
  */
 
 tyrano.plugin.kag.tag.plugin = {
-
     vital: ["name"],
 
     pm: {
-
         name: "",
-        storage: "init.ks"
-
+        storage: "init.ks",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var storage_url = "";
         var name = pm.name;
 
@@ -2058,8 +1936,7 @@ tyrano.plugin.kag.tag.plugin = {
         this.kag.stat.mp = pm;
 
         this.kag.ftag.startTag("call", pm);
-
-    }
+    },
 };
 
 /*
@@ -2085,18 +1962,14 @@ tyrano.plugin.kag.tag.plugin = {
  */
 
 tyrano.plugin.kag.tag.sysview = {
-
     vital: ["type", "storage"],
 
     pm: {
-
         type: "",
-        storage: ""
-
+        storage: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var type = pm.type;
         var storage = pm.storage;
 
@@ -2109,8 +1982,7 @@ tyrano.plugin.kag.tag.sysview = {
         this.kag.stat.sysview[type] = storage;
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -2136,25 +2008,27 @@ tyrano.plugin.kag.tag.sysview = {
  */
 
 tyrano.plugin.kag.tag.loadcss = {
-
     vital: ["file"],
 
     pm: {
-        file: ""
+        file: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var file = pm.file;
 
         //ファイルの読み込み
-        var style = '<link class="_tyrano_cssload_tag" rel="stylesheet" href="' + file + "?" + Math.floor(Math.random() * 10000000) + '">';
-        $('head link:last').after(style);
+        var style =
+            '<link class="_tyrano_cssload_tag" rel="stylesheet" href="' +
+            file +
+            "?" +
+            Math.floor(Math.random() * 10000000) +
+            '">';
+        $("head link:last").after(style);
         this.kag.stat.cssload[file] = true;
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -2185,16 +2059,14 @@ tyrano.plugin.kag.tag.loadcss = {
  */
 
 tyrano.plugin.kag.tag.save_img = {
-
     vital: [],
 
     pm: {
         storage: "",
-        folder: ""
+        folder: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var storage = pm.storage;
         var folder = "";
         var storage_url = "";
@@ -2224,10 +2096,8 @@ tyrano.plugin.kag.tag.save_img = {
         this.kag.stat.save_img = storage_url;
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
 
 /*
  #[nolog]
@@ -2258,20 +2128,15 @@ tyrano.plugin.kag.tag.save_img = {
  */
 
 tyrano.plugin.kag.tag.nolog = {
-
     vital: [],
 
-    pm: {
+    pm: {},
 
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.log_write = false;
         //記録しないフラグ追加
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -2303,22 +2168,16 @@ tyrano.plugin.kag.tag.nolog = {
  */
 
 tyrano.plugin.kag.tag.endnolog = {
-
     vital: [],
 
-    pm: {
+    pm: {},
 
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.log_write = true;
         //記録しないフラグ追加
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
 
 /*
  #[pushlog]
@@ -2347,16 +2206,14 @@ tyrano.plugin.kag.tag.endnolog = {
  */
 
 tyrano.plugin.kag.tag.pushlog = {
-
     vital: ["text"],
 
     pm: {
-        "text": "",
-        "join": "false"
+        text: "",
+        join: "false",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         if (pm.join == "true") {
             this.kag.pushBackLog(pm.text, "join");
         } else {
@@ -2364,8 +2221,7 @@ tyrano.plugin.kag.tag.pushlog = {
         }
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
 
 /*
@@ -2387,19 +2243,13 @@ tyrano.plugin.kag.tag.pushlog = {
  */
 
 tyrano.plugin.kag.tag.start_keyconfig = {
+    pm: {},
 
-
-    pm: {
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.enable_keyconfig = true;
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
 
 /*
  #[stop_keyconfig]
@@ -2430,19 +2280,13 @@ tyrano.plugin.kag.tag.start_keyconfig = {
  */
 
 tyrano.plugin.kag.tag.stop_keyconfig = {
+    pm: {},
 
-
-    pm: {
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.stat.enable_keyconfig = false;
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };
-
 
 /*
  #[apply_local_patch]
@@ -2471,17 +2315,14 @@ tyrano.plugin.kag.tag.stop_keyconfig = {
  */
 
 tyrano.plugin.kag.tag.apply_local_patch = {
-
     vital: ["file"],
 
     pm: {
         file: "",
-        reload: "false"
-
+        reload: "false",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         if (!$.isNWJS() && !$.isElectron()) {
@@ -2491,13 +2332,10 @@ tyrano.plugin.kag.tag.apply_local_patch = {
 
         var patch_path = $.localFilePath() + "/" + pm.file;
 
-        that.kag.applyPatch(patch_path, pm.reload, function() {
-
+        that.kag.applyPatch(patch_path, pm.reload, function () {
             that.kag.ftag.nextOrder();
-
         });
-
-    }
+    },
 };
 
 /*
@@ -2523,19 +2361,15 @@ tyrano.plugin.kag.tag.apply_local_patch = {
  #[end]
  */
 
-
 tyrano.plugin.kag.tag.check_web_patch = {
-
     vital: ["url"],
 
     pm: {
         url: "",
-        reload: "false"
-
+        reload: "false",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         if (!$.isNWJS() && !$.isElectron()) {
@@ -2547,52 +2381,57 @@ tyrano.plugin.kag.tag.check_web_patch = {
             url: pm.url + "?" + Math.floor(Math.random() * 1000000),
             cache: false,
             dataType: "json",
-            success: function(json) {
-
+            success: function (json) {
                 if (typeof json != "object") {
                     json = JSON.parse(json);
                 }
 
                 that.checkPatch(json, pm);
             },
-            error: function(e) {
+            error: function (e) {
                 console.log(e);
                 alert("file not found:" + pm.url);
-            }
-
+            },
         });
-
     },
 
-    checkPatch: function(obj, pm) {
-
+    checkPatch: function (obj, pm) {
         var that = this;
 
         //バージョンの確認
         if (typeof this.kag.variable.sf._patch_version == "undefined") {
-            this.kag.evalScript("sf._patch_version=" + this.kag.config["game_version"]);
+            this.kag.evalScript(
+                "sf._patch_version=" + this.kag.config["game_version"],
+            );
         }
 
-        if (parseFloat(this.kag.variable.sf._patch_version) < parseFloat(obj.version)) {
+        if (
+            parseFloat(this.kag.variable.sf._patch_version) <
+            parseFloat(obj.version)
+        ) {
+            $.confirm(
+                "新しいアップデートが見つかりました。Ver:" +
+                    parseFloat(obj.version) +
+                    "「" +
+                    obj.message +
+                    "」<br />アップデートを行いますか？",
+                function () {
+                    alert(
+                        "アップデートを行います。完了後、自動的にゲームは終了します。",
+                    );
 
-            $.confirm("新しいアップデートが見つかりました。Ver:" + parseFloat(obj.version) + "「" + obj.message + "」<br />アップデートを行いますか？",
-                function() {
-
-                    alert("アップデートを行います。完了後、自動的にゲームは終了します。");
-
-                    var http = require('http');
-                    var fs = require('fs');
+                    var http = require("http");
+                    var fs = require("fs");
 
                     var file = obj.file;
                     // URLを指定
                     var url = $.getDirPath(pm.url) + file;
 
                     if (url.indexOf("https") != -1) {
-                        http = require('https');
+                        http = require("https");
                         //alert("エラー：SSL(https)の通信は非対応です");
                         //return;
                     }
-
 
                     // 出力ファイル名を指定
                     var patch_path = $.localFilePath();
@@ -2602,59 +2441,44 @@ tyrano.plugin.kag.tag.check_web_patch = {
 
                     var flag = false;
                     // ダウンロード開始
-                    var req = http.get(url, function(res) {
-
+                    var req = http.get(url, function (res) {
                         res.pipe(outFile);
 
-                        res.on('end', function() {
-
+                        res.on("end", function () {
                             outFile.close();
                             //アップデートを実行
-                            that.kag.evalScript("sf._patch_version=" + obj.version);
+                            that.kag.evalScript(
+                                "sf._patch_version=" + obj.version,
+                            );
 
                             window.close();
 
                             //require('nw.gui').Window.get().close();
-
                         });
-
                     });
 
                     // エラーがあれば扱う。
-                    req.on('error', function(err) {
-                        console.log('Error: ', err); return;
+                    req.on("error", function (err) {
+                        console.log("Error: ", err);
+                        return;
                     });
-
-
-
-
-                }, function() {
-
+                },
+                function () {
                     that.kag.ftag.nextOrder();
-
-                }
+                },
             );
-
         } else {
-
             that.kag.ftag.nextOrder();
-
         }
 
         console.log(obj);
-
-
 
         //ディレクトリのみ変更して差し替えて実行。
         //メッセージは表示するよ。
         //バージョンを確認。未反映ならダウンロードして配置する。
         //再起動
-
-
-    }
+    },
 };
-
-
 
 /*
 #[set_resizecall]
@@ -2691,7 +2515,6 @@ storage=呼び出すシナリオファイル名を指定します。省略され
 
 //背景変更
 tyrano.plugin.kag.tag.set_resizecall = {
-
     vital: ["storage"],
 
     pm: {
@@ -2699,8 +2522,7 @@ tyrano.plugin.kag.tag.set_resizecall = {
         target: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         //ストレージとターゲット
@@ -2712,6 +2534,5 @@ tyrano.plugin.kag.tag.set_resizecall = {
         //$(window).trigger("resize");
 
         this.kag.ftag.nextOrder();
-
-    }
+    },
 };

--- a/tyrano/plugins/kag/kag.tag_three.js
+++ b/tyrano/plugins/kag/kag.tag_three.js
@@ -76,34 +76,33 @@ $.getAngle = function(){
 */
 
 /*
- #[3d_init]
- :group
- 3D関連
+#[3d_init]
 
- :title
- 3D機能の初期化
+:group
+3D関連
 
- :exp
- 3D関連の機能を使用するために必要な宣言です。
- このタグを通過時、ゲーム内に3Dを表示するためのシーンが追加されます。
- また、タグを配置していないと3d_xxx で始まるタグを使用できません。
+:title
+3D機能の初期化
 
- 3D機能を使用する直前に宣言するようにしましょう。
- また3D機能の仕様が終わった段階で[3d_close]を行いましょう。
+:exp
+3D関連の機能を使用するために必要な宣言です。
+このタグを通過時、ゲーム内に3Dを表示するためのシーンが追加されます。
+また、タグを配置していないと3d_xxx で始まるタグを使用できません。
 
- :sample
- [3d_init layer=0 ]
+3D機能を使用する直前に宣言するようにしましょう。
+また3D機能の仕様が終わった段階で[3d_close]を行いましょう。
 
- :param
- layer=3Dモデルを配置するレイヤを指定できます。,
- camera=カメラのモードを指定できます。「Perspective」（遠近感あり）「Orthographic」（遠近感なしの平行投影）デフォルトはPerspective,
- near=カメラに近いオブジェクトをどの距離まで描画するかを設定できます。デフォルトは１,
- far=カメラから遠いオブジェクトを表示する距離を設定できます。大きすぎると不必要に遠くまで描画するため処理が重くなります。可能な限り小さい値に調整しましょう。デフォルトは5000
+:sample
+[3d_init layer=0 ]
 
+:param
+layer=3Dモデルを配置するレイヤを指定できます。,
+camera=カメラのモードを指定できます。「Perspective」（遠近感あり）「Orthographic」（遠近感なしの平行投影）デフォルトはPerspective,
+near=カメラに近いオブジェクトをどの距離まで描画するかを設定できます。デフォルトは１,
+far=カメラから遠いオブジェクトを表示する距離を設定できます。大きすぎると不必要に遠くまで描画するため処理が重くなります。可能な限り小さい値に調整しましょう。デフォルトは5000
 
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_init"] = {
     vital: [],
@@ -304,39 +303,37 @@ tyrano.plugin.kag.tag["3d_init"] = {
 };
 
 /*
- #[3d_model_new]
- :group
- 3D関連
+#[3d_model_new]
 
- :title
- 3Dモデルの作成
+:group
+3D関連
 
- :exp
- 外部ファイル形式の3Dモデルを読み込んで定義します。
- 実行時はゲーム画面には表示されません。表示するには[3d_show ]が必要です。
- 3Dモデルファイルは data/others/3d/modelフォルダに配置します。
+:title
+3Dモデルの作成
 
- :sample
- [3d_init layer=0]
+:exp
+外部ファイル形式の3Dモデルを読み込んで定義します。
+実行時はゲーム画面には表示されません。表示するには[3d_show ]が必要です。
+3Dモデルファイルは data/others/3d/modelフォルダに配置します。
 
- [3d_model_new name="mymodel" storage="mymodel/scene.gltf" ]
- [3d_show name="mymodel" pos="100,20,20" rot="1,1,1" scale=10 ]
+:sample
+[3d_init layer=0]
 
- :param
- name=3Dオブジェクトの名前です。この名前をつかって表示・非表示などの制御を行います。,
- storage=3Dファイルを指定します。gltf obj 形式に対応します。ファイルはothers/3d/modelフォルダに配置してください。,
- pos=3Dオブジェクトを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
- rot=3Dオブジェクトの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
- scale=3Dオブジェクトの拡大率を指定します。半角カンマで区切ってxyz軸の拡大率を指定します。,
- tonemap=トーンマッピングが有効な場合、このオブジェクトが影響を受けるか否かを設定できます。デフォルトはtrue。無効にする場合はfalseを指定してください。,
- motion=ファイルにモーションが存在する場合、モーション名を指定することができます。指定がない場合は１つめのモーションファイルが自動的に適応されます。,
- folder=ファイルの配置フォルダを変更できます。
+[3d_model_new name="mymodel" storage="mymodel/scene.gltf" ]
+[3d_show name="mymodel" pos="100,20,20" rot="1,1,1" scale=10 ]
 
+:param
+name=3Dオブジェクトの名前です。この名前をつかって表示・非表示などの制御を行います。,
+storage=3Dファイルを指定します。gltf obj 形式に対応します。ファイルはothers/3d/modelフォルダに配置してください。,
+pos=3Dオブジェクトを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
+rot=3Dオブジェクトの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
+scale=3Dオブジェクトの拡大率を指定します。半角カンマで区切ってxyz軸の拡大率を指定します。,
+tonemap=トーンマッピングが有効な場合、このオブジェクトが影響を受けるか否かを設定できます。デフォルトはtrue。無効にする場合はfalseを指定します。,
+motion=ファイルにモーションが存在する場合、モーション名を指定できます。指定がない場合は１つめのモーションファイルが自動的に適応されます。,
+folder=ファイルの配置フォルダを変更できます。
 
-
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_model_new"] = {
     vital: ["name", "storage"],
@@ -488,40 +485,38 @@ tyrano.plugin.kag.tag["3d_model_new"] = {
 };
 
 /*
- #[3d_sphere_new]
- :group
- 3D関連
+#[3d_sphere_new]
 
- :title
- 3Dモデル(球体)
+:group
+3D関連
 
- :exp
- 球体の3Dモデルを定義します
+:title
+3Dモデル(球体)
 
- :sample
+:exp
+球体の3Dモデルを定義します
+
+:sample
 
 [3d_sphere_new name="tama" ]
 [3d_show name=tama pos="365,145,0" rot="0.92,-4.3,0" scale="0.77,0.77,0.77" time=2000]
 
- :param
- name=3Dオブジェクトの名前です。この名前をつかって表示・非表示などの制御を行います。,
- texture=球体にテクスチャを貼ることができます。画像は「others/3d/texture」以下に配置してください。サイズは256x256 や 512x512 といったサイズを推奨します。,
- color=色を指定できます。0xRRGGBB 形式で指定します。,
- pos=3Dオブジェクトを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
- rot=3Dオブジェクトの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
- scale=3Dオブジェクトの拡大率を指定します。半角カンマで区切ってxyz軸の拡大率を指定します。,
+:param
+name=3Dオブジェクトの名前です。この名前をつかって表示・非表示などの制御を行います。,
+texture=球体にテクスチャを貼ることができます。画像は「others/3d/texture」以下に配置してください。サイズは256x256 や 512x512 といったサイズを推奨します。,
+color=色を指定できます。0xRRGGBB 形式で指定します。,
+pos=3Dオブジェクトを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
+rot=3Dオブジェクトの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
+scale=3Dオブジェクトの拡大率を指定します。半角カンマで区切ってxyz軸の拡大率を指定します。,
 
- radius=球体の半径を指定します。デフォルトは300,
- width=球体の横幅を指定します。デフォルトは30,
- height=球体の高さを指定します。デフォルトは30,
+radius=球体の半径を指定します。デフォルトは300,
+width=球体の横幅を指定します。デフォルトは30,
+height=球体の高さを指定します。デフォルトは30,
 
- tonemap=トーンマッピングが有効な場合、このオブジェクトが影響を受けるか否かを設定できます。デフォルトはtrue。無効にする場合はfalseを指定してください。
+tonemap=トーンマッピングが有効な場合、このオブジェクトが影響を受けるか否かを設定できます。デフォルトはtrue。無効にする場合はfalseを指定します。
 
-
-
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_sphere_new"] = {
     vital: ["name"],
@@ -555,35 +550,34 @@ tyrano.plugin.kag.tag["3d_sphere_new"] = {
 };
 
 /*
- #[3d_sprite_new]
- :group
- 3D関連
+#[3d_sprite_new]
 
- :title
- 3Dモデル(スプライト)
+:group
+3D関連
 
- :exp
- スプライトの3Dモデルを定義します。
- イメージとの違いはスプライトの場合、オブジェクトが常にカメラの方を向きます。
+:title
+3Dモデル(スプライト)
 
- :sample
+:exp
+スプライトの3Dモデルを定義します。
+イメージとの違いはスプライトの場合、オブジェクトが常にカメラの方を向きます。
+
+:sample
 
 [3d_sprite_new name="yamato" storage="doki.png"]
 [3d_show name="yamato"]
 
- :param
- name=3Dオブジェクトの名前です。この名前をつかって表示・非表示などの制御を行います。,
- storage=表示する画像ファイルを指定します。ファイルは「othres/3d/sprite」フォルダ以下に配置してください。,
- pos=3Dオブジェクトを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
- rot=3Dオブジェクトの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
- scale=3Dオブジェクトの拡大率を指定します。半角カンマで区切ってxyz軸の拡大率を指定します。,
- tonemap=トーンマッピングが有効な場合、このオブジェクトが影響を受けるか否かを設定できます。デフォルトはfalse。有効にする場合はtrueを指定してください。,
- folder=ファイルの配置フォルダを変更できます。
+:param
+name=3Dオブジェクトの名前です。この名前をつかって表示・非表示などの制御を行います。,
+storage=表示する画像ファイルを指定します。ファイルは「othres/3d/sprite」フォルダ以下に配置してください。,
+pos=3Dオブジェクトを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
+rot=3Dオブジェクトの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
+scale=3Dオブジェクトの拡大率を指定します。半角カンマで区切ってxyz軸の拡大率を指定します。,
+tonemap=トーンマッピングが有効な場合、このオブジェクトが影響を受けるか否かを設定できます。デフォルトはfalse。有効にする場合はtrueを指定します。,
+folder=ファイルの配置フォルダを変更できます。
 
-
-
- #[end]
- */
+#[end]
+*/
 
 //スプライトを配置する
 tyrano.plugin.kag.tag["3d_sprite_new"] = {
@@ -667,20 +661,21 @@ tyrano.plugin.kag.tag["3d_sprite_new"] = {
 };
 
 /*
- #[3d_event]
- :group
- 3D関連
+#[3d_event]
 
- :title
- 3Dイベント定義
+:group
+3D関連
 
- :exp
- 3Dシーン上のオブジェクトがクリックされたときに、イベントを発火させることができます。
- イベントは[s]タグに到達していないと発火しません。
- また、一度イベントが発火すると自動的に全イベントが無効化されます（イベント定義自体は残っている）
- 再度イベントを発生させたい場合は[3d_event_start]を通過する必要があります。
+:title
+3Dイベント定義
 
- :sample
+:exp
+3Dシーン上のオブジェクトがクリックされたときに、イベントを発火させることができます。
+イベントは[s]タグに到達していないと発火しません。
+また、一度イベントが発火すると自動的に全イベントが無効化されます（イベント定義自体は残っている）
+再度イベントを発生させたい場合は[3d_event_start]を通過する必要があります。
+
+:sample
 
 ;3Dモデルの定義と表示
 [3d_model_new name="miruku" storage="miruku/scene.gltf" scale=300 pos="0,-300,500" ]
@@ -710,14 +705,12 @@ tyrano.plugin.kag.tag["3d_sprite_new"] = {
 @3d_event_start
 
 :param
-name=3Dオブジェクトの名前です。イベントを発生させる3Dオブジェクトのnameを指定してください。,
-storage=移動するシナリオファイル名を指定します。省略された場合は現在のシナリオファイルと見なされます,
+name=3Dオブジェクトの名前です。イベントを発生させる3Dオブジェクトのnameを指定します。,
+storage=移動するシナリオファイル名を指定します。省略された場合は現在のシナリオファイルとみなされます。,
 target=ジャンプ先のラベル名を指定します。省略すると先頭から実行されます
 
-
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_event"] = {
     vital: ["name"],
@@ -739,17 +732,18 @@ tyrano.plugin.kag.tag["3d_event"] = {
 };
 
 /*
- #[3d_event_delete]
- :group
- 3D関連
+#[3d_event_delete]
 
- :title
- 3Dイベントの削除
+:group
+3D関連
 
- :exp
- 登録した3Dイベントを無効化します。
+:title
+3Dイベントの削除
 
- :sample
+:exp
+登録した3Dイベントを無効化します。
+
+:sample
 
 ;ボックスの表示
 [3d_box_new name="box" width=100 height=100 depth=100 scale=2 tone=false color="0xFFFFFF"]
@@ -762,12 +756,10 @@ tyrano.plugin.kag.tag["3d_event"] = {
 
 
 :param
-name=3Dオブジェクトの名前です。イベントを削除する3Dオブジェクトのnameを指定してください。
+name=3Dオブジェクトの名前です。イベントを削除する3Dオブジェクトのnameを指定します。
 
-
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_event_delete"] = {
     vital: ["name"],
@@ -786,26 +778,25 @@ tyrano.plugin.kag.tag["3d_event_delete"] = {
 };
 
 /*
- #[3d_event_start]
- :group
- 3D関連
+#[3d_event_start]
 
- :title
- 3Dイベントの開始
+:group
+3D関連
 
- :exp
- 登録した3Dイベントを開始します。
- イベントが実行された後は必ず全イベントが無効化されるため、このタグで再度受付を開始する必要があります。
+:title
+3Dイベントの開始
 
- :sample
+:exp
+登録した3Dイベントを開始します。
+イベントが実行された後は必ず全イベントが無効化されるため、このタグで再度受付を開始する必要があります。
 
-
- :param
+:sample
 
 
+:param
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_event_start"] = {
     vital: [],
@@ -820,26 +811,25 @@ tyrano.plugin.kag.tag["3d_event_start"] = {
 };
 
 /*
- #[3d_event_stop]
- :group
- 3D関連
+#[3d_event_stop]
+
+:group
+3D関連
 
 :title
- 3Dイベントの停止
+3Dイベントの停止
 
 :exp
- 登録した3Dイベントを停止します。
- [3d_event_start]で再開できます。
- 登録したイベント自体は消えません。
+登録した3Dイベントを停止します。
+[3d_event_start]で再開できます。
+登録したイベント自体は消えません。
 
 :sample
 
 :param
 
-
-
- #[end]
- */
+#[end]
+*/
 
 //イベントを取得する。
 tyrano.plugin.kag.tag["3d_event_stop"] = {
@@ -855,17 +845,18 @@ tyrano.plugin.kag.tag["3d_event_stop"] = {
 };
 
 /*
- #[3d_box_new]
- :group
- 3D関連
+#[3d_box_new]
 
- :title
- 3Dモデル(ボックス)
+:group
+3D関連
 
- :exp
- 立方体の3Dモデルを定義します。
+:title
+3Dモデル(ボックス)
 
- :sample
+:exp
+立方体の3Dモデルを定義します。
+
+:sample
 
 ;ボックスの定義と表示
 [3d_box_new name="mybox1" ]
@@ -876,24 +867,22 @@ tyrano.plugin.kag.tag["3d_event_stop"] = {
 [3d_show name="mybox2" time=2000 ]
 
 
- :param
- name=3Dオブジェクトの名前です。この名前をつかって表示・非表示などの制御を行います。,
- texture=表示する画像ファイルを指定します。ファイルは「othres/3d/texture」フォルダ以下に配置してください。１つのテクスチャの場合はすべての面が同じ画像になりますが、半角カンマで区切って６つ指定するとすべての面に異なるテクスチャを適応することもできます,
- color=色を指定できます。0xRRGGBB 形式で指定します。,
- width=3Dオブジェクトの横幅を指定します。デフォルトは1です,
- height=3Dオブジェクトの高さを指定します。デフォルトは1です,
- depth=3Dオブジェクトの深さを指定します。デフォルトは1です,
+:param
+name=3Dオブジェクトの名前です。この名前をつかって表示・非表示などの制御を行います。,
+texture=表示する画像ファイルを指定します。ファイルは「othres/3d/texture」フォルダ以下に配置してください。１つのテクスチャの場合はすべての面が同じ画像になりますが、半角カンマで区切って６つ指定するとすべての面に異なるテクスチャを適応することもできます,
+color=色を指定できます。0xRRGGBB 形式で指定します。,
+width=3Dオブジェクトの横幅を指定します。デフォルトは1です,
+height=3Dオブジェクトの高さを指定します。デフォルトは1です,
+depth=3Dオブジェクトの深さを指定します。デフォルトは1です,
 
- pos=3Dオブジェクトを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
- rot=3Dオブジェクトの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
- scale=3Dオブジェクトの拡大率を指定します。半角カンマで区切ってxyz軸の拡大率を指定します。,
+pos=3Dオブジェクトを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
+rot=3Dオブジェクトの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
+scale=3Dオブジェクトの拡大率を指定します。半角カンマで区切ってxyz軸の拡大率を指定します。,
 
- tonemap=トーンマッピングが有効な場合、このオブジェクトが影響を受けるか否かを設定できます。デフォルトはfalse。有効にする場合はtrueを指定してください。
+tonemap=トーンマッピングが有効な場合、このオブジェクトが影響を受けるか否かを設定できます。デフォルトはfalse。有効にする場合はtrueを指定します。
 
-
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_box_new"] = {
     vital: ["name"],
@@ -927,39 +916,38 @@ tyrano.plugin.kag.tag["3d_box_new"] = {
 };
 
 /*
- #[3d_image_new]
- :group
- 3D関連
+#[3d_image_new]
 
- :title
- 3Dモデル(イメージ)
+:group
+3D関連
 
- :exp
- イメージの3Dモデルを定義します。
- 平面の板が3Dシーンに追加されるイメージです。
+:title
+3Dモデル(イメージ)
 
- :sample
+:exp
+イメージの3Dモデルを定義します。
+平面の板が3Dシーンに追加されるイメージです。
+
+:sample
 
 ;3Dイメージ
 [3d_image_new name="myimg" texture="room.jpg" width=200 doubleside=true ]
 [3d_show name="myimg" ]
 
- :param
- name=3Dオブジェクトの名前です。この名前をつかって表示・非表示などの制御を行います。,
- texture=表示する画像ファイルを指定します。ファイルは「othres/3d/texture」フォルダ以下に配置してください。,
- width=3Dオブジェクトの横幅を指定します。デフォルトは1です,
- height=3Dオブジェクトの高さを指定します。省略した場合は画像サイズの比率を保った形で表示できます。,
+:param
+name=3Dオブジェクトの名前です。この名前をつかって表示・非表示などの制御を行います。,
+texture=表示する画像ファイルを指定します。ファイルは「othres/3d/texture」フォルダ以下に配置してください。,
+width=3Dオブジェクトの横幅を指定します。デフォルトは1です,
+height=3Dオブジェクトの高さを指定します。省略した場合は画像サイズの比率を保った形で表示できます。,
 
- pos=3Dオブジェクトを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
- rot=3Dオブジェクトの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
- scale=3Dオブジェクトの拡大率を指定します。半角カンマで区切ってxyz軸の拡大率を指定します。,
- doubleside=テクスチャを両面に表示させるかを指定します。デフォルトはfalse。trueを指定すると裏面にもテクスチャが表示されます。,
- tonemap=トーンマッピングが有効な場合、このオブジェクトが影響を受けるか否かを設定できます。デフォルトはfalse。有効にする場合はtrueを指定してください。
+pos=3Dオブジェクトを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
+rot=3Dオブジェクトの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
+scale=3Dオブジェクトの拡大率を指定します。半角カンマで区切ってxyz軸の拡大率を指定します。,
+doubleside=テクスチャを両面に表示させるかを指定します。デフォルトはfalse。trueを指定すると裏面にもテクスチャが表示されます。,
+tonemap=トーンマッピングが有効な場合、このオブジェクトが影響を受けるか否かを設定できます。デフォルトはfalse。有効にする場合はtrueを指定します。
 
-
-
- #[end]
- */
+#[end]
+*/
 
 //球体をつくる
 tyrano.plugin.kag.tag["3d_image_new"] = {
@@ -1129,34 +1117,33 @@ tyrano.plugin.kag.tag["obj_model_new"] = {
 };
 
 /*
- #[3d_show]
- :group
- 3D関連
+#[3d_show]
 
- :title
- 3Dオブジェクト表示
+:group
+3D関連
 
- :exp
- 定義した3Dオブジェクトを実際にゲーム画面に登場させます。
+:title
+3Dオブジェクト表示
 
- :sample
+:exp
+定義した3Dオブジェクトを実際にゲーム画面に登場させます。
+
+:sample
 
 ;3Dイメージ
 [3d_image_new name="myimg" texture="room.jpg" width=200 doubleside=true ]
 [3d_show name="myimg" ]
 
- :param
- name=3Dオブジェクトの名前です。表示させたいオブジェクトのnameを指定してください,
- time=表示させるまでの時間をミリ秒で指定します。デフォルトは500,
- wait=表示の完了を待つか否か。デフォルトはtrue。,
- pos=3Dオブジェクトを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
- rot=3Dオブジェクトの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
- scale=3Dオブジェクトの拡大率を指定します。半角カンマで区切ってxyz軸の拡大率を指定します。
+:param
+name=3Dオブジェクトの名前です。表示させたいオブジェクトのnameを指定します,
+time=表示させるまでの時間をミリ秒で指定します。デフォルトは500,
+wait=表示の完了を待つか否か。デフォルトはtrue。,
+pos=3Dオブジェクトを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
+rot=3Dオブジェクトの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
+scale=3Dオブジェクトの拡大率を指定します。半角カンマで区切ってxyz軸の拡大率を指定します。
 
-
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_show"] = {
     vital: ["name"],
@@ -1214,19 +1201,20 @@ tyrano.plugin.kag.tag["3d_show"] = {
 };
 
 /*
- #[3d_hide]
- :group
- 3D関連
+#[3d_hide]
 
- :title
- 3Dオブジェクト非表示
+:group
+3D関連
 
- :exp
- 3Dオブジェクトをゲーム画面から退場させます。
- このタグを実行しても定義自体は削除されません。
- もう一度表示する場合は[3d_show]タグを使ってください。
+:title
+3Dオブジェクト非表示
 
- :sample
+:exp
+3Dオブジェクトをゲーム画面から退場させます。
+このタグを実行しても定義自体は削除されません。
+もう一度表示する場合は[3d_show]タグを使ってください。
+
+:sample
 
 ;3Dイメージ
 [3d_image_new name="myimg" texture="room.jpg" width=200 doubleside=true ]
@@ -1235,14 +1223,13 @@ tyrano.plugin.kag.tag["3d_show"] = {
 非表示にします。[p]
 [3d_hide name="myimg"]
 
- :param
- name=3Dオブジェクトの名前です。退場させたいオブジェクトのnameを指定してください,
- time=退場させるまでの時間をミリ秒で指定します。デフォルトは500,
- wait=退場の完了を待つか否か。デフォルトはtrue。
+:param
+name=3Dオブジェクトの名前です。退場させたいオブジェクトのnameを指定します,
+time=退場させるまでの時間をミリ秒で指定します。デフォルトは500,
+wait=退場の完了を待つか否か。デフォルトはtrue。
 
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_hide"] = {
     vital: ["name"],
@@ -1283,27 +1270,27 @@ tyrano.plugin.kag.tag["3d_hide"] = {
 };
 
 /*
- #[3d_hide_all]
- :group
- 3D関連
+#[3d_hide_all]
 
- :title
- 3Dオブジェクト全非表示
+:group
+3D関連
 
- :exp
- すべての3Dオブジェクトをゲーム画面から退場させます。
- このタグを実行しても定義自体は削除されません。
- もう一度表示する場合は[3d_show]タグを使ってください。
+:title
+3Dオブジェクト全非表示
 
- :sample
+:exp
+すべての3Dオブジェクトをゲーム画面から退場させます。
+このタグを実行しても定義自体は削除されません。
+もう一度表示する場合は[3d_show]タグを使ってください。
 
- :param
- time=退場させるまでの時間をミリ秒で指定します。デフォルトは500,
- wait=退場の完了を待つか否か。デフォルトはtrue。
+:sample
 
+:param
+time=退場させるまでの時間をミリ秒で指定します。デフォルトは500,
+wait=退場の完了を待つか否か。デフォルトはtrue。
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_hide_all"] = {
     vital: [],
@@ -1357,19 +1344,20 @@ tyrano.plugin.kag.tag["3d_hide_all"] = {
 
 /*
  #[3d_delete]
- :group
- 3D関連
 
- :title
- 3Dオブジェクト削除
+:group
+3D関連
 
- :exp
- 3Dオブジェクトを削除します。
- このタグは定義からも削除されるので、再度使用する場合は
- もう一度 new タグで定義する必要があります。
- 使用しなくなった3Dオブジェクトはこまめに削除することで軽量な動作が期待できます。
+:title
+3Dオブジェクト削除
 
- :sample
+:exp
+3Dオブジェクトを削除します。
+このタグは定義からも削除されるので、再度使用する場合は
+もう一度 new タグで定義する必要があります。
+使用しなくなった3Dオブジェクトはこまめに削除することで軽量な動作が期待できます。
+
+:sample
 
 ;3Dイメージ
 [3d_image_new name="myimg" texture="room.jpg" width=200 doubleside=true ]
@@ -1381,13 +1369,11 @@ tyrano.plugin.kag.tag["3d_hide_all"] = {
 定義からも削除[p]
 [3d_delete name="myimg"]
 
- :param
- name=3Dオブジェクトの名前です。削除していオブジェクトのnameを指定してください
+:param
+name=3Dオブジェクトの名前です。削除していオブジェクトのnameを指定します
 
-
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_delete"] = {
     vital: ["name"],
@@ -1412,25 +1398,24 @@ tyrano.plugin.kag.tag["3d_delete"] = {
 };
 
 /*
- #[3d_delete_all]
- :group
- 3D関連
+#[3d_delete_all]
 
- :title
- 3Dオブジェクト全削除
+:group
+3D関連
 
- :exp
- 3Dオブジェクトをすべて削除します。
- 3Dシーンをリセットするときに利用します。
+:title
+3Dオブジェクト全削除
 
- :sample
+:exp
+3Dオブジェクトをすべて削除します。
+3Dシーンをリセットするときに利用します。
 
- :param
+:sample
 
+:param
 
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_delete_all"] = {
     vital: [],
@@ -1456,26 +1441,25 @@ tyrano.plugin.kag.tag["3d_delete_all"] = {
 };
 
 /*
- #[3d_canvas_show]
- :group
- 3D関連
+#[3d_canvas_show]
 
- :title
- 3Dキャンバス表示
+:group
+3D関連
 
- :exp
- 3Dキャンバスを表示にします。
- 例えば、3Dシーンからノベルパートへの移動を頻繁にする場合などは便利です。
+:title
+3Dキャンバス表示
 
- :sample
- time=表示にかける時間をミリ秒で指定できます。デフォルトは1000です。
+:exp
+3Dキャンバスを表示にします。
+例えば、3Dシーンからノベルパートへの移動を頻繁にする場合などは便利です。
 
- :param
+:sample
+time=表示にかける時間をミリ秒で指定できます。デフォルトは1000です。
 
+:param
 
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_canvas_show"] = {
     vital: [],
@@ -1495,26 +1479,26 @@ tyrano.plugin.kag.tag["3d_canvas_show"] = {
 };
 
 /*
- #[3d_canvas_hide]
- :group
- 3D関連
+#[3d_canvas_hide]
 
- :title
- 3Dキャンバス非表示
+:group
+3D関連
 
- :exp
- 3Dキャンバスを非表示にします。
- 3Dシーン自体は維持されます。
- 例えば、3Dシーンからノベルパートへの移動を頻繁にする場合などは便利です。
+:title
+3Dキャンバス非表示
 
- :sample
- time=表示にかける時間をミリ秒で指定できます。デフォルトは1000です。
+:exp
+3Dキャンバスを非表示にします。
+3Dシーン自体は維持されます。
+例えば、3Dシーンからノベルパートへの移動を頻繁にする場合などは便利です。
 
- :param
+:sample
+time=表示にかける時間をミリ秒で指定できます。デフォルトは1000です。
 
+:param
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_canvas_hide"] = {
     vital: [],
@@ -1534,25 +1518,25 @@ tyrano.plugin.kag.tag["3d_canvas_hide"] = {
 };
 
 /*
- #[3d_close]
- :group
- 3D関連
+#[3d_close]
 
- :title
- 3Dシーン削除
+:group
+3D関連
 
- :exp
- 3Dシーンをすべて削除します。
- このタグを使用すると3D系の機能は全て使えなくなります。
- もう一度使用する場合は[3d_init]タグを通過させてください。
+:title
+3Dシーン削除
 
- :sample
+:exp
+3Dシーンをすべて削除します。
+このタグを使用すると3D系の機能は全て使えなくなります。
+もう一度使用する場合は[3d_init]タグを通過させてください。
 
- :param
+:sample
 
+:param
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_close"] = {
     vital: [],
@@ -1574,68 +1558,67 @@ tyrano.plugin.kag.tag["3d_close"] = {
 };
 
 /*
- #[3d_anim]
- :group
- 3D関連
+#[3d_anim]
 
- :title
- 3Dアニメーション
+:group
+3D関連
 
- :exp
- シーン上の3Dオブジェクトをアニメーションさせることができます。
+:title
+3Dアニメーション
 
- :sample
+:exp
+シーン上の3Dオブジェクトをアニメーションさせることができます。
 
- [3d_model_new name="mymodel" storage="mymodel/scene.gltf" ]
- [3d_anim name="miruku" pos="79,-458,727" scale="318.45,318.45,318.45" rot="0.13,-0.64,0" effect="easeInCubic" wait=true]
+:sample
 
-
- :param
- name=3Dオブジェクトの名前です。この名前の3Dオブジェクトをアニメーションさせます。カメラをアニメーションさせる場合は「camera」という名前を指定します。,
- pos=アニメーション後、3Dオブジェクトを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
- rot=アニメーション後、3Dオブジェクトの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
- scale=アニメーション後、3Dオブジェクトの拡大率を指定します。半角カンマで区切ってxyz軸の拡大率を指定します。,
- time=アニメーションにかける時間をミリ秒で指定します。デフォルトは1000です。,
- wait=アニメーションの完了を待つか否か。true or false デフォルトはtrueです。,
- lookat=ameraのときだけ有効。オブジェクトのnameかpos座標を指定することでカメラを特定の方向に向けることができます。,
- effect= 変化のエフェクトを指定します。指定できる文字列は以下の種類です<br />
- jswing
- ｜def
- ｜easeInQuad
- ｜easeOutQuad
- ｜easeInOutQuad
- ｜easeInCubic
- ｜easeOutCubic
- ｜easeInOutCubic
- ｜easeInQuart
- ｜easeOutQuart
- ｜easeInOutQuart
- ｜easeInQuint
- ｜easeOutQuint
- ｜easeInOutQuint
- ｜easeInSine
- ｜easeOutSine
- ｜easeInOutSine
- ｜easeInExpo
- ｜easeOutExpo
- ｜easeInOutExpo
- ｜easeInCirc
- ｜easeOutCirc
- ｜easeInOutCirc
- ｜easeInElastic
- ｜easeOutElastic
- ｜easeInOutElastic
- ｜easeInBack
- ｜easeOutBack
- ｜easeInOutBack
- ｜easeInBounce
- ｜easeOutBounce
- ｜easeInOutBounce
+[3d_model_new name="mymodel" storage="mymodel/scene.gltf" ]
+[3d_anim name="miruku" pos="79,-458,727" scale="318.45,318.45,318.45" rot="0.13,-0.64,0" effect="easeInCubic" wait=true]
 
 
+:param
+name=3Dオブジェクトの名前です。この名前の3Dオブジェクトをアニメーションさせます。カメラをアニメーションさせる場合は「camera」という名前を指定します。,
+pos=アニメーション後、3Dオブジェクトを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
+rot=アニメーション後、3Dオブジェクトの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
+scale=アニメーション後、3Dオブジェクトの拡大率を指定します。半角カンマで区切ってxyz軸の拡大率を指定します。,
+time=アニメーションにかける時間をミリ秒で指定します。デフォルトは1000です。,
+wait=アニメーションの完了を待つか否か。true or false デフォルトはtrueです。,
+lookat=ameraのときだけ有効。オブジェクトのnameかpos座標を指定することでカメラを特定の方向に向けることができます。,
+effect= 変化のエフェクトを指定します。指定できる文字列は以下の種類です<br />
+jswing
+｜def
+｜easeInQuad
+｜easeOutQuad
+｜easeInOutQuad
+｜easeInCubic
+｜easeOutCubic
+｜easeInOutCubic
+｜easeInQuart
+｜easeOutQuart
+｜easeInOutQuart
+｜easeInQuint
+｜easeOutQuint
+｜easeInOutQuint
+｜easeInSine
+｜easeOutSine
+｜easeInOutSine
+｜easeInExpo
+｜easeOutExpo
+｜easeInOutExpo
+｜easeInCirc
+｜easeOutCirc
+｜easeInOutCirc
+｜easeInElastic
+｜easeOutElastic
+｜easeInOutElastic
+｜easeInBack
+｜easeOutBack
+｜easeInOutBack
+｜easeInBounce
+｜easeOutBounce
+｜easeInOutBounce
 
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_anim"] = {
     vital: ["name"],
@@ -1725,26 +1708,25 @@ tyrano.plugin.kag.tag["3d_anim"] = {
 };
 
 /*
- #[3d_anim_stop]
- :group
- 3D関連
+#[3d_anim_stop]
 
- :title
- 3Dアニメ停止
+:group
+3D関連
 
- :exp
- アニメーション中の3Dオブジェクトを停止することができます。
+:title
+3Dアニメ停止
 
- :sample
+:exp
+アニメーション中の3Dオブジェクトを停止できます。
 
- :param
- name=アニメーションを停止する3Dオブジェクトの名前を指定します。 ,
- finish=true or false を指定します。falseを指定するとアニメーション停止の位置でオブジェクトが停止します。trueだとアニメーションする予定の位置まで移動します。デフォルトはtrue。
+:sample
 
+:param
+name=アニメーションを停止する3Dオブジェクトの名前を指定します。 ,
+finish=true or false を指定します。falseを指定するとアニメーション停止の位置でオブジェクトが停止します。trueだとアニメーションする予定の位置まで移動します。デフォルトはtrue。
 
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_anim_stop"] = {
     vital: ["name"],
@@ -1768,31 +1750,29 @@ tyrano.plugin.kag.tag["3d_anim_stop"] = {
 };
 
 /*
- #[3d_scene]
- :group
- 3D関連
+#[3d_scene]
 
- :title
- 3Dシーン設定
+:group
+3D関連
 
- :exp
- 3Dのシーン全体に影響する設定を行うことができます。
+:title
+3Dシーン設定
 
- :sample
+:exp
+3Dのシーン全体に影響する設定を行うことができます。
 
- [3d_scene light_amb="2" tonemap=""]
+:sample
 
- :param
+[3d_scene light_amb="2" tonemap=""]
 
- tonemap=トーンマッピングをシーンに設定できます。指定できる種類はNo/Linear/Reinhard/Uncharted2/Cineon/ACESFilmic。デフォルトはNo（トーンマッピングなし）。,
- tonemap_value=トーンマッピングの強さを設定します。デフォルトは0.8です。,
- light_amb=環境光の強さを指定します。デフォルトは1。例えば 0.5 だと暗め。2だとかなり明るくなります。
+:param
 
+tonemap=トーンマッピングをシーンに設定できます。指定できる種類はNo/Linear/Reinhard/Uncharted2/Cineon/ACESFilmic。デフォルトはNo（トーンマッピングなし）。,
+tonemap_value=トーンマッピングの強さを設定します。デフォルトは0.8です。,
+light_amb=環境光の強さを指定します。デフォルトは1。例えば 0.5 だと暗め。2だとかなり明るくなります。
 
-
-
- #[end]
- */
+#[end]
+*/
 
 //カメラの設定を変更
 tyrano.plugin.kag.tag["3d_scene"] = {
@@ -1864,30 +1844,30 @@ tyrano.plugin.kag.tag["3d_scene"] = {
 };
 
 /*
- #[3d_camera]
- :group
- 3D関連
+#[3d_camera]
 
- :title
- 3Dカメラ
+:group
+3D関連
 
- :exp
- 3Dシーンのカメラを設定できます。
- カメラの座標を確認したい場合は[camera_debug]をつかって、座標や傾きをテストするのがおすすめです。
+:title
+3Dカメラ
 
- :sample
+:exp
+3Dシーンのカメラを設定できます。
+カメラの座標を確認したい場合は[camera_debug]をつかって、座標や傾きをテストするのがおすすめです。
+
+:sample
 
 [3d_camera pos="10,20,30" ]
 
- :param
- pos=カメラを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
- rot=カメラの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
- tonemap=トーンマッピングをシーンに設定できます。指定できる種類はNo/Linear/Reinhard/Uncharted2/Cineon/ACESFilmic。デフォルトはNo（トーンマッピングなし）。,
- lookat=シーン上の3Dオブジェクトのnameを指定して、そのオブジェクトの方にカメラを向けることができます。 もしくはposを直接指定することで、その座標にカメラを向けることもできます。
+:param
+pos=カメラを配置する座標を指定します。半角のカンマで区切ってxyz座標を表します。 ,
+rot=カメラの傾きを指定します。半角カンマで区切ってxyz軸の回転を設定します。,
+tonemap=トーンマッピングをシーンに設定できます。指定できる種類はNo/Linear/Reinhard/Uncharted2/Cineon/ACESFilmic。デフォルトはNo（トーンマッピングなし）。,
+lookat=シーン上の3Dオブジェクトのnameを指定して、そのオブジェクトの方にカメラを向けることができます。 もしくはposを直接指定することで、その座標にカメラを向けることもできます。
 
-
- #[end]
- */
+#[end]
+*/
 
 //カメラの設定を変更
 tyrano.plugin.kag.tag["3d_camera"] = {
@@ -1951,30 +1931,29 @@ tyrano.plugin.kag.tag["3d_camera"] = {
 };
 
 /*
- #[3d_gyro]
- :group
- 3D関連
+#[3d_gyro]
 
- :title
- 3Dジャイロ
+:group
+3D関連
 
- :exp
- スマホの傾きでカメラを制御することができます。
- PCゲームの場合はマウスの位置でジャイロを再現することができます。
+:title
+3Dジャイロ
 
- :sample
+:exp
+スマホの傾きでカメラを制御できます。
+PCゲームの場合はマウスの位置でジャイロを再現できます。
+
+:sample
 
 [3d_gyro max_x="20" max_y="20" ]
 
- :param
- max_x=X軸方向の傾き上限を角度で指定します。デフォルトは30,
- max_y=Y軸方向の傾き上限を角度で指定します。デフォルトは30,
- mode=position か rotation を指定します。傾きに対してカメラに回転の影響を与えるのか、座標移動を与えるのかの違いがあります。デフォルトはrotation（回転）です。
+:param
+max_x=X軸方向の傾き上限を角度で指定します。デフォルトは30,
+max_y=Y軸方向の傾き上限を角度で指定します。デフォルトは30,
+mode=position か rotation を指定します。傾きに対してカメラに回転の影響を与えるのか、座標移動を与えるのかの違いがあります。デフォルトはrotation（回転）です。
 
-
-
- #[end]
- */
+#[end]
+*/
 
 //カメラの設定を変更
 (tyrano.plugin.kag.tag["3d_gyro"] = {
@@ -2242,7 +2221,7 @@ tyrano.plugin.kag.tag["3d_camera"] = {
      :exp
      スマホ限定
      ジャイロの動きを停止します。
-     カメラの位置も戻したい場合はこのタグの直後に3d_cameraで指定してください。
+     カメラの位置も戻したい場合はこのタグの直後に3d_cameraで指定します。
      再度ジャイロを有効にしたい場合は [3d_gyro] タグです。
 
      :sample
@@ -2284,7 +2263,7 @@ tyrano.plugin.kag.tag["3d_camera"] = {
      3Dカメラデバッグ
 
      :exp
-     3Dシーンのカメラ座標をマウスでドラッグアンドドロップしながら、調整することができます。
+     3Dシーンのカメラ座標をマウスでドラッグアンドドロップしながら、調整できます。
      デバッグを終了する場合は画面左上のボタンを押します。
      マウス操作
      左クリック：カメラの向き(rot)
@@ -2574,17 +2553,18 @@ tyrano.plugin.kag.tag["3d_camera"] = {
     });
 
 /*
- #[3d_motion]
- :group
- 3D関連
+#[3d_motion]
 
- :title
- モーション変更
+:group
+3D関連
 
- :exp
- 3Dモデルのモーションを変更することができます。
+:title
+モーション変更
 
- :sample
+:exp
+3Dモデルのモーションを変更できます。
+
+:sample
 
 ;モデルの定義。最初はRunningというモーションで表示。
 [3d_model_new name="Robot" storage="Robot.glb" pos="0,0,0" scale="2" motion="Running" ]
@@ -2594,14 +2574,12 @@ tyrano.plugin.kag.tag["3d_camera"] = {
 
 [3d_motion name="Robot" motion="Punch"]
 
- :param
- name=3Dオブジェクトの名前を指定します。 ,
- motion=モーション名を指定してください。
+:param
+name=3Dオブジェクトの名前を指定します。 ,
+motion=モーション名を指定します。
 
-
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_motion"] = {
     vital: ["name", "motion"],
@@ -2625,23 +2603,24 @@ tyrano.plugin.kag.tag["3d_motion"] = {
 };
 
 /*
- #[3d_debug]
- :group
- 3D関連
+#[3d_debug]
 
- :title
- 3Dデバッグ
+:group
+3D関連
 
- :exp
- 3Dシーンのオブジェクトをマウスでドラッグアンドドロップしながら、調整することができます。
- デバッグを終了する場合は画面左上のボタンを押します。
- マウス操作
- 左クリック：カメラの向き(rot)
- 右クリック：カメラの位置(pos)
- 中央クリック：ポジションのz軸
- スクロール：拡大縮小（scale）
+:title
+3Dデバッグ
 
- :sample
+:exp
+3Dシーンのオブジェクトをマウスでドラッグアンドドロップしながら、調整できます。
+デバッグを終了する場合は画面左上のボタンを押します。
+マウス操作
+左クリック：カメラの向き(rot)
+右クリック：カメラの位置(pos)
+中央クリック：ポジションのz軸
+スクロール：拡大縮小（scale）
+
+:sample
 
 [3d_model_new name="Robot" storage="Robot.glb" ]
 [3d_show name="Robot" rot="0.28,0.67,0" pos="-129,-24,910" scale="9.68" ]
@@ -2650,17 +2629,15 @@ tyrano.plugin.kag.tag["3d_motion"] = {
 
 [3d_debug name="Robot" ]
 
- :param
- name=デバッグする3Dオブジェクトのnameを指定してください。,
- button_text=デバッグを終了するボタンのテキストを自由に設定できます。デフォルトは「3Dインスペクタを閉じる」,
- menu=デバッグのメニューを表示するか否か。falseを指定すると終了させるボタンのみになります。デフォルトはtrue(表示) ,
- overlap=true or false。trueを指定すると最前面にモデルが表示されます。メニューに隠れたくない場合はここをtrueにしてください。デフォルトはflase,
- reset=true or false。trueを指定するとデバッグが終わった後、モデルがデバッグ前の位置に戻ります。デフォルトはfalse。
+:param
+name=デバッグする3Dオブジェクトのnameを指定します。,
+button_text=デバッグを終了するボタンのテキストを自由に設定できます。デフォルトは「3Dインスペクタを閉じる」,
+menu=デバッグのメニューを表示するか否か。falseを指定すると終了させるボタンのみになります。デフォルトはtrue(表示) ,
+overlap=true or false。trueを指定すると最前面にモデルが表示されます。メニューに隠れたくない場合はここをtrueにしてください。デフォルトはflase,
+reset=true or false。trueを指定するとデバッグが終わった後、モデルがデバッグ前の位置に戻ります。デフォルトはfalse。
 
-
-
- #[end]
- */
+#[end]
+*/
 
 tyrano.plugin.kag.tag["3d_debug"] = {
     vital: ["name"],

--- a/tyrano/plugins/kag/kag.tag_three.js
+++ b/tyrano/plugins/kag/kag.tag_three.js
@@ -1,7 +1,4 @@
-
-
-$.three_pos = function(str) {
-
+$.three_pos = function (str) {
     var obj = {};
     arr_obj = str.split(",");
 
@@ -16,30 +13,31 @@ $.three_pos = function(str) {
     }
 
     return obj;
-
 };
 
-$.setVector = function(model) {
-
+$.setVector = function (model) {
     var vector = {};
 
-    vector["pos"] = { "x": model.position.x, "y": model.position.y, "z": model.position.z };
-    vector["rot"] = { "x": model.rotation.x, "y": model.rotation.y, "z": model.rotation.z };
-    vector["scale"] = { "x": model.scale.x, "y": model.scale.y, "z": model.scale.z };
+    vector["pos"] = {
+        x: model.position.x,
+        y: model.position.y,
+        z: model.position.z,
+    };
+    vector["rot"] = {
+        x: model.rotation.x,
+        y: model.rotation.y,
+        z: model.rotation.z,
+    };
+    vector["scale"] = { x: model.scale.x, y: model.scale.y, z: model.scale.z };
 
     return vector;
-
 };
 
-
-$.orgFloor = function(value, base) {
-
+$.orgFloor = function (value, base) {
     return Math.floor(value * base) / base;
-
 };
 
-$.checkThreeModel = function(name) {
-
+$.checkThreeModel = function (name) {
     if (TYRANO.kag.tmp.three.models[name]) {
         return true;
     } else {
@@ -77,7 +75,6 @@ $.getAngle = function(){
 }
 */
 
-
 /*
  #[3d_init]
  :group
@@ -109,11 +106,9 @@ $.getAngle = function(){
  */
 
 tyrano.plugin.kag.tag["3d_init"] = {
-
     vital: [],
 
     pm: {
-
         layer: "0",
         page: "fore",
         camera: "Perspective",
@@ -121,13 +116,11 @@ tyrano.plugin.kag.tag["3d_init"] = {
         far: "5000",
 
         next: "true",
-
     },
 
     clock: {},
 
-    start: function(pm) {
-
+    start: function (pm) {
         var that = this;
 
         var target_layer = this.kag.layer.getLayer(pm.layer, pm.page);
@@ -148,18 +141,18 @@ tyrano.plugin.kag.tag["3d_init"] = {
         var sc_height = parseInt(this.kag.config.scHeight);
 
         j_canvas.css({
-            "position": "absolute",
-            "width": sc_width,
-            "height": sc_height,
+            position: "absolute",
+            width: sc_width,
+            height: sc_height,
         });
 
         target_layer.append(j_canvas);
 
         const renderer = new THREE.WebGLRenderer({
-            canvas: document.querySelector('#three'),
+            canvas: document.querySelector("#three"),
             alpha: true,
             antialias: true,
-            preserveDrawingBuffer: true
+            preserveDrawingBuffer: true,
         });
 
         renderer.setPixelRatio(window.devicePixelRatio);
@@ -172,13 +165,20 @@ tyrano.plugin.kag.tag["3d_init"] = {
         const camera_mode = pm.camera + "Camera";
 
         // カメラを作成 Perspective or Orthographic
-        const camera = new THREE[camera_mode](45, sc_width / sc_height, parseFloat(pm.near), parseFloat(pm.far));
-        camera.rotation.order = 'YXZ';
+        const camera = new THREE[camera_mode](
+            45,
+            sc_width / sc_height,
+            parseFloat(pm.near),
+            parseFloat(pm.far),
+        );
+        camera.rotation.order = "YXZ";
 
         camera.position.set(0, 0, +1000);
 
-        this.kag.tmp.three.models["camera"] = new ThreeModel({ "name": "camera", "model": camera, "mixer": null, "gltf": null, "pm": pm }, three);
-
+        this.kag.tmp.three.models["camera"] = new ThreeModel(
+            { name: "camera", model: camera, mixer: null, gltf: null, pm: pm },
+            three,
+        );
 
         //指定のレイヤは表示状態に移行。
         target_layer.show();
@@ -211,7 +211,6 @@ tyrano.plugin.kag.tag["3d_init"] = {
 
         //毎フレーム時に実行されるループイベントです
         function tick() {
-
             if (three.orbit_controls) {
                 three.orbit_controls.update();
             }
@@ -225,9 +224,6 @@ tyrano.plugin.kag.tag["3d_init"] = {
             if (three.stat.is_load == false) {
                 window.cancelAnimationFrame(req_id);
             }
-
-
-
         }
 
         //イベント検知用の処理
@@ -236,11 +232,9 @@ tyrano.plugin.kag.tag["3d_init"] = {
         if (pm.next == "true") {
             this.kag.ftag.nextOrder();
         }
-
     },
 
-    initEvent: function(three) {
-
+    initEvent: function (three) {
         var that = this;
 
         var renderer = three.renderer;
@@ -249,8 +243,7 @@ tyrano.plugin.kag.tag["3d_init"] = {
         var camera = three.camera;
         var scene = three.scene;
 
-        j_canvas.on("click", function(event) {
-
+        j_canvas.on("click", function (event) {
             var x = event.clientX;
             var y = event.clientY;
 
@@ -272,27 +265,19 @@ tyrano.plugin.kag.tag["3d_init"] = {
                 //console.log(intersects[0].object);
                 var name = intersects[0].object.userData["name"];
                 if (that.kag.stat.is_strong_stop == true) {
-
                     if (three.evt[name]) {
                         that.kag.layer.showEventLayer();
                         that.kag.ftag.startTag("jump", three.evt[name]);
                         return;
                     }
-
                 } else {
-
                     //console.log("none");
-
                 }
-
             }
-
         });
-
     },
 
-    updateFrame: function() {
-
+    updateFrame: function () {
         //対応が必要なフレーム処理をここで実施する。
 
         var three = this.kag.tmp.three;
@@ -302,32 +287,21 @@ tyrano.plugin.kag.tag["3d_init"] = {
         var delta = this.clock.getDelta();
 
         for (key in models) {
-
             if (models[key].mixer) {
                 models[key].update(delta);
             }
-
         }
 
         //フレームアップデートのタイミングでジャイロ反映
         if (three.stat.gyro.mode == 1) {
-
             camera.rotation.x = three.stat.gyro.x;
             camera.rotation.y = three.stat.gyro.y;
-
         } else if (three.stat.gyro.mode == 2) {
-
             camera.position.x = three.stat.gyro.x;
             camera.position.y = three.stat.gyro.y;
-
         }
-
-    }
-
-
+    },
 };
-
-
 
 /*
  #[3d_model_new]
@@ -365,11 +339,9 @@ tyrano.plugin.kag.tag["3d_init"] = {
  */
 
 tyrano.plugin.kag.tag["3d_model_new"] = {
-
     vital: ["name", "storage"],
 
     pm: {
-
         name: "",
         storage: "",
 
@@ -380,11 +352,9 @@ tyrano.plugin.kag.tag["3d_model_new"] = {
         motion: "",
         next: "true",
         folder: "",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
 
         var folder = "";
@@ -398,12 +368,10 @@ tyrano.plugin.kag.tag["3d_model_new"] = {
         var ext = $.getExt(pm.storage);
 
         if (ext == "gltf" || ext == "glb") {
-
             var storage_url = "./data/" + folder + "/" + pm.storage;
 
             var loader = new THREE.GLTFLoader();
             loader.load(storage_url, (data) => {
-
                 var gltf = data;
                 var model = gltf.scene;
 
@@ -420,12 +388,10 @@ tyrano.plugin.kag.tag["3d_model_new"] = {
                 let mixer = new THREE.AnimationMixer(model);
 
                 if (animations.length > 0) {
-
                     let anim = animations[0];
 
                     //モーションが指定されている場合はそれを再生する
                     if (pm.motion != "") {
-
                         for (var i = 0; i < animations.length; i++) {
                             var name = animations[i].name;
 
@@ -433,18 +399,25 @@ tyrano.plugin.kag.tag["3d_model_new"] = {
                                 anim = animations[i];
                                 break;
                             }
-
                         }
                     }
 
                     const anime = mixer.clipAction(anim);
                     anime.play();
-
                 } else {
                     mixer = undefined;
                 }
 
-                this.kag.tmp.three.models[pm.name] = new ThreeModel({ "name": pm.name, "model": model, "mixer": mixer, "gltf": gltf, "pm": pm }, three);
+                this.kag.tmp.three.models[pm.name] = new ThreeModel(
+                    {
+                        name: pm.name,
+                        model: model,
+                        mixer: mixer,
+                        gltf: gltf,
+                        pm: pm,
+                    },
+                    three,
+                );
 
                 if (pm.tonemap == "true") {
                     this.kag.tmp.three.models[pm.name].setToneMaped(true);
@@ -455,78 +428,64 @@ tyrano.plugin.kag.tag["3d_model_new"] = {
                 if (pm.next == "true") {
                     this.kag.ftag.nextOrder();
                 }
-
-
             });
-
         } else if (ext == "obj") {
-
             var obj_url = "./data/" + folder + "/" + pm.storage;
             var mtl_file = obj_url.replace(".obj", ".mtl");
             var mtl_url = mtl_file;
 
             var mtlLoader = new THREE.MTLLoader();
             mtlLoader.load(mtl_url, (materials) => {
-
                 materials.preload();
                 var objLoader = new THREE.OBJLoader();
                 objLoader.setMaterials(materials);
 
                 materials.toneMaped = false;
 
-                objLoader.load(obj_url, (obj) => {
+                objLoader.load(
+                    obj_url,
+                    (obj) => {
+                        var model = obj;
+                        let pos = $.three_pos(pm.pos);
+                        let scale = $.three_pos(pm.scale);
+                        let rot = $.three_pos(pm.rot);
 
-                    var model = obj;
-                    let pos = $.three_pos(pm.pos);
-                    let scale = $.three_pos(pm.scale);
-                    let rot = $.three_pos(pm.rot);
+                        //モデルのサイズ。
+                        model.position.set(pos.x, pos.y, pos.z);
+                        model.scale.set(scale.x, scale.y, scale.z);
+                        model.rotation.set(rot.x, rot.y, rot.z);
 
-                    //モデルのサイズ。
-                    model.position.set(pos.x, pos.y, pos.z);
-                    model.scale.set(scale.x, scale.y, scale.z);
-                    model.rotation.set(rot.x, rot.y, rot.z);
+                        //three.scene.add(model);
+                        this.kag.tmp.three.models[pm.name] = new ThreeModel(
+                            { name: pm.name, model: model, pm: pm },
+                            three,
+                        );
 
-                    //three.scene.add(model);
-                    this.kag.tmp.three.models[pm.name] = new ThreeModel({ "name": pm.name, "model": model, "pm": pm }, three);
+                        if (pm.tonemap == "true") {
+                            this.kag.tmp.three.models[pm.name].setToneMaped(
+                                true,
+                            );
+                        } else {
+                            this.kag.tmp.three.models[pm.name].setToneMaped(
+                                false,
+                            );
+                        }
 
-
-                    if (pm.tonemap == "true") {
-                        this.kag.tmp.three.models[pm.name].setToneMaped(true);
-                    } else {
-                        this.kag.tmp.three.models[pm.name].setToneMaped(false);
-                    }
-
-                    if (pm.next == "true") {
-                        this.kag.ftag.nextOrder();
-                    }
-
-                } /*, onProgress, onError */);
-
+                        if (pm.next == "true") {
+                            this.kag.ftag.nextOrder();
+                        }
+                    } /*, onProgress, onError */,
+                );
             });
-
-
         } else if (ext == "mmd") {
-
-
-
-
-
         } else {
             alert("エラー：" + ext + "はサポートしていないファイル形式です");
         }
 
         //読み込んだシーンが暗いので、明るくする
         //three.render.gammaOutput = true;
-
-
-
     },
-
-
-
-
 };
-
 
 /*
  #[3d_sphere_new]
@@ -565,11 +524,9 @@ tyrano.plugin.kag.tag["3d_model_new"] = {
  */
 
 tyrano.plugin.kag.tag["3d_sphere_new"] = {
-
     vital: ["name"],
 
     pm: {
-
         name: "",
 
         type: "SphereGeometry",
@@ -586,24 +543,16 @@ tyrano.plugin.kag.tag["3d_sphere_new"] = {
         rot: "0",
 
         folder: "",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         pm.arg1 = pm.radius;
         pm.arg2 = pm.width;
         pm.arg3 = pm.height;
 
         this.kag.ftag.startTag("obj_model_new", pm);
-
     },
-
-
-
-
 };
-
 
 /*
  #[3d_sprite_new]
@@ -638,11 +587,9 @@ tyrano.plugin.kag.tag["3d_sphere_new"] = {
 
 //スプライトを配置する
 tyrano.plugin.kag.tag["3d_sprite_new"] = {
-
     vital: ["name", "storage"],
 
     pm: {
-
         name: "",
         storage: "",
 
@@ -653,11 +600,9 @@ tyrano.plugin.kag.tag["3d_sprite_new"] = {
         next: "true",
 
         folder: "",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var folder = "";
 
         if (pm.folder != "") {
@@ -672,9 +617,8 @@ tyrano.plugin.kag.tag["3d_sprite_new"] = {
         const material = new THREE.SpriteMaterial({
             map: new THREE.TextureLoader().load(storage_url),
             alphaTest: 0.01,
-            transparent: true
+            transparent: true,
         });
-
 
         if (pm.tonemap == "true") {
             material.toneMapped = true;
@@ -684,43 +628,43 @@ tyrano.plugin.kag.tag["3d_sprite_new"] = {
 
         var model = new THREE.Sprite(material);
 
-        $("<img />").attr("src", storage_url).on("load", (e) => {
+        $("<img />")
+            .attr("src", storage_url)
+            .on("load", (e) => {
+                var width = $(e.currentTarget).get(0).width;
+                var height = $(e.currentTarget).get(0).height;
 
-            var width = $(e.currentTarget).get(0).width;
-            var height = $(e.currentTarget).get(0).height;
+                let pos = $.three_pos(pm.pos);
+                let rot = $.three_pos(pm.rot);
 
-            let pos = $.three_pos(pm.pos);
-            let rot = $.three_pos(pm.rot);
+                model.position.set(pos.x, pos.y, pos.z);
+                model.rotation.set(rot.x, rot.y, rot.z);
 
-            model.position.set(pos.x, pos.y, pos.z);
-            model.rotation.set(rot.x, rot.y, rot.z);
+                if (pm.scale == "") {
+                    model.scale.set(
+                        parseInt(width) * 1,
+                        parseInt(height) * 1,
+                        1,
+                    );
+                } else {
+                    let scale = $.three_pos(pm.scale);
+                    model.scale.set(scale.x, scale.y, scale.z);
+                }
 
-            if (pm.scale == "") {
-                model.scale.set((parseInt(width) * 1), (parseInt(height) * 1), 1);
-            } else {
-                let scale = $.three_pos(pm.scale);
-                model.scale.set(scale.x, scale.y, scale.z);
-            }
+                var three = this.kag.tmp.three;
+                var scene = three.scene;
 
-            var three = this.kag.tmp.three;
-            var scene = three.scene;
+                this.kag.tmp.three.models[pm.name] = new ThreeModel(
+                    { name: pm.name, model: model, pm: pm },
+                    three,
+                );
 
-            this.kag.tmp.three.models[pm.name] = new ThreeModel({ "name": pm.name, "model": model, "pm": pm }, three);
-
-            if (pm.next == "true") {
-                this.kag.ftag.nextOrder();
-            }
-
-
-        });
-
-
+                if (pm.next == "true") {
+                    this.kag.ftag.nextOrder();
+                }
+            });
     },
-
-
 };
-
-
 
 /*
  #[3d_event]
@@ -776,32 +720,23 @@ target=ジャンプ先のラベル名を指定します。省略すると先頭�
  */
 
 tyrano.plugin.kag.tag["3d_event"] = {
-
     vital: ["name"],
 
     pm: {
-
         name: "",
         storage: "",
         target: "",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
 
         three.stat.start_event = true;
         three.evt[pm.name] = pm;
 
         this.kag.ftag.nextOrder();
-
-
     },
-
-
 };
-
 
 /*
  #[3d_event_delete]
@@ -835,29 +770,20 @@ name=3Dオブジェクトの名前です。イベントを削除する3Dオブ�
  */
 
 tyrano.plugin.kag.tag["3d_event_delete"] = {
-
     vital: ["name"],
 
     pm: {
-
         name: "",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
 
         delete three.evt[pm.name];
 
         this.kag.ftag.nextOrder();
-
-
     },
-
-
 };
-
 
 /*
  #[3d_event_start]
@@ -882,24 +808,16 @@ tyrano.plugin.kag.tag["3d_event_delete"] = {
  */
 
 tyrano.plugin.kag.tag["3d_event_start"] = {
-
     vital: [],
 
-    pm: {
+    pm: {},
 
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
         three.stat.start_event = true;
         this.kag.ftag.nextOrder();
-
     },
-
-
 };
-
 
 /*
  #[3d_event_stop]
@@ -925,24 +843,16 @@ tyrano.plugin.kag.tag["3d_event_start"] = {
 
 //イベントを取得する。
 tyrano.plugin.kag.tag["3d_event_stop"] = {
-
     vital: [],
 
-    pm: {
+    pm: {},
 
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
         three.stat.start_event = false;
         this.kag.ftag.nextOrder();
-
     },
-
-
 };
-
 
 /*
  #[3d_box_new]
@@ -986,16 +896,14 @@ tyrano.plugin.kag.tag["3d_event_stop"] = {
  */
 
 tyrano.plugin.kag.tag["3d_box_new"] = {
-
     vital: ["name"],
 
     pm: {
-
         name: "",
 
         type: "BoxGeometry",
 
-        texture: "",  // ,でくくると６面体それぞれにテクスチャを貼ることができる。
+        texture: "", // ,でくくると６面体それぞれにテクスチャを貼ることができる。
         color: "0x00ff00",
 
         width: "1",
@@ -1007,24 +915,16 @@ tyrano.plugin.kag.tag["3d_box_new"] = {
         rot: "0",
 
         folder: "",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         pm.arg1 = pm.width;
         pm.arg2 = pm.height;
         pm.arg3 = pm.depth;
 
         this.kag.ftag.startTag("obj_model_new", pm);
-
     },
-
-
-
-
 };
-
 
 /*
  #[3d_image_new]
@@ -1063,11 +963,9 @@ tyrano.plugin.kag.tag["3d_box_new"] = {
 
 //球体をつくる
 tyrano.plugin.kag.tag["3d_image_new"] = {
-
     vital: ["name", "width"],
 
     pm: {
-
         name: "",
 
         type: "PlaneGeometry",
@@ -1083,58 +981,44 @@ tyrano.plugin.kag.tag["3d_image_new"] = {
 
         doubleside: "false",
         tonemap: "false",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         //heightが省略されている場合は画像のサイズから数値を決める
         if (pm.height == "") {
-
             var texture_url = "./data/others/3d/texture/" + pm.texture;
 
-            $("<img />").attr("src", texture_url).on("load", (e) => {
+            $("<img />")
+                .attr("src", texture_url)
+                .on("load", (e) => {
+                    var width = $(e.currentTarget).get(0).width;
+                    var height = $(e.currentTarget).get(0).height;
 
-                var width = $(e.currentTarget).get(0).width;
-                var height = $(e.currentTarget).get(0).height;
+                    var tmp = height / width;
 
-                var tmp = height / width;
+                    pm.height = parseInt(parseInt(pm.width) * tmp);
 
-                pm.height = parseInt(parseInt(pm.width) * tmp);
+                    pm.arg1 = pm.width;
+                    pm.arg2 = pm.height;
+                    pm.arg3 = 1;
 
-                pm.arg1 = pm.width;
-                pm.arg2 = pm.height;
-                pm.arg3 = 1;
-
-                this.kag.ftag.startTag("obj_model_new", pm);
-
-
-            });
-
+                    this.kag.ftag.startTag("obj_model_new", pm);
+                });
         } else {
-
             pm.arg1 = pm.width;
             pm.arg2 = pm.height;
             pm.arg3 = 1;
 
             this.kag.ftag.startTag("obj_model_new", pm);
-
         }
     },
-
-
-
-
 };
-
 
 //基本図形 直接タグで実行することはない。
 tyrano.plugin.kag.tag["obj_model_new"] = {
-
     vital: ["name", "type"],
 
     pm: {
-
         name: "",
         type: "",
 
@@ -1146,7 +1030,7 @@ tyrano.plugin.kag.tag["obj_model_new"] = {
         arg3: 0,
 
         scale: "", //100,100,100 //みたいな感じで指定できる。
-        pos: "",  // 100,40,50
+        pos: "", // 100,40,50
         rot: "",
 
         doubleside: "false",
@@ -1157,44 +1041,42 @@ tyrano.plugin.kag.tag["obj_model_new"] = {
         folder: "",
 
         next: "true",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
         var scene = three.scene;
 
         //var storage_url = "./data/" + folder + "/" + pm.storage;
 
-        const geometry = new THREE[pm.type](parseFloat(pm.arg1), parseFloat(pm.arg2), parseFloat(pm.arg3));
+        const geometry = new THREE[pm.type](
+            parseFloat(pm.arg1),
+            parseFloat(pm.arg2),
+            parseFloat(pm.arg3),
+        );
 
         // 画像を読み込む
         let material;
 
         if (pm.texture != "") {
-
             //boxで配列の場合は別処理になる
             if (pm.type == "BoxGeometry" && pm.texture.split(",").length > 1) {
-
                 var arr_texture = pm.texture.split(",");
                 var arr_material = [];
                 const loader = new THREE.TextureLoader();
 
                 for (let i = 0; i < arr_texture.length; i++) {
-
-                    var texture_url = "./data/others/3d/texture/" + arr_texture[i];
+                    var texture_url =
+                        "./data/others/3d/texture/" + arr_texture[i];
                     const texture = loader.load(texture_url);
-                    arr_material.push(new THREE.MeshStandardMaterial({ map: texture }));
-
+                    arr_material.push(
+                        new THREE.MeshStandardMaterial({ map: texture }),
+                    );
                 }
 
                 // マテリアルにテクスチャーを設定
                 material = arr_material;
-
-
             } else {
-
                 var texture_url = "./data/others/3d/texture/" + pm.texture;
                 const loader = new THREE.TextureLoader();
                 const texture = loader.load(texture_url);
@@ -1202,15 +1084,13 @@ tyrano.plugin.kag.tag["obj_model_new"] = {
                 material = new THREE.MeshStandardMaterial({
                     map: texture,
                     alphaTest: 0.01,
-                    transparent: true
+                    transparent: true,
                 });
-
             }
-
         } else {
-
-            material = new THREE.MeshStandardMaterial({ color: parseInt(pm.color.toLowerCase()) });
-
+            material = new THREE.MeshStandardMaterial({
+                color: parseInt(pm.color.toLowerCase()),
+            });
         }
 
         if (pm.doubleside == "true") {
@@ -1222,7 +1102,6 @@ tyrano.plugin.kag.tag["obj_model_new"] = {
         } else {
             material.toneMapped = false;
         }
-
 
         // メッシュを作成
         const model = new THREE.Mesh(geometry, material);
@@ -1238,21 +1117,16 @@ tyrano.plugin.kag.tag["obj_model_new"] = {
         // 3D空間にメッシュを追加
         //scene.add(model);
 
-        this.kag.tmp.three.models[pm.name] = new ThreeModel({ "name": pm.name, "model": model, "pm": pm }, three);
+        this.kag.tmp.three.models[pm.name] = new ThreeModel(
+            { name: pm.name, model: model, pm: pm },
+            three,
+        );
 
         if (pm.next == "true") {
             this.kag.ftag.nextOrder();
         }
-
-
     },
-
-
-
-
 };
-
-
 
 /*
  #[3d_show]
@@ -1285,11 +1159,9 @@ tyrano.plugin.kag.tag["obj_model_new"] = {
  */
 
 tyrano.plugin.kag.tag["3d_show"] = {
-
     vital: ["name"],
 
     pm: {
-
         name: "",
         time: "500",
 
@@ -1298,11 +1170,9 @@ tyrano.plugin.kag.tag["3d_show"] = {
         rot: "",
 
         wait: "true",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
 
         if ($.checkThreeModel(pm.name) == false) {
@@ -1314,7 +1184,7 @@ tyrano.plugin.kag.tag["3d_show"] = {
         three.scene.add(model.model);
 
         var options = {
-            duration: parseInt(pm.time)
+            duration: parseInt(pm.time),
         };
 
         if (pm.pos != "") {
@@ -1333,25 +1203,15 @@ tyrano.plugin.kag.tag["3d_show"] = {
         }
 
         if (pm.wait == "true") {
-
             model.fade("in", options, () => {
                 this.kag.ftag.nextOrder();
             });
-
         } else {
-
             model.fade("in", options);
             this.kag.ftag.nextOrder();
-
         }
-
-
     },
-
-
 };
-
-
 
 /*
  #[3d_hide]
@@ -1385,20 +1245,16 @@ tyrano.plugin.kag.tag["3d_show"] = {
  */
 
 tyrano.plugin.kag.tag["3d_hide"] = {
-
     vital: ["name"],
 
     pm: {
-
         name: "",
         time: "500",
         next: "true",
-        wait: "true"
-
+        wait: "true",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         if ($.checkThreeModel(pm.name) == false) {
             return;
         }
@@ -1406,36 +1262,25 @@ tyrano.plugin.kag.tag["3d_hide"] = {
         var three = this.kag.tmp.three;
 
         var options = {
-            duration: parseInt(pm.time)
+            duration: parseInt(pm.time),
         };
 
         var model = this.kag.tmp.three.models[pm.name];
 
         if (pm.wait == "true") {
-
             model.fade("out", options, (_model) => {
                 this.kag.ftag.nextOrder();
                 three.scene.remove(_model);
             });
-
         } else {
-
             model.fade("out", options, (_model) => {
                 three.scene.remove(_model);
             });
 
             this.kag.ftag.nextOrder();
-
         }
-
-
     },
-
-
 };
-
-
-
 
 /*
  #[3d_hide_all]
@@ -1460,25 +1305,19 @@ tyrano.plugin.kag.tag["3d_hide"] = {
  #[end]
  */
 
-
-
 tyrano.plugin.kag.tag["3d_hide_all"] = {
-
     vital: [],
 
     pm: {
-
         time: "500",
         wait: "true",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
 
         var options = {
-            duration: parseInt(pm.time)
+            duration: parseInt(pm.time),
         };
 
         var models = this.kag.tmp.three.models;
@@ -1487,48 +1326,34 @@ tyrano.plugin.kag.tag["3d_hide_all"] = {
         var fin_fade = 0;
 
         for (let key in models) {
-
             if (key == "camera") continue;
 
             cnt_fade++;
 
             if (pm.wait == "true") {
-
                 models[key].fade("out", options, (_model) => {
-
                     three.scene.remove(_model);
                     fin_fade++;
 
                     if (cnt_fade == fin_fade) {
                         this.kag.ftag.nextOrder();
                     }
-
                 });
-
             } else {
-
                 models[key].fade("out", options, (_model) => {
-
                     three.scene.remove(_model);
                     fin_fade++;
-
                 });
 
                 this.kag.ftag.nextOrder();
-
             }
-
         }
 
         if (cnt_fade == 0) {
             this.kag.ftag.nextOrder();
         }
-
     },
-
-
 };
-
 
 /*
  #[3d_delete]
@@ -1565,17 +1390,13 @@ tyrano.plugin.kag.tag["3d_hide_all"] = {
  */
 
 tyrano.plugin.kag.tag["3d_delete"] = {
-
     vital: ["name"],
 
     pm: {
-
         name: "",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         if ($.checkThreeModel(pm.name) == false) {
             return;
         }
@@ -1587,14 +1408,8 @@ tyrano.plugin.kag.tag["3d_delete"] = {
 
         delete this.kag.tmp.three.models[pm.name];
         this.kag.ftag.nextOrder();
-
-
     },
-
-
 };
-
-
 
 /*
  #[3d_delete_all]
@@ -1618,38 +1433,27 @@ tyrano.plugin.kag.tag["3d_delete"] = {
  */
 
 tyrano.plugin.kag.tag["3d_delete_all"] = {
-
     vital: [],
 
-    pm: {
+    pm: {},
 
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
 
         var models = this.kag.tmp.three.models;
 
         for (let key in models) {
-
             if (key == "camera") continue;
 
             var model = models[key];
             three.scene.remove(model.model);
 
             delete three.models[key];
-
         }
 
         this.kag.ftag.nextOrder();
-
     },
-
-
 };
-
-
 
 /*
  #[3d_canvas_show]
@@ -1674,27 +1478,21 @@ tyrano.plugin.kag.tag["3d_delete_all"] = {
  */
 
 tyrano.plugin.kag.tag["3d_canvas_show"] = {
-
     vital: [],
 
     pm: {
-        time: "1000"
+        time: "1000",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
         this.kag.tmp.three.stat.canvas_show = true;
 
         three.j_canvas.fadeIn(parseInt(pm.time), () => {
             this.kag.ftag.nextOrder();
         });
-
     },
-
-
 };
-
 
 /*
  #[3d_canvas_hide]
@@ -1719,27 +1517,21 @@ tyrano.plugin.kag.tag["3d_canvas_show"] = {
  */
 
 tyrano.plugin.kag.tag["3d_canvas_hide"] = {
-
     vital: [],
 
     pm: {
-        time: "1000"
+        time: "1000",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
         this.kag.tmp.three.stat.canvas_show = false;
 
         three.j_canvas.fadeOut(parseInt(pm.time), () => {
             this.kag.ftag.nextOrder();
         });
-
     },
-
-
 };
-
 
 /*
  #[3d_close]
@@ -1762,16 +1554,12 @@ tyrano.plugin.kag.tag["3d_canvas_hide"] = {
  #[end]
  */
 
-
 tyrano.plugin.kag.tag["3d_close"] = {
-
     vital: [],
 
-    pm: {
-    },
+    pm: {},
 
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
 
         three.stat.is_load = false;
@@ -1782,13 +1570,8 @@ tyrano.plugin.kag.tag["3d_close"] = {
         }
 
         this.kag.ftag.nextOrder();
-
     },
-
-
 };
-
-
 
 /*
  #[3d_anim]
@@ -1854,13 +1637,10 @@ tyrano.plugin.kag.tag["3d_close"] = {
  #[end]
  */
 
-
 tyrano.plugin.kag.tag["3d_anim"] = {
-
     vital: ["name"],
 
     pm: {
-
         name: "",
         time: "1000",
         effect: "linear",
@@ -1872,11 +1652,9 @@ tyrano.plugin.kag.tag["3d_anim"] = {
         lookat: "",
 
         wait: "true",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         if ($.checkThreeModel(pm.name) == false) {
             return;
         }
@@ -1884,16 +1662,14 @@ tyrano.plugin.kag.tag["3d_anim"] = {
         var three = this.kag.tmp.three;
 
         var options = {
-            "duration": parseInt(pm.time),
-            "easing": pm.effect
+            duration: parseInt(pm.time),
+            easing: pm.effect,
         };
 
         var map_type = {};
 
         if (pm.pos != "") {
-
             if (pm.name == "camera" && pm.lookat != "") {
-
                 if (three.models[pm.lookat]) {
                     var model = three.models[pm.lookat].model;
                     var pos = { x: 0, y: 0, z: 0 };
@@ -1902,19 +1678,13 @@ tyrano.plugin.kag.tag["3d_anim"] = {
                     pos.z = model.position.z;
 
                     map_type["position"] = pos;
-
                 } else {
                     //座標を直接し指定
                     map_type["position"] = $.three_pos(pm.lookat);
                 }
-
-
             } else {
-
                 map_type["position"] = $.three_pos(pm.pos);
-
             }
-
         }
 
         if (pm.rot != "") {
@@ -1929,38 +1699,30 @@ tyrano.plugin.kag.tag["3d_anim"] = {
         var cnt_type = Object.keys(map_type).length;
 
         for (let key in map_type) {
-
             var pos = map_type[key];
             var type = key;
 
-            this.kag.tmp.three.models[pm.name].toAnim(type, pos, options, () => {
+            this.kag.tmp.three.models[pm.name].toAnim(
+                type,
+                pos,
+                options,
+                () => {
+                    cnt_fin++;
 
-                cnt_fin++;
-
-                if (cnt_fin >= cnt_type) {
-
-                    if (pm.wait == "true") {
-                        this.kag.ftag.nextOrder();
+                    if (cnt_fin >= cnt_type) {
+                        if (pm.wait == "true") {
+                            this.kag.ftag.nextOrder();
+                        }
                     }
-
-                }
-
-            });
-
+                },
+            );
         }
 
         if (pm.wait != "true") {
             this.kag.ftag.nextOrder();
         }
-
-
     },
-
-
-
-
 };
-
 
 /*
  #[3d_anim_stop]
@@ -1985,18 +1747,14 @@ tyrano.plugin.kag.tag["3d_anim"] = {
  */
 
 tyrano.plugin.kag.tag["3d_anim_stop"] = {
-
     vital: ["name"],
 
     pm: {
-
         name: "",
         finish: "true",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         if ($.checkThreeModel(pm.name) == false) {
             return;
         }
@@ -2006,15 +1764,8 @@ tyrano.plugin.kag.tag["3d_anim_stop"] = {
         this.kag.tmp.three.models[pm.name].stopAnim(pm.finish);
 
         this.kag.ftag.nextOrder();
-
     },
-
-
-
-
 };
-
-
 
 /*
  #[3d_scene]
@@ -2043,46 +1794,37 @@ tyrano.plugin.kag.tag["3d_anim_stop"] = {
  #[end]
  */
 
-
 //カメラの設定を変更
 tyrano.plugin.kag.tag["3d_scene"] = {
-
     vital: [],
 
     pm: {
-
         tonemap: "",
         tonemap_value: "0.8",
 
-        light_amb: "",   // 100,40,50
+        light_amb: "", // 100,40,50
 
-        fog: "",   //
+        fog: "", //
         fog_range: "1,3000",
         fog_color: "0xFFFFFF",
 
         next: "true",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
         var scene = three.scene;
         var camera = three.camera;
         var renderer = three.renderer;
 
         if (pm.light_amb != "") {
-
             three.stat.scene_pm["light_amb"] = pm.light_amb;
 
             //オブジェクトに設定を入れる。
             three.light_amb.intensity = parseFloat(pm.light_amb);
-
-
         }
 
         if (pm.tonemap != "") {
-
             three.stat.scene_pm["tonemap"] = pm.tonemap;
 
             //表示の方法
@@ -2093,46 +1835,33 @@ tyrano.plugin.kag.tag["3d_scene"] = {
             for (let key in three.models) {
                 three.models[key].needsUpdate();
             }
-
         }
 
         if (pm.fog != "") {
-
             if (pm.fog == "true") {
-
                 three.stat.scene_pm["fog"] = pm.fog;
                 three.stat.scene_pm["fog_color"] = pm.fog_color;
                 three.stat.scene_pm["fog_range"] = pm.fog_range;
 
                 var fog_tmp = pm.fog_range.split(",");
-                scene.fog = new THREE.Fog(parseInt(pm.fog_color), parseFloat(fog_tmp[0]), parseFloat(fog_tmp[1]));
-
+                scene.fog = new THREE.Fog(
+                    parseInt(pm.fog_color),
+                    parseFloat(fog_tmp[0]),
+                    parseFloat(fog_tmp[1]),
+                );
             } else {
-
                 three.stat.scene_pm["fog"];
 
                 scene.fog.near = 0.1;
                 scene.fog.far = 0;
-
             }
-
         }
 
         if (pm.next == "true") {
             this.kag.ftag.nextOrder();
         }
-
-
     },
-
-
-
-
 };
-
-
-
-
 
 /*
  #[3d_camera]
@@ -2160,24 +1889,19 @@ tyrano.plugin.kag.tag["3d_scene"] = {
  #[end]
  */
 
-
 //カメラの設定を変更
 tyrano.plugin.kag.tag["3d_camera"] = {
-
     vital: [],
 
     pm: {
-
-        pos: "",   // 100,40,50
-        rot: "",   //
-        lookat: "",  //モデル名を設定。どの場所をみるか。 モデル名　か positionを直指定。
+        pos: "", // 100,40,50
+        rot: "", //
+        lookat: "", //モデル名を設定。どの場所をみるか。 モデル名　か positionを直指定。
 
         next: "true",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
         var camera = three.camera;
         var renderer = three.renderer;
@@ -2199,15 +1923,11 @@ tyrano.plugin.kag.tag["3d_camera"] = {
             camera.rotation.set(rot.x, rot.y, rot.z);
         }
 
-
-
-
         if (pm.lookat != "") {
-
             var pos = {
                 x: 0,
                 y: 0,
-                z: 0
+                z: 0,
             };
 
             if (three.models[pm.lookat]) {
@@ -2216,31 +1936,19 @@ tyrano.plugin.kag.tag["3d_camera"] = {
                 pos.x = model.position.x;
                 pos.y = model.position.y;
                 pos.z = model.position.z;
-
             } else {
                 //座標を直接し指定
                 pos = $.three_pos(pm.lookat);
             }
 
             camera.lookAt(new THREE.Vector3(pos.x, pos.y, pos.z));
-
         }
 
         if (pm.next == "true") {
             this.kag.ftag.nextOrder();
         }
-
-
-
     },
-
-
-
-
 };
-
-
-
 
 /*
  #[3d_gyro]
@@ -2268,34 +1976,27 @@ tyrano.plugin.kag.tag["3d_camera"] = {
  #[end]
  */
 
-
 //カメラの設定を変更
-tyrano.plugin.kag.tag["3d_gyro"] = {
-
+(tyrano.plugin.kag.tag["3d_gyro"] = {
     vital: [],
 
     pm: {
-
         max_x: "30",
         max_y: "30",
 
         mode: "rotation", // rotation or position
 
         next: "true",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
         var camera = three.camera;
         var renderer = three.renderer;
 
         //ジャイロ設定
         if (true) {
-
             const GyroMonitor = (device_type) => {
-
                 //var first_pos = {x:}
                 var first_beta = 0;
                 var first_gamma = 0;
@@ -2318,13 +2019,10 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
                 three.stat.gyro.pm = pm;
 
                 const orientEvent = (e) => {
-
-
                     //let angle_code = $.getAngle();
                     //console.log(angle);
 
                     if (first_flag == true) {
-
                         first_flag = false;
                         first_beta = e.beta;
                         first_gamma = e.gamma;
@@ -2338,16 +2036,12 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
                         }
 
                         if (angle != 0) {
-
                             //値の入れ替え
                             [max_x, max_y] = [max_y, max_x];
-
                         } else {
-
                             max_x = pm.max_x;
                             max_y = pm.max_y;
                         }
-
                     }
 
                     if (angle != this.kag.tmp.angle) {
@@ -2356,7 +2050,6 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
                     }
 
                     if (angle != 0) {
-
                         var t_gamma = e.gamma;
 
                         if (angle == -90) {
@@ -2370,77 +2063,61 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
                         }
                     }
 
-
-
                     var hen_y = first_beta - e.beta;
                     var hen_x = first_gamma - e.gamma;
 
-
                     if (Math.abs(hen_y) > max_y) {
-                        if (hen_y > 0) { hen_y = max_y; } else { hen_y = (-1 * max_y); }
+                        if (hen_y > 0) {
+                            hen_y = max_y;
+                        } else {
+                            hen_y = -1 * max_y;
+                        }
                     }
 
                     if (Math.abs(hen_x) > max_x) {
-                        if (hen_x > 0) { hen_x = max_x; } else { hen_x = (-1 * max_x); }
+                        if (hen_x > 0) {
+                            hen_x = max_x;
+                        } else {
+                            hen_x = -1 * max_x;
+                        }
                     }
-
 
                     //カメラのローテーション
                     var gyro_x = 0;
                     var gyro_y = 0;
 
-
                     if (three.stat.gyro.mode == 1) {
-
                         //縦持ち
                         if (angle == 0) {
-
-                            gyro_y = default_camera_x - (hen_x * (Math.PI / 180));
-                            gyro_x = default_camera_y - (hen_y * (Math.PI / 180));
-
-
+                            gyro_y = default_camera_x - hen_x * (Math.PI / 180);
+                            gyro_x = default_camera_y - hen_y * (Math.PI / 180);
                         } else if (angle == -90) {
-
-                            gyro_y = default_camera_y + (hen_y * (Math.PI / 180));
-                            gyro_x = default_camera_x - (hen_x * (Math.PI / 180));
-
+                            gyro_y = default_camera_y + hen_y * (Math.PI / 180);
+                            gyro_x = default_camera_x - hen_x * (Math.PI / 180);
                         } else if (angle == 90) {
-
-                            gyro_y = default_camera_y + (hen_y * -1 * (Math.PI / 180));
-                            gyro_x = default_camera_x - (hen_x * -1 * (Math.PI / 180));
-
+                            gyro_y =
+                                default_camera_y + hen_y * -1 * (Math.PI / 180);
+                            gyro_x =
+                                default_camera_x - hen_x * -1 * (Math.PI / 180);
                         }
-
-
                     } else if (three.stat.gyro.mode == 2) {
-
                         //縦持ち
                         if (angle == 0) {
-
                             //position  変更
-                            gyro_x = default_camera_pos_y + (hen_x * 10);
-                            gyro_y = default_camera_pos_x + (hen_y * 10);
-
-
+                            gyro_x = default_camera_pos_y + hen_x * 10;
+                            gyro_y = default_camera_pos_x + hen_y * 10;
                         } else if (angle == -90) {
-
-                            gyro_y = default_camera_pos_y + (hen_x * 10);
-                            gyro_x = default_camera_pos_x + (hen_y * 10);
-
+                            gyro_y = default_camera_pos_y + hen_x * 10;
+                            gyro_x = default_camera_pos_x + hen_y * 10;
                         } else if (angle == 90) {
-
                             //position  変更
-                            gyro_y = default_camera_pos_y + (hen_x * 10);
-                            gyro_x = default_camera_pos_x + (hen_y * 10);
-
+                            gyro_y = default_camera_pos_y + hen_x * 10;
+                            gyro_x = default_camera_pos_x + hen_y * 10;
                         }
-
-
                     }
 
                     three.stat.gyro.x = gyro_x;
                     three.stat.gyro.y = gyro_y;
-
                 };
 
                 var sc_width = parseInt(this.kag.config.scWidth);
@@ -2451,7 +2128,6 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
 
                 //PC版のイベントマウス動かします。
                 const mouseMoveEvent = (e) => {
-
                     //マウスがどう動いたか
                     var x = e.clientX;
                     var y = e.clientY;
@@ -2470,9 +2146,7 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
                     var gyro_x = 0;
                     var gyro_y = 0;
 
-
                     if (first_flag == true) {
-
                         first_flag = false;
 
                         if (pm.mode == "rotation") {
@@ -2480,101 +2154,83 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
                         } else {
                             three.stat.gyro.mode = 2;
                         }
-
-
                     }
-
 
                     //最大値以上になってたら、止める
                     if (three.stat.gyro.mode == 1) {
-
                         //rotation 変更
-                        gyro_x = default_camera_x + (max_x * p_x * (Math.PI / 180));
-                        gyro_y = default_camera_y - (max_y * p_y * (Math.PI / 180));
-
+                        gyro_x =
+                            default_camera_x + max_x * p_x * (Math.PI / 180);
+                        gyro_y =
+                            default_camera_y - max_y * p_y * (Math.PI / 180);
                     } else if (three.stat.gyro.mode == 2) {
-
                         //position  変更
                         gyro_y = default_camera_pos_x + max_x * p_x;
                         gyro_x = default_camera_pos_y + max_y * p_y;
-
                     }
 
                     three.stat.gyro.x = gyro_y;
                     three.stat.gyro.y = gyro_x;
-
-
-
                 };
 
                 if (device_type == "pc") {
-
                     //イベントの登録と削除。マシンの場合
-                    $(".tyrano_base").get(0).removeEventListener('mousemove', mouseMoveEvent);
-                    $(".tyrano_base").get(0).addEventListener('mousemove', mouseMoveEvent, true);
-
+                    $(".tyrano_base")
+                        .get(0)
+                        .removeEventListener("mousemove", mouseMoveEvent);
+                    $(".tyrano_base")
+                        .get(0)
+                        .addEventListener("mousemove", mouseMoveEvent, true);
                 } else {
-
                     //スマホの場合
-                    window.removeEventListener('deviceorientation', orientEvent);
-                    window.addEventListener('deviceorientation', orientEvent, true);
-
+                    window.removeEventListener(
+                        "deviceorientation",
+                        orientEvent,
+                    );
+                    window.addEventListener(
+                        "deviceorientation",
+                        orientEvent,
+                        true,
+                    );
                 }
-
-
             };
 
-
             const requestDeviceMotionPermission = () => {
-
                 //PCと
                 if ($.userenv() != "pc") {
                     if (DeviceMotionEvent) {
-
-                        if (typeof DeviceMotionEvent.requestPermission === 'function') {
-
-                            DeviceMotionEvent.requestPermission().then(permissionState => {
-
-                                if (permissionState === 'granted') {
-                                    GyroMonitor("sp");
-                                } else {
-                                    // 許可を得られなかった場合の処理
-                                }
-                            })
+                        if (
+                            typeof DeviceMotionEvent.requestPermission ===
+                            "function"
+                        ) {
+                            DeviceMotionEvent.requestPermission()
+                                .then((permissionState) => {
+                                    if (permissionState === "granted") {
+                                        GyroMonitor("sp");
+                                    } else {
+                                        // 許可を得られなかった場合の処理
+                                    }
+                                })
                                 .catch(console.error); // https通信でない場合などで許可を取得できなかった場合
-
                         } else {
-
                             //アンドロイド
                             GyroMonitor("sp");
                         }
-
                     } else {
-
                     }
                 } else {
-
                     GyroMonitor("pc");
-
                 }
-
             };
 
-
             requestDeviceMotionPermission();
-
         }
 
         if (pm.next == "true") {
             this.kag.ftag.nextOrder();
         }
-
-    }
-
-},
-
-
-
+    },
+}),
     /*
      #[3d_gyro_stop]
      :group
@@ -2598,23 +2254,18 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
      #[end]
      */
 
-
     //カメラの設定を変更
-    tyrano.plugin.kag.tag["3d_gyro_stop"] = {
-
+    (tyrano.plugin.kag.tag["3d_gyro_stop"] = {
         vital: [],
 
         pm: {
-
             max_x: "30",
             max_y: "30",
             frame: "1",
             next: "true",
-
         },
 
-        start: function(pm) {
-
+        start: function (pm) {
             var three = this.kag.tmp.three;
             var camera = three.camera;
             var renderer = three.renderer;
@@ -2622,11 +2273,8 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
             three.stat.gyro.mode = 0;
 
             this.kag.ftag.nextOrder();
-
-        }
-
-    },
-
+        },
+    }),
     /*
      #[3d_debug_camera]
      :group
@@ -2657,23 +2305,16 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
      #[end]
      */
 
-
-
-
-    tyrano.plugin.kag.tag["3d_debug_camera"] = {
-
+    (tyrano.plugin.kag.tag["3d_debug_camera"] = {
         vital: [],
 
         pm: {
-
             name: "camera",
             button_text: "カメラインスペクタを閉じる",
             menu: "true",
         },
 
-        start: function(pm) {
-
-
+        start: function (pm) {
             var three = this.kag.tmp.three;
 
             //一番前にもってきて、うごかせるようにする。
@@ -2707,11 +2348,9 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
             var original_pos = new THREE.Vector3(); // create once and reuse
 
             var hen_pos = {
-
                 x: 0,
                 y: 0,
                 z: 0,
-
             };
 
             var original_v = $.setVector(model);
@@ -2724,7 +2363,6 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
             var first_model_z = 0;
 
             function evt_mousewheel(e) {
-
                 var delta = e.wheelDelta;
 
                 if (delta < 0) {
@@ -2735,14 +2373,10 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
 
                 evt_mouseup();
                 e.preventDefault();
-
             }
 
-
             function evt_mousedown(e) {
-
                 if (e.button == 0) {
-
                     button = 0;
 
                     first_client_x = e.clientX;
@@ -2750,18 +2384,12 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
 
                     first_model_x = model.rotation.x;
                     first_model_y = model.rotation.y;
-
-
-                }
-                else if (e.button == 1) {
+                } else if (e.button == 1) {
                     //target.innerHTML = "中ボタンが押されました。";
                     button = 1;
                     first_client_y = e.clientY;
                     first_model_z = model.position.z;
-
-                }
-                else if (e.button == 2) {
-
+                } else if (e.button == 2) {
                     button = 2;
 
                     first_client_x = e.clientX;
@@ -2769,35 +2397,24 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
 
                     first_model_x = model.position.x;
                     first_model_y = model.position.y;
-
                 }
 
                 mousedown = true;
-
-
             }
 
             function evt_mousemove(e) {
-
                 if (!mousedown) return;
 
                 if (button == 0) {
-
                     var hen_x = first_client_x - e.clientX;
                     model.rotation.y = first_model_y + hen_x * 0.005;
 
                     var hen_y = first_client_y - e.clientY;
                     model.rotation.x = first_model_x + hen_y * 0.005;
-
-
                 } else if (button == 1) {
-
                     var hen_y = first_client_y - e.clientY;
                     model.position.z = first_model_z + hen_y;
-
                 } else if (button == 2) {
-
-
                     var hen_x = first_client_x - e.clientX;
                     model.position.x = first_model_x + hen_x * 1;
 
@@ -2806,83 +2423,121 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
 
                     model.position.x = $.orgFloor(model.position.x, 1);
                     model.position.y = $.orgFloor(model.position.y, 1);
-
                 }
-
             }
 
             function evt_mouseup(e) {
-
                 first_client_x = 0;
                 first_client_y = 0;
 
                 if (button == 0) {
-
-                    var str = $.orgFloor(model.rotation.x, 100) + "," + $.orgFloor(model.rotation.y, 100) + "," + model.rotation.z;
-
+                    var str =
+                        $.orgFloor(model.rotation.x, 100) +
+                        "," +
+                        $.orgFloor(model.rotation.y, 100) +
+                        "," +
+                        model.rotation.z;
                 } else if (button == 2 || button == 1) {
-
-
                 }
 
-                var msg_pos = model.position.x + "," + model.position.y + "," + model.position.z;
-                var msg_rot = $.orgFloor(model.rotation.x, 100) + "," + $.orgFloor(model.rotation.y, 100) + "," + $.orgFloor(model.rotation.z, 100);
-                var msg_scale = $.orgFloor(model.scale.x, 100) + "," + $.orgFloor(model.scale.y, 100) + "," + $.orgFloor(model.scale.z, 100);
+                var msg_pos =
+                    model.position.x +
+                    "," +
+                    model.position.y +
+                    "," +
+                    model.position.z;
+                var msg_rot =
+                    $.orgFloor(model.rotation.x, 100) +
+                    "," +
+                    $.orgFloor(model.rotation.y, 100) +
+                    "," +
+                    $.orgFloor(model.rotation.z, 100);
+                var msg_scale =
+                    $.orgFloor(model.scale.x, 100) +
+                    "," +
+                    $.orgFloor(model.scale.y, 100) +
+                    "," +
+                    $.orgFloor(model.scale.z, 100);
 
-                var msg = 'pos="' + msg_pos + '" rot="' + msg_rot + '" scale="' + msg_scale + '" ';
+                var msg =
+                    'pos="' +
+                    msg_pos +
+                    '" rot="' +
+                    msg_rot +
+                    '" scale="' +
+                    msg_scale +
+                    '" ';
                 j_debug_msg.find("input").val(msg);
 
                 mousedown = false;
-
             }
 
-
             ///マウスホイール
-            renderer.domElement.addEventListener("mousewheel", evt_mousewheel, false);
-            renderer.domElement.addEventListener('mousedown', evt_mousedown, false);
-            renderer.domElement.addEventListener('mouseup', evt_mouseup, false);
-            renderer.domElement.addEventListener('mousemove', evt_mousemove, false);
-
+            renderer.domElement.addEventListener(
+                "mousewheel",
+                evt_mousewheel,
+                false,
+            );
+            renderer.domElement.addEventListener(
+                "mousedown",
+                evt_mousedown,
+                false,
+            );
+            renderer.domElement.addEventListener("mouseup", evt_mouseup, false);
+            renderer.domElement.addEventListener(
+                "mousemove",
+                evt_mousemove,
+                false,
+            );
 
             //デバッグ終了ボタンを押すと、nextOrderする。
             //リロードボタンの配置
             //メッセージエリア非表示。
 
-            var j_close_button = $("<div class='area_three_debug' style='position:absolute;z-index:9999999999;padding:10px;opacity:0.8;background-color:white;left:0px;top:0px'><button style='cursor:pointer'><span style=''>" + pm.button_text + "</span></button></div>");
+            var j_close_button = $(
+                "<div class='area_three_debug' style='position:absolute;z-index:9999999999;padding:10px;opacity:0.8;background-color:white;left:0px;top:0px'><button style='cursor:pointer'><span style=''>" +
+                    pm.button_text +
+                    "</span></button></div>",
+            );
             j_close_button.draggable({
-
                 scroll: false,
                 //containment:".tyrano_base",
-                stop: (e, ui) => {
-
-                }
-
+                stop: (e, ui) => {},
             });
 
-            var j_debug_msg = $("<div style='padding:5px'><input type='text' style='width:320px' /></div>");
+            var j_debug_msg = $(
+                "<div style='padding:5px'><input type='text' style='width:320px' /></div>",
+            );
             var j_copy_button = $("<input type='button' value='コピー' />");
 
             j_copy_button.on("click", (e) => {
-
                 evt_mouseup();
 
                 j_debug_msg.find("input").select();
                 // コピー
                 document.execCommand("copy");
-
             });
 
             var j_reset_button = $("<input type='button' value='リセット' />");
             j_reset_button.on("click", (e) => {
-
                 //モデルを最初の位置に戻す
                 //document.execCommand("copy");
-                model.position.set(original_v.pos.x, original_v.pos.y, original_v.pos.z);
-                model.rotation.set(original_v.rot.x, original_v.rot.y, original_v.rot.z);
-                model.scale.set(original_v.scale.x, original_v.scale.y, original_v.scale.z);
-
+                model.position.set(
+                    original_v.pos.x,
+                    original_v.pos.y,
+                    original_v.pos.z,
+                );
+                model.rotation.set(
+                    original_v.rot.x,
+                    original_v.rot.y,
+                    original_v.rot.z,
+                );
+                model.scale.set(
+                    original_v.scale.x,
+                    original_v.scale.y,
+                    original_v.scale.z,
+                );
             });
-
 
             j_close_button.find("button").on("click", (e) => {
                 j_close_button.remove();
@@ -2890,38 +2545,33 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
                 j_canvas.css("z-index", old_canvas_zindex);
                 target_layer.css("z-index", old_target_layer_zindex);
 
-
-                renderer.domElement.removeEventListener("mousedown", evt_mousedown);
+                renderer.domElement.removeEventListener(
+                    "mousedown",
+                    evt_mousedown,
+                );
                 renderer.domElement.removeEventListener("mouseup", evt_mouseup);
-                renderer.domElement.removeEventListener("mousemove", evt_mousemove);
-                renderer.domElement.removeEventListener("mousewheel", evt_mousewheel);
+                renderer.domElement.removeEventListener(
+                    "mousemove",
+                    evt_mousemove,
+                );
+                renderer.domElement.removeEventListener(
+                    "mousewheel",
+                    evt_mousewheel,
+                );
 
                 this.kag.ftag.nextOrder();
-
             });
 
             if (pm.menu == "true") {
-
                 j_close_button.append("<span style='font-size:10px'>｜</span>");
                 j_close_button.append(j_copy_button);
                 j_close_button.append(j_reset_button);
                 j_close_button.append(j_debug_msg);
-
             }
 
             $("body").append(j_close_button);
-
-
-
-
         },
-
-
-
-
-    };
-
-
+    });
 
 /*
  #[3d_motion]
@@ -2954,18 +2604,14 @@ tyrano.plugin.kag.tag["3d_gyro"] = {
  */
 
 tyrano.plugin.kag.tag["3d_motion"] = {
-
     vital: ["name", "motion"],
 
     pm: {
-
         name: "",
         motion: "",
-
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         if ($.checkThreeModel(pm.name) == false) {
             return;
         }
@@ -2975,14 +2621,8 @@ tyrano.plugin.kag.tag["3d_motion"] = {
         this.kag.tmp.three.models[pm.name].setMotion(pm.motion);
 
         this.kag.ftag.nextOrder();
-
-
     },
-
-
 };
-
-
 
 /*
  #[3d_debug]
@@ -3022,13 +2662,10 @@ tyrano.plugin.kag.tag["3d_motion"] = {
  #[end]
  */
 
-
 tyrano.plugin.kag.tag["3d_debug"] = {
-
     vital: ["name"],
 
     pm: {
-
         name: "",
         button_text: "3Dインスペクタを閉じる",
         menu: "true",
@@ -3036,8 +2673,7 @@ tyrano.plugin.kag.tag["3d_debug"] = {
         reset: "false",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         var three = this.kag.tmp.three;
 
         //一番前にもってきて、うごかせるようにする。
@@ -3073,11 +2709,9 @@ tyrano.plugin.kag.tag["3d_debug"] = {
         var original_pos = new THREE.Vector3(); // create once and reuse
 
         var hen_pos = {
-
             x: 0,
             y: 0,
             z: 0,
-
         };
 
         var original_v = $.setVector(model);
@@ -3086,49 +2720,39 @@ tyrano.plugin.kag.tag["3d_debug"] = {
         var first_model_z = 0;
 
         function evt_mousewheel(e) {
-
             var delta = e.wheelDelta;
 
             if (delta < 0) {
-
                 model.scale.x -= model.scale.x * 0.01;
                 model.scale.y -= model.scale.y * 0.01;
                 model.scale.z -= model.scale.z * 0.01;
-
             } else {
-
                 model.scale.x += model.scale.x * 0.01;
                 model.scale.y += model.scale.y * 0.01;
                 model.scale.z += model.scale.z * 0.01;
-
             }
 
             evt_mouseup();
 
             e.preventDefault();
-
         }
 
-
         function evt_mousedown(e) {
-
             if (e.button == 0) {
                 button = 0;
-            }
-            else if (e.button == 1) {
+            } else if (e.button == 1) {
                 //target.innerHTML = "中ボタンが押されました。";
                 button = 1;
                 first_client_y = e.clientY;
                 first_model_z = model.position.z;
-            }
-            else if (e.button == 2) {
-
+            } else if (e.button == 2) {
                 button = 2;
 
                 vec.set(
                     (e.clientX / window.innerWidth) * 2 - 1,
-                    - (e.clientY / window.innerHeight) * 2 + 1,
-                    0.5);
+                    -(e.clientY / window.innerHeight) * 2 + 1,
+                    0.5,
+                );
 
                 vec.unproject(camera);
 
@@ -3137,49 +2761,45 @@ tyrano.plugin.kag.tag["3d_debug"] = {
                 var distance = 0;
 
                 if (camera.position.z > 0) {
-                    distance = - camera.position.z / vec.z;
+                    distance = -camera.position.z / vec.z;
                 } else {
                     distance = camera.position.z / vec.z;
                 }
 
-                original_pos.copy(camera.position).add(vec.multiplyScalar(distance));
+                original_pos
+                    .copy(camera.position)
+                    .add(vec.multiplyScalar(distance));
 
                 hen_pos.x = model.position.x - original_pos.x;
                 hen_pos.y = model.position.y - original_pos.y;
-
-
             }
 
             mousedown = true;
             prevPosition = { x: e.clientX, y: e.clientY };
-
-
         }
 
         function evt_mousemove(e) {
-
             if (!mousedown) return;
 
             j_close_button.hide();
 
             if (button == 0) {
-
-                moveDistance = { x: prevPosition.x - e.clientX, y: prevPosition.y - e.clientY };
+                moveDistance = {
+                    x: prevPosition.x - e.clientX,
+                    y: prevPosition.y - e.clientY,
+                };
                 model.rotation.x += moveDistance.y * 0.01;
                 model.rotation.y -= moveDistance.x * 0.01;
                 prevPosition = { x: e.clientX, y: e.clientY };
-
             } else if (button == 1) {
-
                 var hen_y = first_client_y - e.clientY;
                 model.position.z = first_model_z + hen_y;
-
             } else if (button == 2) {
-
                 vec.set(
                     (e.clientX / window.innerWidth) * 2 - 1,
-                    - (e.clientY / window.innerHeight) * 2 + 1,
-                    0.5);
+                    -(e.clientY / window.innerHeight) * 2 + 1,
+                    0.5,
+                );
 
                 vec.unproject(camera);
 
@@ -3188,7 +2808,7 @@ tyrano.plugin.kag.tag["3d_debug"] = {
                 var distance = 0;
 
                 if (camera.position.z > 0) {
-                    distance = - camera.position.z / vec.z;
+                    distance = -camera.position.z / vec.z;
                 } else {
                     distance = camera.position.z / vec.z;
                 }
@@ -3197,28 +2817,40 @@ tyrano.plugin.kag.tag["3d_debug"] = {
 
                 model.position.x = $.orgFloor(hen_pos.x + pos.x, 1);
                 model.position.y = $.orgFloor(hen_pos.y + pos.y, 1);
-
             }
-
-
         }
 
         function evt_mouseup(e) {
-
             j_close_button.show();
 
             if (button == 0) {
-
-                var str = $.orgFloor(model.rotation.x, 100) + "," + $.orgFloor(model.rotation.y, 100) + "," + model.rotation.z;
-
+                var str =
+                    $.orgFloor(model.rotation.x, 100) +
+                    "," +
+                    $.orgFloor(model.rotation.y, 100) +
+                    "," +
+                    model.rotation.z;
             } else if (button == 2 || button == 1) {
-
-
             }
 
-            var msg_pos = model.position.x + "," + model.position.y + "," + model.position.z;
-            var msg_rot = $.orgFloor(model.rotation.x, 100) + "," + $.orgFloor(model.rotation.y, 100) + "," + $.orgFloor(model.rotation.z, 100);
-            var msg_scale = $.orgFloor(model.scale.x, 100) + "," + $.orgFloor(model.scale.y, 100) + "," + $.orgFloor(model.scale.z, 100);
+            var msg_pos =
+                model.position.x +
+                "," +
+                model.position.y +
+                "," +
+                model.position.z;
+            var msg_rot =
+                $.orgFloor(model.rotation.x, 100) +
+                "," +
+                $.orgFloor(model.rotation.y, 100) +
+                "," +
+                $.orgFloor(model.rotation.z, 100);
+            var msg_scale =
+                $.orgFloor(model.scale.x, 100) +
+                "," +
+                $.orgFloor(model.scale.y, 100) +
+                "," +
+                $.orgFloor(model.scale.z, 100);
 
             //pmを更新する
             var _pm = model_obj["pm"];
@@ -3227,11 +2859,17 @@ tyrano.plugin.kag.tag["3d_debug"] = {
             _pm["scale"] = msg_scale;
             model_obj["pm"] = _pm;
 
-            var msg = 'pos="' + msg_pos + '" rot="' + msg_rot + '" scale="' + msg_scale + '" ';
+            var msg =
+                'pos="' +
+                msg_pos +
+                '" rot="' +
+                msg_rot +
+                '" scale="' +
+                msg_scale +
+                '" ';
             j_debug_msg.find("input").val(msg);
 
             mousedown = false;
-
         }
 
         if (pm.overlap == "true") {
@@ -3240,58 +2878,68 @@ tyrano.plugin.kag.tag["3d_debug"] = {
         }
 
         //デバッグ用のレイヤ
-        var j_three_debug_layer = $("<div style='width:100%;height:100%;position:absolute;z-index:9999999;'></div>");
+        var j_three_debug_layer = $(
+            "<div style='width:100%;height:100%;position:absolute;z-index:9999999;'></div>",
+        );
         $(".tyrano_base").append(j_three_debug_layer);
         var three_debug_layer = j_three_debug_layer.get(0);
 
         ///マウスホイール
         three_debug_layer.addEventListener("mousewheel", evt_mousewheel, false);
-        three_debug_layer.addEventListener('mousedown', evt_mousedown, false);
-        three_debug_layer.addEventListener('mouseup', evt_mouseup, false);
-        three_debug_layer.addEventListener('mousemove', evt_mousemove, false);
-
+        three_debug_layer.addEventListener("mousedown", evt_mousedown, false);
+        three_debug_layer.addEventListener("mouseup", evt_mouseup, false);
+        three_debug_layer.addEventListener("mousemove", evt_mousemove, false);
 
         //デバッグ終了ボタンを押すと、nextOrderする。
         //リロードボタンの配置
         //メッセージエリア非表示。
 
-        var j_close_button = $("<div class='area_three_debug' style='position:absolute;z-index:9999999999;padding:10px;opacity:0.8;background-color:white;left:0px;top:0px'><button style='cursor:pointer'><span style=''>" + pm.button_text + "</span></button></div>");
+        var j_close_button = $(
+            "<div class='area_three_debug' style='position:absolute;z-index:9999999999;padding:10px;opacity:0.8;background-color:white;left:0px;top:0px'><button style='cursor:pointer'><span style=''>" +
+                pm.button_text +
+                "</span></button></div>",
+        );
         j_close_button.draggable({
-
             scroll: false,
             //containment:".tyrano_base",
-            stop: (e, ui) => {
-
-            }
+            stop: (e, ui) => {},
         });
 
-        var j_debug_msg = $("<div style='padding:5px'><input type='text' style='width:320px' /></div>");
+        var j_debug_msg = $(
+            "<div style='padding:5px'><input type='text' style='width:320px' /></div>",
+        );
         var j_copy_button = $("<input type='button' value='コピー' />");
 
         j_copy_button.on("click", (e) => {
-
             evt_mouseup();
 
             j_debug_msg.find("input").select();
             // コピー
             document.execCommand("copy");
-
         });
 
         var j_reset_button = $("<input type='button' value='リセット' />");
         j_reset_button.on("click", (e) => {
-
             //モデルを最初の位置に戻す
             //document.execCommand("copy");
-            model.position.set(original_v.pos.x, original_v.pos.y, original_v.pos.z);
-            model.rotation.set(original_v.rot.x, original_v.rot.y, original_v.rot.z);
-            model.scale.set(original_v.scale.x, original_v.scale.y, original_v.scale.z);
-
+            model.position.set(
+                original_v.pos.x,
+                original_v.pos.y,
+                original_v.pos.z,
+            );
+            model.rotation.set(
+                original_v.rot.x,
+                original_v.rot.y,
+                original_v.rot.z,
+            );
+            model.scale.set(
+                original_v.scale.x,
+                original_v.scale.y,
+                original_v.scale.z,
+            );
         });
 
-
         j_close_button.find("button").on("click", (e) => {
-
             j_three_debug_layer.remove();
 
             if (pm.reset == "true") {
@@ -3309,29 +2957,19 @@ tyrano.plugin.kag.tag["3d_debug"] = {
             three_debug_layer.removeEventListener("mousewheel", evt_mousewheel);
 
             this.kag.ftag.nextOrder();
-
         });
 
         if (pm.menu == "true") {
-
             j_close_button.append("<span>｜</span>");
             j_close_button.append(j_copy_button);
             j_close_button.append(j_reset_button);
 
             j_close_button.append(j_debug_msg);
-
         }
 
         $("body").append(j_close_button);
 
-
         //初期値を設定する。
         evt_mouseup();
-
-
     },
-
-
-
-
 };

--- a/tyrano/plugins/kag/kag.tag_vchat.js
+++ b/tyrano/plugins/kag/kag.tag_vchat.js
@@ -1,6 +1,5 @@
 //スクリプトの評価
 
-
 /*
 TYRANO.kag.stat.tchat = {
             "current_top":0,
@@ -25,7 +24,6 @@ TYRANO.kag.stat.tchat = {
         };
 */
 
-
 /*
  vchat_in
  画面外にバルーンを配置する動作。一般的なタグとしては利用不可。
@@ -34,15 +32,11 @@ TYRANO.kag.stat.tchat = {
 var _vchat_log_count = 0;
 
 tyrano.plugin.kag.tag.vchat_in = {
-
     vital: [],
 
-    pm: {
+    pm: {},
 
-    },
-
-    start: function(pm) {
-
+    start: function (pm) {
         this.kag.layer.hideEventLayer();
 
         var that = this;
@@ -57,9 +51,13 @@ tyrano.plugin.kag.tag.vchat_in = {
 
         var j_area_chat = $("#vchat_base");
 
-        j_area_chat.find(".current_vchat").addClass("talked_vchat").removeClass("current_vchat");
+        j_area_chat
+            .find(".current_vchat")
+            .addClass("talked_vchat")
+            .removeClass("current_vchat");
 
-        var html = '\
+        var html =
+            '\
         <div style="right: 0px; margin-right: 5px;" class="vchat current_vchat ">\
             <div class="v_chat_text vchat-text" style="margin-top: 0px; margin-right: 5px; margin-left: 20px; background-color: rgb(255, 255, 255);">\
                 <h3 class="ribbon20 vchat_chara_name"></h3>\
@@ -99,7 +97,6 @@ tyrano.plugin.kag.tag.vchat_in = {
             /*  "font-family":that.kag.stat.font.face,*/
         });
 
-
         var j_area_chat = $("#vchat_base");
 
         j_area_chat.prepend(j_vchat);
@@ -110,55 +107,33 @@ tyrano.plugin.kag.tag.vchat_in = {
         _vchat_log_count++;
 
         if (_vchat_log_count > this.kag.stat.vchat.max_log_count) {
-
             //最後の１個消す
             $("#vchat_base").find(".vchat:eq(-1)").remove();
-
         }
 
         this.kag.layer.showEventLayer();
 
         return false;
-
-
     },
-
-
-
-
 };
 
-
 tyrano.plugin.kag.tag.vchat_config = {
-
     vital: [],
 
     pm: {
-        chara_name_color: ""
+        chara_name_color: "",
     },
 
-    start: function(pm) {
-
-
+    start: function (pm) {
         if (pm.chara_name_color != "") {
-
             this.kag.stat.vchat.chara_name_color = pm.chara_name_color;
-
         }
 
         this.kag.ftag.nextOrder();
-
-
     },
-
-
-
-
 };
 
-
 tyrano.plugin.kag.tag.vchat_chara = {
-
     vital: ["name"],
 
     pm: {
@@ -166,8 +141,7 @@ tyrano.plugin.kag.tag.vchat_chara = {
         color: "",
     },
 
-    start: function(pm) {
-
+    start: function (pm) {
         //vchatが有効じゃない場合は無視する
         if (!this.kag.stat.vchat.is_active) {
             this.kag.ftag.nextOrder();
@@ -178,7 +152,7 @@ tyrano.plugin.kag.tag.vchat_chara = {
 
         if (!charas[pm.name]) {
             charas[pm.name] = {
-                "color": "",
+                color: "",
             };
         }
 
@@ -187,10 +161,5 @@ tyrano.plugin.kag.tag.vchat_chara = {
         }
 
         this.kag.ftag.nextOrder();
-
     },
-
-
-
-
 };

--- a/tyrano/tyrano.base.js
+++ b/tyrano/tyrano.base.js
@@ -1,36 +1,30 @@
-
 tyrano.base = {
-
     //読み込み対象のモジュール
     tyrano: null,
     modules: [],
-    options: {
+    options: {},
 
-    },
-
-    init: function(tyrano) {
+    init: function (tyrano) {
         this.tyrano = tyrano;
     },
 
-    setBaseSize: function(width, height) {
-
-        this.tyrano.get(".tyrano_base").css("width", width).css("height", height).css("background-color", "black");
-
+    setBaseSize: function (width, height) {
+        this.tyrano
+            .get(".tyrano_base")
+            .css("width", width)
+            .css("height", height)
+            .css("background-color", "black");
     },
 
-    fitBaseSize: function(width, height) {
-
+    fitBaseSize: function (width, height) {
         var that = this;
-        setTimeout(function() {
+        setTimeout(function () {
             that._fitBaseSize(width, height);
         }, 100);
-
     },
 
-
     //画面サイズをぴったりさせます
-    _fitBaseSize: function(width, height) {
-
+    _fitBaseSize: function (width, height) {
         var that = this;
         var view_width = $.getViewPort().width;
         var view_height = $.getViewPort().height;
@@ -46,7 +40,6 @@ tyrano.base = {
 
         //比率を固定にしたい場合は以下　以下のとおりになる
         if (screen_ratio == "fix") {
-
             if (width_f > height_f) {
                 scale_f = height_f;
             } else {
@@ -55,31 +48,42 @@ tyrano.base = {
 
             this.tyrano.kag.tmp.base_scale = scale_f;
 
-            setTimeout(function() {
-
-                var margin_top = document.documentElement.clientHeight - window.innerHeight;
+            setTimeout(function () {
+                var margin_top =
+                    document.documentElement.clientHeight - window.innerHeight;
 
                 //中央寄せなら、画面サイズ分を引く。
-                if (that.tyrano.kag.config["ScreenCentering"] && that.tyrano.kag.config["ScreenCentering"] == "true") {
-
+                if (
+                    that.tyrano.kag.config["ScreenCentering"] &&
+                    that.tyrano.kag.config["ScreenCentering"] == "true"
+                ) {
                     $(".tyrano_base").css("transform-origin", "0 0");
                     $(".tyrano_base").css({
-                        margin: 0
+                        margin: 0,
                     });
 
-                    var width = Math.abs(parseInt(window.innerWidth) - parseInt(that.tyrano.kag.config.scWidth * scale_f)) / 2;
-                    var height = Math.abs(parseInt(window.innerHeight) - parseInt(that.tyrano.kag.config.scHeight * scale_f)) / 2;
+                    var width =
+                        Math.abs(
+                            parseInt(window.innerWidth) -
+                                parseInt(
+                                    that.tyrano.kag.config.scWidth * scale_f,
+                                ),
+                        ) / 2;
+                    var height =
+                        Math.abs(
+                            parseInt(window.innerHeight) -
+                                parseInt(
+                                    that.tyrano.kag.config.scHeight * scale_f,
+                                ),
+                        ) / 2;
 
                     if (width_f > height_f) {
                         $(".tyrano_base").css("margin-left", width + "px");
                         $(".tyrano_base").css("margin-top", margin_top + "px");
                     } else {
-
                         $(".tyrano_base").css("margin-left", "0px");
                         $(".tyrano_base").css("margin-top", height + "px");
-
                     }
-
                 }
 
                 $(".tyrano_base").css("transform", "scale(" + scale_f + ") ");
@@ -90,44 +94,37 @@ tyrano.base = {
                 }
 
                 //vchat形式が有効ならそのエリアも調整する
-                if (that.tyrano.kag.config["vchat"] && that.tyrano.kag.config["vchat"] == "true") {
+                if (
+                    that.tyrano.kag.config["vchat"] &&
+                    that.tyrano.kag.config["vchat"] == "true"
+                ) {
+                    var base_height = Math.round(
+                        parseInt($("#tyrano_base").css("height")) * scale_f,
+                    );
 
-                    var base_height = Math.round(parseInt($("#tyrano_base").css("height")) * scale_f);
-
-                    var vchat_height = (view_height - base_height);
+                    var vchat_height = view_height - base_height;
 
                     $("#vchat_base").css({
                         "margin-top": base_height,
-                        "height": vchat_height
+                        "height": vchat_height,
                     });
-
-
-
                 }
-
-
-
             }, 100);
-
         } else if (screen_ratio == "fit") {
-
             //スクリーンサイズに合わせて自動的に調整される
-            setTimeout(function() {
-                $(".tyrano_base").css("transform", "scaleX(" + width_f + ") scaleY(" + height_f + ")");
+            setTimeout(function () {
+                $(".tyrano_base").css(
+                    "transform",
+                    "scaleX(" + width_f + ") scaleY(" + height_f + ")",
+                );
                 window.scrollTo(width, height);
             }, 100);
-
         } else {
-
             //スクリーンサイズ固定
-
         }
-
-
     },
 
-    test: function() {
+    test: function () {
         //alert("tyrano test");
-    }
-
+    },
 };

--- a/tyrano/tyrano.js
+++ b/tyrano/tyrano.js
@@ -1,37 +1,35 @@
 function object(o) {
-    var f = object.f, i, len, n, prop;
+    var f = object.f,
+        i,
+        len,
+        n,
+        prop;
     f.prototype = o;
-    n = new f;
+    n = new f();
     for (i = 1, len = arguments.length; i < len; ++i)
-        for (prop in arguments[i])
-            n[prop] = arguments[i][prop];
+        for (prop in arguments[i]) n[prop] = arguments[i][prop];
     return n;
 }
 
-object.f = function() { };
+object.f = function () {};
 
 var tyrano = {};
 tyrano.plugin = {};
 
 tyrano.core = {
-
     base: null,
 
     options: {
-
         width: 0,
         height: 0,
-        onComplete: function() { }
-
+        onComplete: function () {},
     },
 
     status: {
-        loaded_plugin: 0
+        loaded_plugin: 0,
     },
 
-
-    init: function(options) {
-
+    init: function (options) {
         var that = this;
 
         this.base = object(tyrano.base);
@@ -39,101 +37,82 @@ tyrano.core = {
 
         this.config = window.config;
 
-
         //スクリプトをロードして、そのオブジェクトを作成
         //alert("wwwww");
         that.loadModule();
-
     },
 
     //プラグインのロード処理
-    loadPlugins: function(array_src, call_back) {
-
+    loadPlugins: function (array_src, call_back) {
         var that = this;
 
         var count_src = 0;
 
         for (var i = 0; i < array_src.length; i++) {
+            $.getScript(
+                "./tyrano/plugins/" + array_src[i] + "/" + array_src[i] + ".js",
+                function () {
+                    count_src++;
 
-            $.getScript("./tyrano/plugins/" + array_src[i] + "/" + array_src[i] + ".js", function() {
-
-                count_src++;
-
-                if (count_src == array_src.length) {
-                    if (call_back) {
-                        call_back(array_src);
+                    if (count_src == array_src.length) {
+                        if (call_back) {
+                            call_back(array_src);
+                        }
                     }
-                }
-            });
-
+                },
+            );
         }
-
     },
 
-    loadModule: function() {
-
+    loadModule: function () {
         var that = this;
         var array_src = ["kag"];
 
         for (var i = 0; i < array_src.length; i++) {
-
             var _name = array_src[i];
             this[_name] = object(tyrano.plugin[_name]);
-            //操作を委譲　
+            //操作を委譲
             this[_name].tyrano = this;
             this[_name].init();
-
         }
 
         this.completeLoad();
-
     },
 
-
     //
-    completeLoad: function() {
-
+    completeLoad: function () {
         //console.log(plugin_name);
 
         //読み込み対象のプラグイン数分実行されたらビルド処理へ
         this.build();
-
-
     },
 
     //ローディング完了、システムを組み上げていきます
-    build: function() {
+    build: function () {},
 
-
-    },
-
-    get: function(mark) {
+    get: function (mark) {
         return $(mark);
     },
 
-    test: function() {
+    test: function () {
         //alert("tyrano test");
-    }
+    },
 };
-
-
 
 var TYRANO = object(tyrano.core);
 window.TYRANO = TYRANO;
 
-if (!('console' in window)) {
-
+if (!("console" in window)) {
     window.console = {};
-    window.console.log = function(str) {
+    window.console.log = function (str) {
         return str;
     };
 }
 
-$(function() {
+$(function () {
     //画面をノベル用に構築していくみたいな
     //yunagi.init();
     //DOM構築完了後の初期化
     //yunagi.init_loaded();
     TYRANO.init();
-
 });

--- a/tyrano/tyrano_player.js
+++ b/tyrano/tyrano_player.js
@@ -1,11 +1,10 @@
-
 //スマートフォン用のaudio オーバーライド
-var Audio = (function() {
+var Audio = (function () {
     // クラス内定数
-    var COUNTRY = 'aaaaa';
+    var COUNTRY = "aaaaa";
 
     // コンストラクタ
-    var Audio = function(storage_url) {
+    var Audio = function (storage_url) {
         if (!(this instanceof Audio)) {
             return new Audio(storage_url);
         }
@@ -16,62 +15,55 @@ var Audio = (function() {
         this.loop = false;
         this.currentTime = 0;
         this.map_event = {}; //コールバックが必要な部分について、イベント登録する。
-
     };
 
     var p = Audio.prototype;
 
     // プロトタイプ内でメソッドを定義
-    p.setName = function(name) {
+    p.setName = function (name) {
         this.name = name;
     };
-    p.getStorageUrl = function() {
+    p.getStorageUrl = function () {
         return this.storage_url;
     };
 
-    p.play = function() {
+    p.play = function () {
         alert("play:" + this.storage_url);
         var obj = {
             action: "play",
             storage: this.storage_url,
             loop: this.loop,
-            volume: this.volume
-
+            volume: this.volume,
         };
         appJsInterface.audio(JSON.stringify(obj));
     };
 
-    p.stop = function() {
+    p.stop = function () {
         alert("stop:" + this.storage_url);
         var obj = {
             action: "stop",
-            storage: this.storage_url
+            storage: this.storage_url,
         };
         appJsInterface.audio(JSON.stringify(obj));
     };
 
-    p.release = function() {
+    p.release = function () {};
 
-    };
-
-    p.pause = function() {
+    p.pause = function () {
         this.stop();
     };
 
     //再生が終わったらcb呼び出し。/////////////////
-    p.onended = function(cb) {
+    p.onended = function (cb) {
         this.map_event["onended"] = cb;
     };
 
-    p.addEventListener = function(event_name, cb) {
+    p.addEventListener = function (event_name, cb) {
         this.map_event[event_name] = cb;
     };
 
     return Audio;
-
 })();
-
-
 
 /*
 var Audio = new Person('太郎', 20);


### PR DESCRIPTION
Prettier周りの更新です。ティラノエンジンの機能変更を**含みません**。
- Prettierの設定ファイルを更新しました。
  - ライブラリ（tyrano/libs/以下）を除く、tyrano/以下のjsファイルが整形対象となります。
- GitHub Actions用の設定ファイルを追加しました。
  - 次のタイミングで、GitHub Actionsによって自動的に整形コミットが追加されるようになりました。
    - masterブランチへのpush時
    - ogihara/devブランチへのpush時
- このPRには、実際にGitHub Actionsによって追加された整形コミットが含まれています。
- GitHub Actionsによって行われる整形と同等の整形をローカルで行なうためには、リポジトリのルートで次のコマンドを叩いてください。（Prettierがグローバルインストールしてある場合）
```bash
prettier --write "tyrano/**/*.js"
```