### PR TITLE
音声周りのバグ修正

### DIFF
--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -726,8 +726,9 @@ tyrano.plugin.kag.tag.stopbgm = {
                 continue;
             }
 
-            // Howlオブジェクトの参照を取得
+            // Howlオブジェクトの参照を取得し、マップからは削除
             const audio_obj = target_map[key];
+            delete target_map[key];
 
             // Howlオブジェクトが取れなければスルー
             if (!audio_obj) {
@@ -913,8 +914,8 @@ tyrano.plugin.kag.tag.xchgbgm = {
         }
 
         // このbufで再生中のBGMがある場合
-        let audio_obj;
-        if ((audio_obj = this.kag.tmp.map_bgm[pm.buf]) && audio_obj.playing()) {
+        const audio_obj = this.kag.tmp.map_bgm[pm.buf];
+        if (audio_obj && audio_obj.playing()) {
             // フェードアウト完了イベントリスナを登録する関数
             const bind_fade_complete_listener = () => {
                 audio_obj.once("fade", () => {

--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -1175,11 +1175,11 @@ tyrano.plugin.kag.tag.bgmopt = {
         // スロットが指定されているかどうかで場合分け
         if (pm.buf) {
             // スロットが指定されている場合
-            if (pm.volume) this.kag.stat.map_bgm_volume[pm.buf] = pm.volume;
+            if (pm.volume !== "") this.kag.stat.map_bgm_volume[pm.buf] = pm.volume;
             config_volume = this.kag.stat.map_bgm_volume[pm.buf];
         } else {
             // スロットが指定されていない場合は個別設定を初期化してから代入
-            if (pm.volume) {
+            if (pm.volume !== "") {
                 this.kag.stat.map_bgm_volume = {};
                 this.kag.config.defaultBgmVolume = pm.volume;
             }
@@ -1284,11 +1284,11 @@ tyrano.plugin.kag.tag.seopt = {
         // スロットが指定されているかどうかで場合分け
         if (pm.buf) {
             // スロットが指定されている場合
-            if (pm.volume) this.kag.stat.map_se_volume[pm.buf] = pm.volume;
+            if (pm.volume !== "") this.kag.stat.map_se_volume[pm.buf] = pm.volume;
             config_volume = this.kag.stat.map_se_volume[pm.buf];
         } else {
             // スロットが指定されていない場合は個別設定を初期化してから代入
-            if (pm.volume) {
+            if (pm.volume !== "") {
                 this.kag.stat.map_se_volume = {};
                 this.kag.config.defaultSeVolume = pm.volume;
             }


### PR DESCRIPTION
#### コンフィグ画面のBGM/SEのミュートボタンが利かない問題を修正

- 数値型の`0`を volume パラメータとして渡した場合に、`0`が falsy であるため`if (pm.volume) { ... }`という if 文によってあたかもボリュームが指定されていないかのように解釈されていたことが原因だった。
- `if (pm.volume !== "") { ... }`に変更して解決した。

#### `[stopbgm]`後に同一の音声を`[playbgm restart=false]`すると無視される問題を修正

- `[stopbgm]`時に`kag.tmp.map_bgm[buf]`を delete して**いなかった**ため、`[playbgm]`中の「同一の音声がいま再生されているか」の判定が正しく動作していなかったことが原因だった。
- `[stopbgm]`時に`kag.tmp.map_bgm[buf]`を delete することで解決した。
- 別のアプローチとして、`[playbgm]`における「同一の音声がいま再生されているか」の判定時に`kag.tmp.map_bgm[buf]`が`Howl`オブジェクトである場合`playing()`メソッドを呼んで再生状態をチェックする、という手法もあると思われたが、今回は見送った。