### PR TITLE
不具合修正・安定化

### DIFF
--- a/tyrano/plugins/kag/kag.event.js
+++ b/tyrano/plugins/kag/kag.event.js
@@ -34,4 +34,63 @@ tyrano.plugin.kag.event = {
             .removeAttr("data-event-tag")
             .removeAttr("data-event-pm");
     },
+
+    /**
+     * 任意のタグをロード時に再び実行するようにする
+     * options = {
+     *   tag: string;
+     *   pm: { [key: string]: string };
+     * }
+     * @param {JQuery<HTMLElement>} j_obj - 対象の要素
+     * @param {string} tag - タグ名
+     * @param {Object} pm - パラメータ
+     */
+    addRestoreData: function (j_obj, tag, pm) {
+        // data-restore属性を取得
+        const restore_data_str = j_obj.attr("data-restore");
+
+        // 配列に直す
+        let restore_data;
+        if (typeof restore_data_str === "string") {
+            restore_data = JSON.parse(restore_data_str);
+        } else {
+            restore_data = [];
+        }
+
+        // 新しいデータを追加して、再びdata-restore属性に戻す
+        restore_data.push({ tag, pm });
+        j_obj.attr("data-restore", JSON.stringify(restore_data));
+    },
+
+    /**
+     * 指定されたタグ名に一致する復元用データを削除する
+     * タグ名が指定されていない場合はすべての復元用データを削除する
+     * @param {JQuery<HTMLElement>} j_obj - 対象の要素
+     * @param {string} [tag] - タグ名
+     */
+    removeRestoreData: function (j_obj, tag) {
+        const restore_data_str = j_obj.attr("data-restore");
+
+        // 復元用データが存在しない場合はなにもしない
+        if (!restore_data_str) {
+            return;
+        }
+
+        // タグが指定されていない場合はすべての復元用データを削除する
+        if (!tag) {
+            j_obj.removeAttr("data-restore");
+            return;
+        }
+
+        // 指定されたタグに一致しない復元用データを選別する
+        const restore_data = JSON.parse(restore_data_str);
+        const filterd_data = restore_data.filter((item) => item.tag !== tag);
+
+        // 選別して残ったものがあるならそれでdata-restore属性を上書き、なにも残らなければ属性ごと削除
+        if (filterd_data.length > 0) {
+            j_obj.attr("data-restore", JSON.stringify(filterd_data));
+        } else {
+            j_obj.removeAttr("data-restore");
+        }
+    },
 };

--- a/tyrano/plugins/kag/kag.js
+++ b/tyrano/plugins/kag/kag.js
@@ -24,6 +24,7 @@ tyrano.plugin.kag = {
         "data-event-pm",
         "data-event-target",
         "data-event-storage",
+        "data-restore",
         "tabindex",
         "l_visible",
         "data-parent-layer",
@@ -120,7 +121,6 @@ tyrano.plugin.kag = {
                 },
 
                 fps: {
-
                     active: false,
 
                     movementSpeed: 300,
@@ -149,19 +149,15 @@ tyrano.plugin.kag = {
                     isJoy: false,
                     camera_pos_y: 40,
 
-
                     fps_rate: 0,
 
                     move_trans_control: false,
-
-                }
-
+                },
             },
 
             groups: {},
             models: {},
             evt: {},
-
         },
 
         preload_audio_map: {},
