### PR TITLE
v515beta7 の不具合修正: [link] [glink] [dialog] 周り

### DIFF
--- a/data/scenario/replay.ks
+++ b/data/scenario/replay.ks
@@ -51,7 +51,7 @@
 [freeimage layer=1]
 
 [iscript]
-tf.flag_replay = false;
+tf.system.flag_replay = false;
 [endscript]
 
 @jump storage=title.ks
@@ -69,7 +69,7 @@ tf.flag_replay = false;
 [cm]
 
 [iscript]
-    tf.flag_replay = true;
+    tf.system.flag_replay = true;
 [endscript]
 
 [free layer=1 name="label_replay"]

--- a/data/scenario/tyrano.ks
+++ b/data/scenario/tyrano.ks
@@ -168,7 +168,7 @@ tf.savetext = "<span style='font-size:10px'>"+tf.save_date+"</span><br />"+tf.ti
 
 [macro name="endreplay"]
 
-    [if exp="tf.flag_replay == true"]
+    [if exp="tf.system.flag_replay == true"]
         
         @layopt page="fore" layer="message0" visible=false
         ;システムボタンを非表示にするなど

--- a/release/master_tyrano/data/scenario/replay.ks
+++ b/release/master_tyrano/data/scenario/replay.ks
@@ -51,7 +51,7 @@
 [freeimage layer=1]
 
 [iscript]
-tf.flag_replay = false;
+tf.system.flag_replay = false;
 [endscript]
 
 @jump storage=title.ks
@@ -69,7 +69,7 @@ tf.flag_replay = false;
 [cm]
 
 [iscript]
-    tf.flag_replay = true;
+    tf.system.flag_replay = true;
 [endscript]
 
 [free layer=1 name="label_replay"]

--- a/release/master_tyrano/data/scenario/tyrano.ks
+++ b/release/master_tyrano/data/scenario/tyrano.ks
@@ -168,7 +168,7 @@ tf.savetext = "<span style='font-size:10px'>"+tf.save_date+"</span><br />"+tf.ti
 
 [macro name="endreplay"]
 
-    [if exp="tf.flag_replay == true"]
+    [if exp="tf.system.flag_replay == true"]
         
         @layopt page="fore" layer="message0" visible=false
         ;システムボタンを非表示にするなど

--- a/tyrano/libs.js
+++ b/tyrano/libs.js
@@ -1169,8 +1169,12 @@
             j_event.setStyle("pointer-events", "auto");
         });
 
-        // アラート: クローズ時の処理
+        //
+        // ボタンのクリックイベント
+        //
+
         if (options.type === "alert") {
+            // アラート: クローズ時の処理
             $(document).on("closed", ".remodal", () => {
                 close_common();
                 $.removeRemodalEvents(false);
@@ -1178,24 +1182,29 @@
                     options.on_ok();
                 }
             });
-            return;
         }
 
