### PR TITLE
Linux Support

### DIFF
--- a/tyrano/libs.js
+++ b/tyrano/libs.js
@@ -473,14 +473,11 @@
 
     //ユーザ環境を取得
     $.userenv = function () {
-        var ua = navigator.userAgent;
-        if (ua.indexOf("iPhone") > -1) {
+        var userAgent = navigator.userAgent;
+    
+        if (userAgent.match(/iphone|ipad|ipod/i)) {
             return "iphone";
-        } else if (ua.indexOf("iPad") > -1) {
-            return "iphone";
-        } else if (ua.indexOf("Android") > -1) {
-            return "android";
-        } else if (ua.indexOf("Chrome") > -1 && navigator.platform.indexOf("Linux") > -1) {
+        } else if (userAgent.match(/android/i)) {
             return "android";
         } else {
             return "pc";


### PR DESCRIPTION
Currently, the support of linux platform is almost out-of-the-box. The only problem is that linux devices are perceived as android.

Tested on x11 with electron 8.

---

現在、Linux プラットフォームのサポートは、すぐに使用できるようになっています。 唯一の問題は、Linux デバイスが Android として認識されることです。

Electron 8 を使用して x11 でテストしました。