@@ -638,15 +634,15 @@ tyrano.plugin.kag = {
         var sf = this.variable.sf;
         var tf = this.variable.tf;
         var mp = this.stat.mp;
-        
+
         try {
             eval(str);
             this.saveSystemVariable();
         } catch (e) {
             console.error(e);
-            this.warning(e,true);
+            this.warning(e, true);
         }
-        
+
         /*
         if(this.kag.is_rider){
             this.kag.rider.pushVariableGrid();
@@ -1412,7 +1408,6 @@ tyrano.plugin.kag = {
                 "./tyrano/libs/three/controls/OrbitControls.js",
                 "./tyrano/libs/three/classes/ThreeModel.js",
                 "./tyrano/libs/three/etc/stats.min.js",
-
             ];
         }
 
@@ -1862,11 +1857,9 @@ tyrano.plugin.kag = {
     //キャッシュ領域にシナリオを格納します。
     //これはシナリオファイルを配置しなくても動的に挿入できることを意味します。
     setCacheScenario: function (filename, str) {
-
         var result_obj = this.parser.parseScenario(str);
         console.log(this.cache_scenario);
         this.cache_scenario["./data/scenario/" + filename] = result_obj;
-
     },
 
     getMessageInnerLayer: function () {
@@ -2037,13 +2030,13 @@ tyrano.plugin.kag = {
             audio_obj.load();
         } else if ("mp4" == ext || "ogv" == ext || "webm" == ext) {
             // 動画ファイルプリロード
-            
+
             let evt_name = "loadeddata";
-            
-            if($.userenv()=="iphone"){
+
+            if ($.userenv() == "iphone") {
                 evt_name = "loadedmetadata";
             }
-            
+
             $("<video />")
                 .on(evt_name, function (e) {
                     onend(this);

--- a/tyrano/plugins/kag/kag.menu.js
+++ b/tyrano/plugins/kag/kag.menu.js
@@ -346,6 +346,21 @@ tyrano.plugin.kag.menu = {
 
         /////////////////////////////////////////////////////////////
 
+        // [anim wait="false"]中のセーブ対策
+        // アニメーションを強制的に完了させる
+        $(".tyrano-anim").each(function () {
+            $(this).stop(true, true);
+        });
+
+        // [chara_mod wait="false"]中のセーブ対策
+        // 表情変更中にセーブが実行された場合は表情変更を強制的に完了させる
+        $(".chara-mod-animation").each(function () {
+            const j_old = $(this);
+            const j_new = j_old.next();
+            j_old.remove();
+            j_new.stop(true, true);
+        });
+
         if (typeof flag_thumb == "undefined") {
             flag_thumb = this.kag.config.configThumbnail;
         }

--- a/tyrano/plugins/kag/kag.menu.js
+++ b/tyrano/plugins/kag/kag.menu.js
@@ -74,13 +74,12 @@ tyrano.plugin.kag.menu = {
                 //戻る機能
                 that.setMenuCloseEvent(layer_menu);
                 that.setHoverEvent(layer_menu);
-        
+
                 //that.setMenuCloseEvent(layer_menu, { target: "menu_window_close" });
 
                 layer_menu
                     .find(".menu_window_close")
                     .click(function (e) {
-
                         //ウィンドウ消去
                         that.kag.layer.hideMessageLayers();
                         layer_menu.html("");
@@ -90,10 +89,9 @@ tyrano.plugin.kag.menu = {
                         }
 
                         e.stopPropagation();
+                    })
+                    .focusable();
 
-
-                    }).focusable();
-                
                 layer_menu
                     .find(".menu_save")
                     .click(function (e) {
@@ -658,17 +656,15 @@ tyrano.plugin.kag.menu = {
             })
             .focusable();
     },
-    
+
     //こ・ぱんださんのプラグイン対応。下位互換性の確保
     setHoverEvent: function (j_parent, options = {}) {
-        
         if (j_parent.html().indexOf('$(".menu_item").hover') == -1 && j_parent.html().indexOf('$(".menu_close").hover') == -1) {
             return false;
         }
-        
-        j_parent.find(".menu_item").off('mouseenter mouseleave');
-        j_parent.find(".menu_item img").off('mouseenter mouseleave');
-        
+        j_parent.find(".menu_item").off("mouseenter mouseleave");
+        j_parent.find(".menu_item img").off("mouseenter mouseleave");
+
         j_parent.find(".menu_item img").each((i, elm) => {
             const j_elm = $(elm);
             const original_src = j_elm.attr("src");
@@ -682,7 +678,6 @@ tyrano.plugin.kag.menu = {
                 },
             );
         });
-        
     },
 
     /**
@@ -869,19 +864,17 @@ tyrano.plugin.kag.menu = {
                 if (this.kag.stat.current_bgm_vol != "") {
                     pm["volume"] = this.kag.stat.current_bgm_vol;
                 }
-                
+
                 if (this.kag.stat.current_bgm_pause_seek != "") {
                     pm["pause"] = "true";
                     pm["seek"] = this.kag.stat.current_bgm_pause_seek;
                 }
-                
+
                 if (this.kag.stat.current_bgm_base64 != "") {
                     pm["base64"] = this.kag.stat.current_bgm_base64;
                 }
-                
+
                 this.kag.ftag.startTag("playbgm", pm);
-                
-                
             }
 
             // ループSE
@@ -891,7 +884,6 @@ tyrano.plugin.kag.menu = {
                 pm_obj["stop"] = "true";
                 this.kag.ftag.startTag("playbgm", pm_obj);
             }
-            
         }
 
         //読み込んだCSSがある場合
@@ -960,23 +952,19 @@ tyrano.plugin.kag.menu = {
 
                 //アニメーションの実行
                 if (key == "layer_camera") {
-                    
                     $(".layer_camera").css("-webkit-transform-origin", "center center");
                     (function (_a3d_define) {
                         setTimeout(function () {
                             $(".layer_camera").a3d(a3d_define);
                         }, 1);
                     })(a3d_define);
-                        
                 } else {
-                    
                     $("." + key + "_fore").css("-webkit-transform-origin", "center center");
                     (function (_a3d_define) {
                         setTimeout(function () {
                             $("." + key + "_fore").a3d(_a3d_define);
                         }, 1);
                     })(a3d_define);
-                    
                 }
             }
         }
@@ -1094,6 +1082,19 @@ tyrano.plugin.kag.menu = {
             var tag_name = j_elm.attr("data-event-tag");
             var pm = JSON.parse(j_elm.attr("data-event-pm"));
             that.kag.getTag(tag_name).setEvent(j_elm, pm);
+        });
+
+        // 復元用タグの実行
+        $("[data-restore]").each(function () {
+            const j_elm = $(this);
+            const restore_data = j_elm.data("restore");
+            if (Array.isArray(restore_data)) {
+                restore_data.forEach((item) => {
+                    const { tag, pm } = item;
+                    pm._next = false;
+                    that.kag.ftag.startTag(tag, pm);
+                });
+            }
         });
 
         //
@@ -1226,15 +1227,15 @@ tyrano.plugin.kag.menu = {
         var that = this;
 
         var layer_menu = this.kag.layer.getMenuLayer();
-        
+
         that.setMenuCloseEvent(j_obj, { callback: cb });
-        
+
         j_obj.hide();
         layer_menu.append(j_obj);
         layer_menu.show();
-        
+
         that.setHoverEvent(layer_menu);
-        
+
         $.preloadImgCallback(
             layer_menu,
             function () {
@@ -1354,7 +1355,7 @@ tyrano.plugin.kag.menu = {
 
                 that.setMenuCloseEvent(layer_menu);
                 that.setHoverEvent(layer_menu);
-        
+
                 that.setMenuScrollEvents(j_menu, { target: ".log_body", move: 60 });
 
                 // スマホのタッチ操作でスクロールできるようにするために touchmove の伝搬を切る

--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -523,8 +523,26 @@ tyrano.plugin.kag.tag.playbgm = {
                         // 状態次第で nextOrder
                         if (this.kag.tmp.is_se_play_wait == true) {
                             // [wse]に到達してSEの再生終了を待っている状態だったら nextOrder
-                            this.kag.tmp.is_se_play_wait = false;
-                            this.kag.ftag.nextOrder();
+                            // …したいのはやまやまだが、その前に
+                            // これ以外の効果音が同時に再生されていないかをチェックする必要がある
+
+                            // SEマップを走査してほかに再生中の効果音がないかどうかをチェック
+                            // ただしループSE（環境音などが想定される）は除外する必要がある
+                            let is_sound_playing = false;
+                            for (const key in this.kag.tmp.map_se) {
+                                const howl = this.kag.tmp.map_se[key];
+                                if (!howl._loop) {
+                                    if (howl.playing()) {
+                                        is_sound_playing = true;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if (!is_sound_playing) {
+                                this.kag.tmp.is_se_play_wait = false;
+                                this.kag.ftag.nextOrder();
+                            }
                         } else if (this.kag.tmp.is_vo_play_wait == true) {
                             // オートモード中に[l]や[p]に到達してボイスの再生終了を待っている状態だったら
                             // この音声がボイスである場合にのみ nextOrder

--- a/tyrano/plugins/kag/kag.tag_ext.js
+++ b/tyrano/plugins/kag/kag.tag_ext.js
@@ -1342,8 +1342,27 @@ tyrano.plugin.kag.tag.kanim = {
         j_targets.each(function () {
             const j_this = $(this);
 
-            // アニメオブジェクトをクローン
-            const this_anim = $.extend({}, anim);
+            // アニメーション定義をディープコピーする
+            const this_anim = $.extend(true, {}, anim);
+
+            // 左右反転画像の場合（すなわち[image reflect="true"]の場合）
+            if (j_this.hasClass("reflect")) {
+                // 画像の左右反転はreflectクラスを付けてtransform: scaleX(-1)を適用することによって実現しているため、
+                // 単純に[kanim]を使用してキーフレームアニメーションを適用すると、
+                // transformプロパティが上書きされることによって、左右反転が解除されてしまう！
+                // そこで、左右反転画像に対して[kanim]を使用する際は、事前にアニメーション定義を書き変えてしまおう
+                let prev_scale_x = 1;
+                for (let key in this_anim.frames) {
+                    const frame = this_anim.frames[key];
+                    if (typeof frame.trans.scaleX === "undefined") {
+                        frame.trans.scaleX = prev_scale_x;
+                    }
+                    prev_scale_x = frame.trans.scaleX;
+                    frame.trans.scaleX *= -1;
+                }
+                // CSSのscaleプロパティによる対応もひとつの手だが、
+                // 旧Chromiumではscaleプロパティが使用できないため実装を保留
+            }
 
             // "この要素"専用の complete メソッドを取り付ける
             this_anim.complete = () => {

--- a/tyrano/plugins/kag/kag.tag_ext.js
+++ b/tyrano/plugins/kag/kag.tag_ext.js
@@ -994,6 +994,7 @@ tyrano.plugin.kag.tag.anim = {
 
                 // アニメーションの実施
                 $(this)
+                    .stop(true, true)
                     .off("remove.anim")
                     .on("remove.anim", () => {
                         // アニメーション中に要素が削除されてしまった場合の対策
@@ -1002,10 +1003,10 @@ tyrano.plugin.kag.tag.anim = {
                         // ※"remove"はJavaScriptの標準イベントではなくjQueryが実装しているカスタムイベント
                         that.kag.popAnimStack();
                     })
-                    .stop(true, true)
+                    .addClass("tyrano-anim")
                     .animate(anim_style, parseInt(pm.time), pm.effect, function () {
                         // 要素削除時のイベントハンドラはもう不要
-                        $(this).off("remove.anim");
+                        $(this).off("remove.anim").removeClass("tyrano-anim");
                         // アニメーションスタックを取り除く
                         that.kag.popAnimStack();
                     });
@@ -3232,8 +3233,11 @@ tyrano.plugin.kag.tag.chara_mod = {
         }
 
         this.kag.preload(folder + storage_url, function () {
-            if ($(".chara-mod-animation").get(0)) {
-                $(".chara-mod-animation_" + pm.name).remove();
+            // wait=falseで表情を変更している最中に重ねて表情変更が実行された場合の対策
+            // アニメーション中の表情が残っている場合はそれを削除する
+            const j_old_face = $(".chara-mod-animation_" + pm.name);
+            if (j_old_face.length) {
+                j_old_face.remove();
             }
 
             if (chara_time != "0") {
@@ -3245,7 +3249,7 @@ tyrano.plugin.kag.tag.chara_mod = {
                 j_new_img.attr("src", folder + storage_url);
                 j_new_img.css("opacity", 0);
 
-                j_img.addClass("chara-mod-animation_" + pm.name);
+                j_img.addClass("chara-mod-animation chara-mod-animation_" + pm.name);
                 j_img.after(j_new_img);
 
                 if (is_cross) {

--- a/tyrano/plugins/kag/kag.tag_ext.js
+++ b/tyrano/plugins/kag/kag.tag_ext.js
@@ -1311,12 +1311,17 @@ tyrano.plugin.kag.tag.kanim = {
     },
 
     start: function (pm) {
-        var that = this;
+        const that = this;
+
+        // pmのコピーを取っておく
+        const original_pm = $.extend({}, pm);
 
         // アニメーション対象を取得、見つからなければ早期リターン
         const j_targets = $.findAnimTargets(pm);
         if (j_targets.length === 0) {
-            this.kag.ftag.nextOrder();
+            if (pm._next !== false) {
+                this.kag.ftag.nextOrder();
+            }
             return;
         }
 
@@ -1379,6 +1384,12 @@ tyrano.plugin.kag.tag.kanim = {
                 that.kag.pushAnimStack();
             }
 
+            // 無限ループアニメーションの場合はロード時に復元が必要
+            that.kag.event.removeRestoreData(j_this, "kanim");
+            if (pm.count === "infinite") {
+                that.kag.event.addRestoreData(j_this, "kanim", original_pm);
+            }
+
             // 要素が削除されたときにcompleteを呼ぶ
             j_this.on("remove", () => {
                 this_anim.complete();
@@ -1394,7 +1405,9 @@ tyrano.plugin.kag.tag.kanim = {
         //     j_targets.remove();
         // }, 300);
 
-        this.kag.ftag.nextOrder();
+        if (pm._next !== false) {
+            this.kag.ftag.nextOrder();
+        }
     },
 };
 
@@ -1452,6 +1465,8 @@ tyrano.plugin.kag.tag.stop_kanim = {
                 "animation-timing-function": "",
                 "transform": "",
             });
+
+            that.kag.event.removeRestoreData(j_this, "kanim");
         });
 
         this.kag.ftag.nextOrder();


### PR DESCRIPTION
主にご報告を受けていた件について修正あるいは対策を行いました。

- 複数の効果音が鳴っているタイミングで[wse]を使用すると、[wse]が**最初に終わった効果音**に反応する件。
  - すべての効果音を待つように。
- [image reflect="true"]で左右反転させた画像に[kanim]を使用すると左右反転が解除される件。
  - 適用前にキーフレームの内容を調整することで左右反転を維持したままアニメーションできるように。
- 無限ループのキーフレームアニメーションがロードで復元されない件。
  - ロード時の処理を追加して、復元できるように。
- GIF/APNG形式のアニメーション画像を複数回あるいは複数個使用した場合に、そのすべての画像でアニメーションのタイミングが同期されてしまう（**最初から再生されない**）件。
  - [image]タグにanimimg=trueを指定すると、最初から再生できるように。
- (wait=falseが指定されている場合)**アニメーションの途中**でセーブができてしまう件。
  - アニメーションの途中でセーブが実行された場合は、stop()メソッドを呼ぶことで強制的にアニメーションを完了するように。
