### PR TITLE
change: `[showsave]`から`[l]`の働きをなくし従来の仕様に変更

### DIFF
--- a/tyrano/plugins/kag/kag.menu.js
+++ b/tyrano/plugins/kag/kag.menu.js
@@ -140,7 +140,14 @@ tyrano.plugin.kag.menu = {
         );
     },
 
-    displaySave: function (cb) {
+    /**
+     * セーブ画面を表示する
+     * cbだけを指定した場合、セーブ完了時とセーブ画面クローズ時どちらもcbが実行される（互換性の担保）
+     * cb_closeを別に指定した場合、セーブ完了時にはcbが、セーブ画面クローズ時にはcb_closeが実行される
+     * @param {function} [cb] - セーブ完了時およびセーブ画面クローズ時のコールバック
+     * @param {function} [cb_close] - セーブ画面クローズ時のコールバック
+     */
+    displaySave: function (cb, cb_close) {
         //セーブ画面作成
 
         var that = this;
@@ -205,7 +212,7 @@ tyrano.plugin.kag.menu = {
 
                 that.setMenuScrollEvents(j_save, { target: ".area_save_list", move: 160 });
 
-                that.setMenu(j_save, cb);
+                that.setMenu(j_save, cb_close || cb);
             },
         );
     },

--- a/tyrano/plugins/kag/kag.tag_ext.js
+++ b/tyrano/plugins/kag/kag.tag_ext.js
@@ -540,22 +540,16 @@ tyrano.plugin.kag.tag.showsave = {
     start: function (pm) {
         var that = this;
 
-        // セーブ完了時コールバックで次のタグに進む仕様を廃止
-        // ([showsave]で開いたメニューからセーブする度に次のタグに進んでしまう問題を解消)
-        // that.kag.stat.load_auto_next = true;
-        // this.kag.menu.displaySave(function () {
-        //     that.kag.stat.load_auto_next = false;
-        //     that.kag.ftag.nextOrder();
-        // });
+        // ここでセーブしたデータをロードしたとき
+        // 自動で次のタグに進むようにする
+        that.kag.stat.load_auto_next = true;
 
-        // スキップとオートを止めつつ実質[l]で待機している状態にする
-        that.kag.stat.is_skip = false;
-        that.kag.stat.is_auto = false;
-        that.kag.ftag.startTag("l");
-
-        // ただ単にセーブメニューを開く
-        // ロールボタンやキーコンフィグからセーブメニューを開いたときと同等の挙動となる
-        this.kag.menu.displaySave();
+        // ここで開いたセーブ画面を閉じたとき
+        // 上記の設定を解除して次のタグに進むようにする
+        this.kag.menu.displaySave(undefined, () => {
+            that.kag.stat.load_auto_next = false;
+            that.kag.ftag.nextOrder();
+        });
     },
 };
 


### PR DESCRIPTION
もともと「[showsave]で表示したセーブメニューからセーブする度にnextOrderが走る」という問題が報告されていた。この問題が発生したタイミングは、過去の「セーブ画面でスロットをクリックしてセーブしたときに自動でセーブ画面を閉じる」という仕様から「セーブしてもセーブ画面を勝手に閉じない」という仕様に変更したタイミングだと思われる。

過去の仕様であれば、[showsave]のコードにおいてセーブ完了時（＝セーブ画面を閉じたとき）にnextOrderする実装で問題なかったが、セーブしてもセーブ画面を閉じなくなったためセーブ画面でタグを進め放題になっていた。

それを荻原が修正した際、セーブしたときのnextOrderコールバックをなくし、セーブ画面から戻ってきたときに次のタグに進められるようにクリック待ちの挙動を実装していた。しかしそのアプローチでは従来の挙動とは異なったものになり、ユーザーの意図しない仕様になっていた。

そこで従来の仕様と挙動を変えずに冒頭の問題を解決するために、displaySaveの実装を変えた。