### PR TITLE
fix: コンフィグ画面で音量をミュートしたのに音声が再生されてしまう問題を修正

### DIFF
--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -2345,6 +2345,8 @@ tyrano.plugin.kag.tag.l = {
                     if (that.kag.tmp.is_vo_play == true) {
                         that.kag.tmp.is_vo_play_wait = true;
                     } else {
+                        // クリック待ちグリフを消去
+                        that.kag.ftag.hideNextImg();
                         that.kag.ftag.nextOrder();
                     }
                 }
@@ -2422,6 +2424,8 @@ tyrano.plugin.kag.tag.p = {
                     if (that.kag.tmp.is_vo_play == true) {
                         that.kag.tmp.is_vo_play_wait = true;
                     } else {
+                        // クリック待ちグリフを消去
+                        that.kag.ftag.hideNextImg();
                         that.kag.ftag.nextOrder();
                     }
                 }

--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -280,7 +280,7 @@ tyrano.plugin.kag.tag.playbgm = {
             case "sound":
                 config_volume = $.parseVolume(this.kag.config.defaultSeVolume);
                 // このbufの個別SE音量が存在する場合はそれで上書き
-                if (this.kag.stat.map_se_volume[buf]) {
+                if (this.kag.stat.map_se_volume[buf] !== undefined) {
                     config_volume = $.parseVolume(this.kag.stat.map_se_volume[buf]);
                 }
                 break;

--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -1278,7 +1278,7 @@ tyrano.plugin.kag.tag.bgmopt = {
         }
 
         // システム変数の変更とセーブ(sfのデータは[eval]実行時点でセーブされる)
-        if (pm.volume) {
+        if (pm.volume !== undefined && pm.volume !== "") {
             this.kag.ftag.startTag("eval", {
                 exp: "sf._system_config_bgm_volume = " + pm.volume,
                 next: pm.next,
@@ -1393,7 +1393,7 @@ tyrano.plugin.kag.tag.seopt = {
         }
 
         // システム変数の変更とセーブ(sfのデータは[eval]実行時点でセーブされる)
-        if (pm.volume) {
+        if (pm.volume !== undefined && pm.volume !== "") {
             this.kag.ftag.startTag("eval", {
                 exp: "sf._system_config_se_volume = " + pm.volume,
                 next: pm.next,


### PR DESCRIPTION
## 問題

最新のティラノスクリプトにおいて、コンフィグ画面でSE音量（buf=1）とボイス音量（buf=2）を個別に設定できるようにしている場合に、SE音量のミュート（音量ゼロ）やボイス音量のミュート（音量ゼロ）が正常に動作しない問題があった。

## 原因

まず、コンフィグ用のシナリオの[seopt]は次のようになっていた。

`[seopt buf="2" volume="&tf.current_vo_vol" effect=true]`

基本的にはティラノスクリプトのパラメータの値は内部的に**文字列型**に変換されるが、変数を介した場合は別である。ここではtf.current_vo_volという変数を使用しているため、volumeパラメータには文字列型でなく**数値型のデータ**が渡される可能性がある（問題のスクリプトでは実際にそうなっていた）。エンジン側でこれを想定していなかったのが根本的な原因であった。

エンジン側では、[playse]の動作定義部において、`コンフィグでbufの個別音量が設定されているかどうか`を確認する際に次の式を用いていた。

`if (this.kag.stat.map_se_volume[buf]) {`

空でない文字列はすべてtrueになるため、音量に文字列の`"0"`が設定されている場合でもtrueとなり問題なく動作したが、上記のスクリプトのように変数を介して文字列の`"0"`ではなく数値の`0`が設定されている場合、音量が設定されていないかのようにみなされる問題が起こっていた。

## 対応

プログラムを次のように修正した。

`if (this.kag.stat.map_se_volume[buf] !== undefined) {`

---

## その他

また、音量のミュート（音量ゼロ）がセーブデータに記憶されない問題もあった。根は上記の問題と同じである。

[bgmopt]および[seopt]の動作定義部において、

`if (pm.volume) {`

となっていた個所を

`if (pm.volume !== undefined && pm.volume !== "") {`

とした。つまり同様に、数値の`0`が渡された場合でもif文をパスするようにした。