-        // コンファーム: OK 時の処理
-        $(document).on("confirmation", ".remodal", () => {
-            close_common();
-            if (typeof options.on_ok === "function") {
-                options.on_ok();
-            }
-        });
+        if (options.type === "confirm") {
+            // コンファーム: OK 時の処理
+            $(document).on("confirmation", ".remodal", () => {
+                close_common();
+                if (typeof options.on_ok === "function") {
+                    options.on_ok();
+                }
+            });
 
-        // コンファーム: Cancel 時の処理
-        $(document).on("cancellation", ".remodal", () => {
-            close_common();
-            if (typeof options.on_cancel === "function") {
-                options.on_cancel();
-            }
-        });
+            // コンファーム: Cancel 時の処理
+            $(document).on("cancellation", ".remodal", () => {
+                close_common();
+                if (typeof options.on_cancel === "function") {
+                    options.on_cancel();
+                }
+            });
+        }
+
+        //
+        // オープンアニメーション
+        //
 
         if (TYRANO.kag.tmp.remodal_opening_effect_time !== undefined) {
             j_anim.setStyleMap({ "animation-duration": TYRANO.kag.tmp.remodal_opening_effect_time }, "webkit");

--- a/tyrano/plugins/kag/kag.event.js
+++ b/tyrano/plugins/kag/kag.event.js
@@ -26,7 +26,7 @@ tyrano.plugin.kag.event = {
      * ロードで復元されないようにする
      * @param {jQuery} j_obj
      */
-    removeEventElement: function (j_obj) {
+    removeEventAttr: function (j_obj) {
         j_obj
             .removeClass("event-setting-element")
             .removeAttr("data-event-target")

--- a/tyrano/plugins/kag/kag.key_mouse.js
+++ b/tyrano/plugins/kag/kag.key_mouse.js
@@ -113,7 +113,7 @@ tyrano.plugin.kag.key_mouse = {
             // * ホールドアクションの予約
             //
 
-            document.addEventListener(
+            this.j_event_layer[0].addEventListener(
                 "touchstart",
                 (e) => {
                     if (e.changedTouches && e.changedTouches[0]) {
@@ -133,7 +133,7 @@ tyrano.plugin.kag.key_mouse = {
                         }
                     }, this.HOLD_TIMEOUT);
                 },
-                { capture: true },
+                { capture: false },
             );
 
             //
@@ -159,7 +159,7 @@ tyrano.plugin.kag.key_mouse = {
                         this.prev_point.y = y;
                     }
                 },
-                { capture: true },
+                { capture: false },
             );
 
             //
@@ -170,7 +170,7 @@ tyrano.plugin.kag.key_mouse = {
             // * ダブルタップの e.preventDefault()
             //
 
-            document.addEventListener(
+            this.j_event_layer[0].addEventListener(
                 "touchend",
                 (e) => {
                     clearTimeout(this.hold_timer_id);
@@ -252,7 +252,7 @@ tyrano.plugin.kag.key_mouse = {
                     this.previous_touchend_time = now;
                     this.touch_position = pos;
                 },
-                { capture: true, passive: false },
+                { capture: false, passive: false },
             );
         }
 

--- a/tyrano/plugins/kag/kag.layer.js
+++ b/tyrano/plugins/kag/kag.layer.js
@@ -520,7 +520,7 @@ tyrano.plugin.kag.layer = {
     cancelAllFreeLayerButtonsEvents: function () {
         const that = this;
         const j_buttons = this.layer_free.find(".event-setting-element");
-        this.kag.event.removeEventElement(j_buttons);
+        this.kag.event.removeEventAttr(j_buttons);
         j_buttons.off("click mouseenter mouseleave mousedown touchstart");
         this.kag.makeUnfocusable(j_buttons);
     },

--- a/tyrano/plugins/kag/kag.menu.js
+++ b/tyrano/plugins/kag/kag.menu.js
@@ -1012,6 +1012,9 @@ tyrano.plugin.kag.menu = {
         //フォーカスの復元
         this.kag.restoreFocusable();
 
+        //クリック待ちグリフの復元
+        this.kag.ftag.restoreNextImg();
+
         //メニューボタンの状態
         if (this.kag.stat.visible_menu_button == true) {
             $(".button_menu").show();

--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -4241,6 +4241,7 @@ tyrano.plugin.kag.tag.link = {
         target: null,
         storage: null,
         keyfocus: "",
+        once: "true",
     },
 
     start: function (pm) {
@@ -4280,19 +4281,14 @@ tyrano.plugin.kag.tag.link = {
         // クリックされたかどうか
         var clicked = false;
 
+        const once = pm.once !== "false";
+
+        // mousedown イベントを親要素に貫通させない
         j_span.on("mousedown", () => {
             return false;
         });
 
-        j_span.bind("click touchstart", function (e) {
-            // クリック済みなら反応しない
-            if (clicked) {
-                return;
-            }
-
-            // クリック済み
-            clicked = true;
-
+        j_span.on("click", (e) => {
             // ブラウザの音声の再生制限を解除
             if (!that.kag.tmp.ready_audio) that.kag.readyAudio();
 
@@ -4306,9 +4302,29 @@ tyrano.plugin.kag.tag.link = {
                 return false;
             }
 
+            // クリック済みなら反応しない
+            if (clicked && once) {
+                return;
+            }
+
             //
             // クリックが有効だったときの処理
             //
+
+            // クリック済み
+            clicked = true;
+
+            // いま存在する once タイプの [link] 要素をクリックできなくする
+            $("[data-event-tag=link]").each((i, elm) => {
+                const j_elm = $(elm);
+                const pm = JSON.parse(j_elm.attr("data-event-pm"));
+                const once = pm.once !== "false";
+                if (once) {
+                    j_elm.off("click");
+                    j_elm.setStyle("cursor", "auto");
+                    this.kag.event.removeEventAttr(j_elm);
+                }
+            });
 
             // 仮想マウスカーソルを消去
             that.kag.key_mouse.vmouse.hide();

--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -6848,7 +6848,8 @@ tyrano.plugin.kag.tag.glink = {
     },
 
     setEvent: function (j_button, pm) {
-        let button_clicked = false;
+        let button_clicked = false; // ボタンがクリックされたか
+        const use_cm = pm.cm !== "false"; // クリック時に[cm]を使用するか。cm="false" が指定されていないなら true
 
         //
         // ホバーイベント
@@ -6896,8 +6897,9 @@ tyrano.plugin.kag.tag.glink = {
             // [s]または[wait]に到達していないときは無効
             if (!this.kag.stat.is_strong_stop) return false;
 
-            // 1度クリックしたボタンも無効
-            if (button_clicked) return false;
+            // 1度クリックした cm="true" なボタンは無効
+            if (button_clicked && use_cm) return false;
+            // ※ cm="false" なボタンは何度でもクリックできるようにする
 
             //
             // クリックが有効だったときの処理
@@ -6930,13 +6932,14 @@ tyrano.plugin.kag.tag.glink = {
             // [cm]+[jump]を実行する関数
             const next = () => {
                 // [cm]を実行するかどうか
-                if (pm.cm === "true") {
+                if (use_cm) {
                     // [cm]の実行
                     this.kag.ftag.startTag("cm", { next: "false" });
                 } else {
                     // [cm]を実行しない場合はボタンが残り続ける
                     // 念のため、すべてのボタンのマウス系イベントを解除しておこう
-                    this.kag.layer.cancelAllFreeLayerButtonsEvents();
+                    // this.kag.layer.cancelAllFreeLayerButtonsEvents();
+                    // cm="false" なボタンは何度でもクリックできるようにしたいためコメントアウト
                 }
 
                 // [jump]の実行

--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -4258,11 +4258,22 @@ tyrano.plugin.kag.tag.link = {
         var _storage = pm.storage;
         var that = TYRANO;
 
+        // クリックされたかどうか
+        var clicked = false;
+
         j_span.on("mousedown", () => {
             return false;
         });
 
         j_span.bind("click touchstart", function (e) {
+            // クリック済みなら反応しない
+            if (clicked) {
+                return;
+            }
+
+            // クリック済み
+            clicked = true;
+
             // ブラウザの音声の再生制限を解除
             if (!that.kag.tmp.ready_audio) that.kag.readyAudio();
 

--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -6250,6 +6250,9 @@ tyrano.plugin.kag.tag.button = {
         // [call]スタックが存在するか
         const exists_call_stack = !!that.kag.getStack("call");
 
+        // preexp をこの時点で評価
+        const preexp = this.kag.embScript(pm.preexp);
+
         //
         // ホバーイベント
         //
@@ -6366,7 +6369,7 @@ tyrano.plugin.kag.tag.button = {
             if (pm.clickse) this.kag.playSound(pm.clickse);
 
             // JSの実行
-            if (pm.exp) this.kag.embScript(pm.exp, this.kag.embScript(pm.preexp));
+            if (pm.exp) this.kag.embScript(pm.exp, preexp);
 
             // セーブスナップの取得
             if (pm.savesnap === "true") that.kag.menu.snapSave(that.kag.stat.current_save_str);
@@ -6864,8 +6867,14 @@ tyrano.plugin.kag.tag.glink = {
     },
 
     setEvent: function (j_button, pm) {
-        let button_clicked = false; // ボタンがクリックされたか
-        const use_cm = pm.cm !== "false"; // クリック時に[cm]を使用するか。cm="false" が指定されていないなら true
+        // ボタンがクリックされたか
+        let button_clicked = false;
+
+        // クリック時に[cm]を使用するか。cm="false" が指定されていないなら true
+        const use_cm = pm.cm !== "false";
+
+        // preexp をこの時点で評価
+        const preexp = this.kag.embScript(pm.preexp);
 
         //
         // ホバーイベント
@@ -6943,7 +6952,7 @@ tyrano.plugin.kag.tag.glink = {
             if (pm.clickse) this.kag.playSound(pm.clickse);
 
             // JSの実行
-            if (pm.exp) this.kag.embScript(pm.exp, this.kag.embScript(pm.preexp));
+            if (pm.exp) this.kag.embScript(pm.exp, preexp);
 
             // [cm]+[jump]を実行する関数
             const next = () => {

--- a/tyrano/plugins/kag/kag.tag_ext.js
+++ b/tyrano/plugins/kag/kag.tag_ext.js
@@ -695,6 +695,7 @@ tyrano.plugin.kag.tag.skipstart = {
             return false;
         }
         this.kag.setSkip(true, pm);
+        this.kag.ftag.hideNextImg();
         this.kag.ftag.nextOrder();
     },
 };
@@ -772,6 +773,7 @@ tyrano.plugin.kag.tag.autostart = {
 
         //[p][l] の処理に、オート判定が入ってます
         this.kag.setAuto(true);
+        this.kag.ftag.hideNextImg();
         this.kag.ftag.nextOrder();
     },
 };


### PR DESCRIPTION
- **[glink] に cm="false" を指定した場合に、[s] に到達するたびに何度でもクリックできる仕様に回帰**。
---
- **[dialog] に type="alert" を指定した場合にゲームが停止する不具合を修正**。
---
- `[link] のジャンプ先に [cm] が記述してあり、タップした瞬間即座に [link] テキストが削除される`ようなスクリプトにおいて、**[link] テキストをタップしたときにキーコンフィグの「ホールド」に割り当てているアクションが起動してしまう問題を修正**。
  - `touchstart イベントハンドラ内で touchstart 対象の要素を除去すると、touchend イベントがドキュメント上のどの要素に対しても発生しなくなる`仕様が存在し、それが原因だった。
    - touchstart でホールドアクションを予約（setTimeout）し、touchend でホールドアクションの予約を破棄（clearTimeout）する実装になっている。その「破棄」が正常に処理されなくなっていたということ。
  - document 要素に capture: true でハンドラをセットしていた部分を、イベントレイヤに capture: false でハンドラをセットする仕様に変える（というかこれが従来の仕様）ことで応急処置とした。
    - document 要素に capture: true でハンドラをセットしていたのには「画面全体のタッチイベントを確実に拾ってキーコンを実行させたい」という意図があったが、危険な変更だった。
---
- [link] タップ時に click と touchstart がどちらも処理される可能性があった部分を修正。
  - clicked フラグを用意し、イベントハンドラが実質1度しか処理されないように修正。
---
- **[link] に click と touchstart イベントハンドラを両方セットしていたが、click のみに変更**。以下のデバイスで動作確認済み。
  - [x] iPhone × Safari
  - [x] iPhone × Chrome
  - [x] Android × Chrome
---
- `[link] のジャンプ先に [cm] が記述されておらず、引き続きテキストを挿入し続ける`ようなスクリプトにおいて、古い [link] が残ったまま再び [s] に到達した際に古い [link] テキストが再度クリックできる仕様があったが、これを修正。**[link] テキストをクリックした時点で画面上に存在する [link] テキストのイベントを取り外す仕様**になった。
  - [link] に once="false" を指定するとこの処理を回避できる。つまり、[s] に到達したときに再びクリックできるようになる。