### PR TITLE
fix: 同時に複数の効果音を鳴らした場合に`[wse]`が先に終わった効果音に反応する問題を修正

### DIFF
--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -523,8 +523,26 @@ tyrano.plugin.kag.tag.playbgm = {
                         // 状態次第で nextOrder
                         if (this.kag.tmp.is_se_play_wait == true) {
                             // [wse]に到達してSEの再生終了を待っている状態だったら nextOrder
-                            this.kag.tmp.is_se_play_wait = false;
-                            this.kag.ftag.nextOrder();
+                            // …したいのはやまやまだが、その前に
+                            // これ以外の効果音が同時に再生されていないかをチェックする必要がある
+
+                            // SEマップを走査してほかに再生中の効果音がないかどうかをチェック
+                            // ただしループSE（環境音などが想定される）は除外する必要がある
+                            let is_sound_playing = false;
+                            for (const key in this.kag.tmp.map_se) {
+                                const howl = this.kag.tmp.map_se[key];
+                                if (!howl._loop) {
+                                    if (howl.playing()) {
+                                        is_sound_playing = true;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if (!is_sound_playing) {
+                                this.kag.tmp.is_se_play_wait = false;
+                                this.kag.ftag.nextOrder();
+                            }
                         } else if (this.kag.tmp.is_vo_play_wait == true) {
                             // オートモード中に[l]や[p]に到達してボイスの再生終了を待っている状態だったら
                             // この音声がボイスである場合にのみ nextOrder


### PR DESCRIPTION
## 問題

```
[playse] // 効果音A (1秒)
[playse] // 効果音B (2秒)
[wse] // 効果音A+Bを同時に再生してその完了を待つ
```

- このようなタグを配置をした場合に、先に効果音Aの再生を完了したタイミングで[wse]を突破してしまう（効果音Bが再生中であるのに）。

## 期待される動作

- 効果音Aと効果音Bの再生をすべて完了したタイミングで[wse]を突破すること。

## 修正の注意点

- 環境音などのループSEが存在する点に注意。単純にSEの再生をすべて待つ実装にすると、ループSEを使用している場合に[wse]でゲームが止まる。

## 修正内容

- `TYRANO.kag.tmp.map_se`のマップを見て、ループ属性のない効果音の再生がすべて完了しているかをチェックするようにした。
