### PR TITLE
セーブデータのサムネ画像のサイズを変更できるようにする。

### DIFF
--- a/data/system/Config.tjs
+++ b/data/system/Config.tjs
@@ -152,10 +152,14 @@
 ;configThumbnail    = true;
 
 // サムネイル画像を使用する場合の画質を指定できます。
-// ブラウザといったローカルストレージを使用する場合は low か middle がおすすめです。
+// WebStorage領域を使用する場合は low か middle がおすすめです。
 // low:最低画質(jpeg)　middle:中画質(jpeg)  high:最高画質(png)
 ;configThumbnailQuality = middle ;
 
+// サムネイル画像を使用する場合の画像サイズを指定できます。
+// WebStorage領域を使用する場合は 数字を小さくしてセーブデータの容量を少なくするのがおすすめです。
+// 0.01 ～ 1.0 (画面サイズそのまま)
+;configThumbnailScale = 0.125;
 
 // セーブスロットの数を指定できます。
 // ただし、configSaveの形式がwebstorageの場合、５個程度に抑えておかないと容量不足でセーブできなくなる可能性があります。

--- a/tyrano/plugins/kag/kag.menu.js
+++ b/tyrano/plugins/kag/kag.menu.js
@@ -429,6 +429,10 @@ tyrano.plugin.kag.menu = {
                 call_back();
             }
         } else {
+            var thumb_scale = this.kag.config.configThumbnailScale || 1;
+            if (thumb_scale < 0.01) thumb_scale = 0.01;
+            if (thumb_scale > 1) thumb_scale = 1;
+
             $("#tyrano_base").find(".layer_blend_mode").css("display", "none");
 
             setTimeout(function () {
@@ -460,11 +464,11 @@ tyrano.plugin.kag.menu = {
                     img.src = _stat.save_img;
                     img.onload = function () {
                         var canvas = document.createElement("canvas");
-                        canvas.width = that.kag.config.scWidth;
-                        canvas.height = that.kag.config.scHeight;
+                        canvas.width = that.kag.config.scWidth * thumb_scale;
+                        canvas.height = that.kag.config.scHeight * thumb_scale;
                         // Draw Image
                         var ctx = canvas.getContext("2d");
-                        ctx.drawImage(img, 0, 0);
+                        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
                         // To Base64
                         var img_code = that.createImgCode(canvas);
 
@@ -537,7 +541,7 @@ tyrano.plugin.kag.menu = {
                     tmp_base.find(".layer_menu").hide();
 
                     var opt = {
-                        scale: 1,
+                        scale: thumb_scale,
                         height: that.kag.config.scHeight,
                         width: that.kag.config.scWidth,
                     };


### PR DESCRIPTION
多くの場合、セーブデータ上のサムネ画像は画面サイズである必要はないと思いますので
サイズを指定するオプションを追加しました。