### PR TITLE
オーディオ周りのバグ修正, 機能追加, 音声プリロードのメモリ圧迫問題の改善提案

### DIFF
--- a/tyrano/plugins/kag/kag.js
+++ b/tyrano/plugins/kag/kag.js
@@ -2416,7 +2416,7 @@ tyrano.plugin.kag = {
 
     /**
      * 再生中のHowlオブジェクトの音量を変更する
-     * @param {Howler} audio_obj
+     * @param {Howl} audio_obj
      * @param {{ tag: number | undefined; config: number | undefined; }} volume_options
      */
     changeHowlVolume: function (audio_obj, options = {}) {

--- a/tyrano/plugins/kag/kag.js
+++ b/tyrano/plugins/kag/kag.js
@@ -1749,7 +1749,7 @@ tyrano.plugin.kag = {
             });
 
             // ロードに失敗したとき
-            audio_obj.once("load", () => {
+            audio_obj.once("loaderror", () => {
                 audio_obj.unload();
                 //that.kag.error("オーディオファイル「"+src+"」が見つかりません。場所はフルパスで指定されていますか？ (例)data/bgm/music.ogg");
                 if (callbk) callbk(audio_obj);
@@ -1761,6 +1761,13 @@ tyrano.plugin.kag = {
 
             // プリロードデータを使い捨てにするかどうか
             audio_obj.__single_use = options.single_use !== undefined ? options.single_use : true;
+
+            // 名前をつけられる
+            const name = options.name || "";
+            const names = name.split(",").map((item) => {
+                return item.trim();
+            });
+            audio_obj.__names = names;
 
             // ロード開始
             audio_obj.load();

--- a/tyrano/plugins/kag/kag.layer.js
+++ b/tyrano/plugins/kag/kag.layer.js
@@ -163,6 +163,9 @@ tyrano.plugin.kag.layer = {
 
         this.kag.stat.is_hide_message = true;
 
+        // ティラノイベント"messagewindow:hide"を発火
+        this.kag.trigger("messagewindow:hide");
+
         var num_message_layer = parseInt(this.kag.config.numMessageLayers);
 
         for (var i = 0; i < num_message_layer; i++) {
@@ -176,6 +179,9 @@ tyrano.plugin.kag.layer = {
     //メッセージレイヤの表示
     showMessageLayers: function () {
         this.kag.stat.is_hide_message = false;
+
+        // ティラノイベント"messagewindow:show"を発火
+        this.kag.trigger("messagewindow:show");
 
         var num_message_layer = parseInt(this.kag.config.numMessageLayers);
 

--- a/tyrano/plugins/kag/kag.menu.js
+++ b/tyrano/plugins/kag/kag.menu.js
@@ -721,8 +721,34 @@ tyrano.plugin.kag.menu = {
             }
         }
 
-        //layerの復元
-        //console.log(data.layer);
+        // BGMを引き継がないタイプのロード(通常のロード)の場合、
+        // いま再生されているすべてのBGMとSEを止める
+        if (options.bgm_over == "false") {
+            // 全BGM停止
+            var map_bgm = this.kag.tmp.map_bgm;
+            for (var key in map_bgm) {
+                this.kag.ftag.startTag("stopbgm", {
+                    stop: "true",
+                    buf: key,
+                });
+            }
+
+            // 全SE停止
+            var map_se = this.kag.tmp.map_se;
+            for (var key in map_se) {
+                if (map_se[key]) {
+                    this.kag.ftag.startTag("stopse", {
+                        stop: "true",
+                        buf: key,
+                    });
+                }
+            }
+        }
+
+        //
+        // レイヤー構造(DOM)の復元
+        //
+
         this.kag.layer.setLayerHtml(data.layer);
 
         // グラデーションテキストの復元
@@ -732,7 +758,10 @@ tyrano.plugin.kag.menu = {
         //awakegame考慮もれ。一旦戻す
         //this.kag.variable.tf.system.backlog = [];
 
-        //ステータスの設定、ディープに設定する
+        //
+        // ステータスの更新
+        //
+
         this.kag.stat = data.stat;
 
         //ステータスがストロングストップの場合
@@ -746,30 +775,11 @@ tyrano.plugin.kag.menu = {
         //タイトルの復元
         this.kag.setTitle(this.kag.stat.title);
 
-        //一旦音楽と効果音は全て止めないと
-
-        //BGMを引き継ぐかどうか。
+        // BGMを引き継がないタイプのロード(通常のロード)の場合、
+        // さっきすべてのBGMとSEを止めてしまったから、
+        // 現在のステータスに記憶されているBGMとループSEを改めて再生する
         if (options.bgm_over == "false") {
-            //全BGMを一旦止める
-            var map_se = this.kag.tmp.map_se;
-            for (var key in map_se) {
-                if (map_se[key]) {
-                    this.kag.ftag.startTag("stopse", {
-                        stop: "true",
-                        buf: key,
-                    });
-                }
-            }
-
-            var map_bgm = this.kag.tmp.map_bgm;
-            for (var key in map_bgm) {
-                this.kag.ftag.startTag("stopbgm", {
-                    stop: "true",
-                    buf: key,
-                });
-            }
-
-            //音楽再生
+            // BGM
             if (this.kag.stat.current_bgm != "") {
                 var mstorage = this.kag.stat.current_bgm;
 
@@ -777,8 +787,6 @@ tyrano.plugin.kag.menu = {
                     loop: "true",
                     storage: mstorage,
                     html5: this.kag.stat.current_bgm_html5,
-                    /*fadein:"true",*/
-                    /*time:2000,*/
                     stop: "true",
                     can_ignore: "false",
                 };
@@ -791,7 +799,7 @@ tyrano.plugin.kag.menu = {
                 this.kag.ftag.startTag("playbgm", pm);
             }
 
-            //効果音再生
+            // ループSE
             for (const key in this.kag.stat.current_se) {
                 var pm_obj = this.kag.stat.current_se[key];
                 pm_obj.can_ignore = "false";

--- a/tyrano/plugins/kag/kag.menu.js
+++ b/tyrano/plugins/kag/kag.menu.js
@@ -694,6 +694,9 @@ tyrano.plugin.kag.menu = {
         // ティラノイベント"load:start"を発火
         this.kag.trigger("load:start");
 
+        // 一時リスナをすべて消去
+        this.kag.offTempListeners();
+
         var auto_next = "no";
 
         //普通のロードの場合

--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -1690,8 +1690,26 @@ tyrano.plugin.kag.tag.text = {
      * 文字の追加を終えて次のタグに進む
      */
     finishAddingChars: function () {
+        // もう追加しおわった
         this.kag.stat.is_adding_text = false;
-        if (!this.kag.stat.is_hide_message) {
+
+        // いまメッセージウィンドウがユーザー操作によって非表示にされているかどうか
+        if (this.kag.stat.is_hide_message) {
+            // メッセージの表示途中でユーザーが右クリックしてメッセージウィンドウを消しおった！
+            // 次のタグ ([text]か[l]か[p]か[font]か…etc) には進ませない
+            // 次にユーザーがメッセージウィンドウを表示したときに一度だけ nextOrder を走らせる
+            this.kag.once(
+                "messagewindow:show",
+                () => {
+                    this.kag.ftag.nextOrder();
+                },
+                {
+                    is_temp: true, // これはセーブデータロード時に削除すべきリスナ
+                    is_system: true, // これはシステムが利用するリスナ
+                },
+            );
+        } else {
+            // ふつうにメッセージウィンドウが表示されている
             this.kag.ftag.nextOrder();
         }
     },

--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -1691,7 +1691,7 @@ tyrano.plugin.kag.tag.text = {
      */
     finishAddingChars: function () {
         this.kag.stat.is_adding_text = false;
-        if (this.kag.stat.is_stop != "true" && !this.kag.stat.is_hide_message) {
+        if (!this.kag.stat.is_hide_message) {
             this.kag.ftag.nextOrder();
         }
     },
@@ -1737,18 +1737,15 @@ tyrano.plugin.kag.tag.text = {
         // - [nowait]中である
         // - 1文字あたりの表示時間が 3 ミリ秒以下である
         if (this.kag.stat.is_skip === true || this.kag.stat.is_nowait || ch_speed <= 3) {
-            // ストップ中じゃなければ
-            if (this.kag.stat.is_stop != "true") {
-                // 全文字表示
-                this.makeAllCharsVisible(j_char_span_children);
-                // スキップ時間のタイムアウトを設ける
-                $.setTimeout(() => {
-                    // メッセージウィンドウが隠れていなければ次のタグへ
-                    if (!this.kag.stat.is_hide_message) {
-                        this.kag.ftag.nextOrder();
-                    }
-                }, parseInt(this.kag.config.skipSpeed));
-            }
+            // 全文字表示
+            this.makeAllCharsVisible(j_char_span_children);
+            // スキップ時間のタイムアウトを設ける
+            $.setTimeout(() => {
+                // メッセージウィンドウが隠れていなければ次のタグへ
+                if (!this.kag.stat.is_hide_message) {
+                    this.kag.ftag.nextOrder();
+                }
+            }, parseInt(this.kag.config.skipSpeed));
             return;
         }
 

--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -186,8 +186,6 @@ tyrano.plugin.kag.tag.playbgm = {
     },
 
     play: function (pm) {
-        this.kag.layer.hideEventLayer();
-
         // 再生しようとしているのはSEか？(BGMではなく)
         const is_se = pm.target === "se";
 
@@ -210,6 +208,10 @@ tyrano.plugin.kag.tag.playbgm = {
 
         // 次のタグに進むべきか
         const should_next_order = pm.stop === "false";
+
+        if (should_next_order) {
+            this.kag.layer.hideEventLayer();
+        }
 
         // 音声タイプ "bgm" or "sound"
         let sound_type = is_se ? "sound" : "bgm";
@@ -925,8 +927,6 @@ tyrano.plugin.kag.tag.playse = {
     },
 
     start: function (pm) {
-        this.kag.layer.hideEventLayer();
-
         if (pm.clear == "true") {
             this.kag.ftag.startTag("stopbgm", {
                 target: "se",

--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -170,10 +170,11 @@ tyrano.plugin.kag.tag.playbgm = {
             seconds_str = colon_hash[colon_hash.length - 1];
         }
 
+        // 小数点が存在するならミリ秒として解釈する
         const dot_hash = seconds_str.split(".");
         if (dot_hash[1]) {
             seconds_str = dot_hash[0];
-            milli_seconds_str = dot_hash[1];
+            milli_seconds_str = dot_hash[1].padEnd(3, "0").substring(0, 3);
         }
 
         const hours_ms = (parseInt(hours_str) || 0) * 1000 * 60 * 60;

--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -1466,6 +1466,162 @@ tyrano.plugin.kag.tag.changevol = {
 };
 
 /*
+#[pausebgm]
+
+:group
+オーディオ関連
+
+:title
+再生中のBGMの一時停止
+
+:exp
+現在再生中のBGMを一時停止できます。
+
+:sample
+
+:param
+buf    = スロットを指定できます。省略すると、全スロットの音声に対して処理が実行されます。,
+
+#[end]
+*/
+
+tyrano.plugin.kag.tag.pausebgm = {
+    pm: {
+        target: "bgm",
+        buf: "",
+        next: "true",
+    },
+
+    start: function (pm) {
+        // next="false"でないときだけ次に進む
+        const next = () => {
+            if (pm.next !== "false") {
+                this.kag.ftag.nextOrder();
+            }
+        };
+
+        // 操作対象のオーディオについて
+        const target_dict = this.kag.getTag("changevol").obtainTargets(pm.target, pm.buf);
+        for (const buf in target_dict) {
+            const audio_obj = target_dict[buf];
+            audio_obj.pause();
+        }
+
+        next();
+    },
+};
+
+/*
+#[resumebgm]
+
+:group
+オーディオ関連
+
+:title
+一時停止中のオーディオの再開
+
+:exp
+一時停止中のオーディオを再開できます。
+
+:sample
+
+:param
+buf    = スロットを指定できます。省略すると、全スロットの音声に対して処理が実行されます。,
+
+#[end]
+*/
+
+tyrano.plugin.kag.tag.resumebgm = {
+    pm: {
+        target: "bgm",
+        buf: "",
+        next: "true",
+    },
+
+    start: function (pm) {
+        // next="false"でないときだけ次に進む
+        const next = () => {
+            if (pm.next !== "false") {
+                this.kag.ftag.nextOrder();
+            }
+        };
+
+        // 操作対象のオーディオについて
+        const target_dict = this.kag.getTag("changevol").obtainTargets(pm.target, pm.buf);
+        for (const buf in target_dict) {
+            const audio_obj = target_dict[buf];
+            audio_obj.play();
+        }
+
+        next();
+    },
+};
+
+/*
+#[pausese]
+
+:group
+オーディオ関連
+
+:title
+再生中のSEの一時停止
+
+:exp
+現在再生中のSEを一時停止できます。
+
+:sample
+
+:param
+buf    = スロットを指定できます。省略すると、全スロットの音声に対して処理が実行されます。,
+
+#[end]
+*/
+
+tyrano.plugin.kag.tag.pausese = {
+    pm: {
+        target: "se",
+        buf: "",
+        next: "true",
+    },
+
+    start: function (pm) {
+        this.kag.getTag("pausebgm").start(pm);
+    },
+};
+
+/*
+#[resumese]
+
+:group
+オーディオ関連
+
+:title
+一時停止中のSEの再開
+
+:exp
+一時停止中のSEを再開できます。
+
+:sample
+
+:param
+buf    = スロットを指定できます。省略すると、全スロットの音声に対して処理が実行されます。,
+
+#[end]
+*/
+
+tyrano.plugin.kag.tag.resumese = {
+    pm: {
+        target: "se",
+        buf: "",
+        next: "true",
+    },
+
+    start: function (pm) {
+        this.kag.getTag("resumebgm").start(pm);
+    },
+};
+
+/*
 #[wbgm]
 
 :group


### PR DESCRIPTION
- メッセージ周りの挙動を調整しました。
- ループSEがロード時に復元されない問題を修正しました。
- プリロードした音声データは基本的に**使い捨て**とし、1回再生したら破棄する仕様に変更してみました。
  - ただし`[preload single_use="false"]`で読み込むことで、使い捨てではなく恒久的に保持するようにできます。
- プリロードした音声データを破棄するための`[unload]`タグを実装しました。
  - ただし`[unload]`タグを実行した直後にメモリが解放されるわけではなく、ブラウザのGCを待たねばなりません。（Electronは不明ですが、少なくとも通常のブラウザでJavaScriptから強制的にGCを呼び出す手段はないようです）
- 再生中のオーディオの音量変更・一時停止・再開用のタグを実装しました。