### PR TITLE
目パチ口パクアニメーションの実装

### DIFF
--- a/tyrano/libs.js
+++ b/tyrano/libs.js
@@ -13,7 +13,6 @@
     };
 
     $.isHTTP = function (str) {
-
         if ($.isBase64(str)) {
             return true;
         }
@@ -303,7 +302,7 @@
     $.tag = function (tag_name, pm) {
         var pm_str = "";
         for (key in pm) {
-            pm_str += " " + key + "=\"" + pm[key] + "\" ";
+            pm_str += " " + key + '="' + pm[key] + '" ';
         }
         return "[" + tag_name + " " + pm_str + " ]";
     };
@@ -357,7 +356,7 @@
     };
 
     //パスにfgimage bgimage image が含まれていた場合、それを適応する
-    $.convertStorage = function (path) { };
+    $.convertStorage = function (path) {};
 
     $.convertColor = function (val) {
         if (val.indexOf("0x") != -1) {
@@ -441,7 +440,6 @@
                     reject();
                 },
             });
-
         });
     };
 
@@ -1037,7 +1035,7 @@
             }
             const file_path = out_path + "/" + key + ".sav";
             fs.unlinkSync(file_path);
-        } catch (e) { }
+        } catch (e) {}
     };
 
     $.setStorageFile = function (key, val) {
@@ -1292,19 +1290,14 @@
     };
 
     $.prompt = function (str, cb) {
-
         alertify.prompt(str, function (flag, text) {
-
             if (typeof cb == "function") {
                 cb(flag, text);
             }
-
         });
-
     };
 
     $.isBase64 = function (str) {
-
         if (!str) return false;
 
         if (str.substr(0, 10) == "data:image") {
@@ -1312,9 +1305,7 @@
         } else {
             return false;
         }
-
-
-    }
+    };
 
     //オブジェクトの個数をもってきます。1
     $.countObj = function (obj) {
@@ -2713,6 +2704,20 @@
             return $.convertLength(item);
         });
         return hash.join(" ");
+    };
+
+    $.fn.showAtIndexWithVisibility = function (index) {
+        return this.each(function (i) {
+            if (i === index) {
+                if (this.style.visibility !== "visible") {
+                    this.style.visibility = "visible";
+                }
+            } else {
+                if (this.style.visibility !== "hidden") {
+                    this.style.visibility = "hidden";
+                }
+            }
+        });
     };
 
     $.captureStackTrace = (str = "captured stack trace!") => {

--- a/tyrano/plugins/kag/kag.js
+++ b/tyrano/plugins/kag/kag.js
@@ -656,18 +656,14 @@ tyrano.plugin.kag = {
 
     //式を評価して値を返却します
     embScript: function (str, preexp) {
-        
         try {
-            
             var f = this.stat.f;
             var sf = this.variable.sf;
             var tf = this.variable.tf;
             var mp = this.stat.mp;
 
-            return eval("("+str+")");
-        
+            return eval("(" + str + ")");
         } catch (e) {
-            
             try {
                 return eval(str);
             } catch (e) {
@@ -3028,6 +3024,423 @@ tyrano.plugin.kag = {
             const j_div = $('<div class="chara_part_container plus_lighter_container" />');
             j_div.insertAfter(j_img);
             j_div.append(j_img);
+        },
+
+        /**
+         * リップシンクの対象となるパーツを取得する。
+         * 取得できなかった場合はnullが返る。
+         * @param {string} name - キャラクターの名前。
+         * @param {string} type - リップシンクタイプ。"voice"または"text"。
+         * @returns {Array<Object>} target_parts - 更新対象のパーツの配列。
+         * @returns {Object} target_parts[].j_frames - jQueryオブジェクト。フレームのコレクション。
+         * @returns {Array<number>} target_parts[].thresholds - 各フレームを表示するための閾値の配列。
+         */
+        getLipSyncParts(name, type = "voice") {
+            // キャラ定義
+            const cpm = this.kag.stat.charas[name];
+
+            // キャラ定義が存在しない→無効
+            if (!cpm) return null;
+            // キャラが表示されていない→無効
+            if (!cpm.is_show === "false") return null;
+            // キャラ定義は存在するがリップシンクタイプが一致しない→無効
+            if (cpm.lipsync_type !== type) return null;
+
+            // キャラのjQueryオブジェクト
+            const j_chara = this.kag.chara.getCharaContainer(name);
+
+            // キャラのjQueryオブジェクトが取得できない→無効
+            if (j_chara.length === 0) return null;
+
+            //
+            // 現在のキャラクターのパーツの状況をチェック
+            //
+
+            // リップシンクのパーツを格納する配列
+            // 口が複数あるようなキャラクターを一応想定している
+            const target_parts = [];
+
+            // すべてのパーツを走査してリップシンク対象のパーツを特定する
+            const part_map = cpm._layer;
+            if (!part_map) return;
+            for (const part in part_map) {
+                const part_obj = part_map[part];
+                const state = part_obj.current_part_id;
+                const part_state_obj = part_obj[state];
+                if (!part_state_obj || !part_state_obj.is_lipsync_enabled) {
+                    continue;
+                }
+                // ここに到達したならばこのパーツはリップシンク対象である
+
+                // このパーツのすべてのフレームの<img>要素の集合を取得
+                const j_frames = j_chara.find(`.lipsync-frame[data-effect=${part}-${state}]`);
+                const thresholds = part_state_obj.lip_volume;
+                if (j_frames.length > 0 && thresholds) {
+                    target_parts.push({
+                        j_frames,
+                        thresholds,
+                        current_index: 0,
+                        max_open_mouth_time: 0,
+                        text_lipsync_timer_id: 0,
+                        def: part_state_obj,
+                    });
+                }
+            }
+            // 対象のパーツがない→無効
+            if (target_parts.length === 0) return null;
+
+            return target_parts;
+        },
+
+        /**
+         * フレームアニメーションの各フレームの画像ソースの配列を取得する
+         * @param {Object} cpm - キャラ定義。例）TYRANO.kag.stat.charas.akane
+         * @param {string} part - パーツ部位名。例）eye
+         * @param {string} state - パーツ状態名。例）smile
+         * @returns {Array<string>}
+         */
+        getFrameAnimationSrcs(cpm, part, state) {
+            // パーツ状態がstorage直接指定の場合は無視
+            if (state === "allow_storage") {
+                return [];
+            }
+
+            // パーツ状態定義を取得
+            const state_obj = cpm["_layer"][part][state];
+
+            // frame_image属性が未指定なら無視
+            if (!state_obj.frame_image) {
+                return [];
+            }
+
+            // 画像ソースの配列
+            const srcs = [];
+
+            // 画像ファイルの拡張子を取得する関数
+            const image_extensions = ["png", "jpg", "jpeg", "gif", "webp", "bmp", "tiff", "tif", "svg", "ico"];
+            const get_image_extension = (filename) => {
+                const extension = filename.split(".").pop();
+                return image_extensions.includes(extension.toLowerCase()) ? extension : null;
+            };
+
+            // ベースフレームの画像ファイルのパス
+            const base_path = $.parseStorage(state_obj.storage, "fgimage");
+            const base_extension = get_image_extension(base_path);
+
+            // すべてのフレームについて画像ソースを決定
+            state_obj.frame_image.forEach((frame_src) => {
+                // このフレームの画像ソースの拡張子を取得
+                // ※省略されている場合もある！
+                const frame_extension = get_image_extension(frame_src);
+
+                // ベースのパスのファイル名部分を置換する
+                const hash_slash = base_path.split("/");
+                let new_filename;
+                // ベースのパスには拡張子が指定されているがこのフレームには拡張子が指定されていない場合
+                // ベースのパスの拡張子でこのフレームのソースを補う
+                if (base_extension && !frame_extension) {
+                    new_filename = `${frame_src}.${base_extension}`;
+                } else {
+                    new_filename = frame_src;
+                }
+                hash_slash.pop();
+                hash_slash.push(new_filename);
+                const src = hash_slash.join("/");
+
+                srcs.push(src);
+            });
+
+            return srcs;
+        },
+
+        /**
+         * フレームアニメーションを設定する
+         * @param {Object} cpm - キャラ定義。例）TYRANO.kag.stat.charas.akane
+         * @param {string} part - パーツ部位名。例）eye
+         * @param {string} state - パーツ状態名。例）smile
+         * @param {jQuery} j_frame_base - ベースとなるパーツの<img>要素。
+         * @param {Array<string>} preload_srcs - この配列に画像ソースを入れておくと関数の呼び出し元でプリロードに使われる。
+         * @returns {jQuery|null}
+         */
+        setFrameAnimation(cpm, part, state, j_frame_base, preload_srcs) {
+            // フレームの画像ソースの配列
+            const frame_srcs = this.getFrameAnimationSrcs(cpm, part, state);
+            if (!frame_srcs.length) {
+                return null;
+            }
+
+            // パーツ状態定義を取得
+            const state_obj = cpm["_layer"][part][state];
+
+            let j_frames = $(j_frame_base);
+            let j_prev_frame = j_frame_base;
+
+            // すべてのフレームについて<img>要素を作成
+            frame_srcs.forEach((frame_src) => {
+                // オリジナルの<img>要素をクローンする
+                const j_clone = j_frame_base.clone();
+
+                // 属性、クラス、CSSの調整
+                j_clone.attr("src", frame_src);
+                j_clone.addClass("sub");
+                j_clone.removeClass("base");
+                j_clone.css("visibility", "hidden");
+
+                // プリロードに追加
+                if (preload_srcs) {
+                    preload_srcs.push(frame_src);
+                }
+
+                // オリジナルの画像の後ろに追加していく
+                j_clone.insertAfter(j_prev_frame);
+                j_prev_frame = j_clone;
+
+                // jQueryオブジェクトの集合に追加しておく
+                j_frames = j_frames.add(j_clone);
+            });
+
+            if (state_obj.lip_image) {
+                cpm.lipsync_type = state_obj.lip_type;
+                state_obj.is_lipsync_enabled = true;
+                j_frame_base.addClass("base");
+                j_frames.addClass("lipsync-frame");
+                j_frames.attr("data-effect", `${part}-${state}`);
+                return j_frames;
+            }
+
+            // オリジナルの<img>要素にクラスと属性付与
+            // キャラの名前、パーツ部位の名前、パーツ状態の名前を記憶
+            j_frame_base.addClass("base");
+            j_frame_base.attr(
+                "data-restore",
+                JSON.stringify({
+                    chara_name: cpm.name,
+                    part_name: part,
+                    state_name: state,
+                }),
+            );
+
+            // すべての<img>要素にクラスと属性付与
+            j_frames.each(function (i) {
+                const j_img = $(this);
+                j_img.addClass("chara-layer-frame");
+                j_img.attr("data-effect", i);
+                j_img.attr("data-event-pm", part);
+            });
+
+            this.startFrameAnimation(state_obj, j_frames);
+            return j_frames;
+        },
+
+        /**
+         * フレームアニメーションを開始する
+         * @param {string} state_obj - パーツ状態定義。例）cpm._layer.eye.smile
+         * @param {jQuery} j_frames - フレームアニメーションを構成するすべての<img>要素のjQueryコレクション
+         */
+        startFrameAnimation(state_obj, j_frames) {
+            // フレーム番号
+            let frame_index = 0;
+
+            // 最初のフレームから最後のフレームに向かっている最中であるかどうか
+            let to_last = true;
+
+            // 総フレーム数
+            const frame_count = state_obj.frame_image.length + 1;
+
+            const calc_duration = (i) => {
+                let duration = state_obj.frame_time[i] || 40;
+                if (Array.isArray(duration)) {
+                    const min = duration[0];
+                    const max = duration[1];
+                    duration = Math.floor(min + (max - min) * Math.random());
+                }
+                return duration;
+            };
+
+            // フレームアニメーション1枚分の処理
+            const anim = () => {
+                clearTimeout(state_obj.frame_timer_id);
+
+                // すでにDOMから削除されている場合はフレームアニメーションを終了する
+                if (j_frames.eq(0).closest("html").length === 0) {
+                    return;
+                }
+
+                // フレーム番号増加
+                switch (state_obj.frame_direction) {
+                    // 0-1-2-3-2-1-0のような変化
+                    case "alternate":
+                        if (to_last) {
+                            frame_index += 1;
+                            if (frame_index === frame_count) {
+                                frame_index -= 2;
+                                to_last = false;
+                            }
+                        } else {
+                            frame_index -= 1;
+                            if (frame_index === -1) {
+                                frame_index += 2;
+                                to_last = true;
+                            }
+                        }
+                        break;
+                    // 0-1-2-3-0-1-2-3のような変化
+                    default:
+                        frame_index = (frame_index + 1) % frame_count;
+                        break;
+                }
+
+                // すべてのフレーム画像を非表示にしてから
+                // 現在のフレーム画像だけを表示する
+                j_frames.showAtIndexWithVisibility(frame_index);
+
+                // 次のフレームまでの時間
+                const duration = calc_duration(frame_index);
+
+                // 次回のフレーム処理の予約
+                state_obj.frame_timer_id = setTimeout(anim, duration);
+            };
+
+            // 最初の瞬き
+            state_obj.frame_timer_id = setTimeout(anim, calc_duration(0));
+        },
+
+        /**
+         * すべてのキャラクターのフレームアニメーションを停止する
+         * ロード時に呼び出す
+         * @returns
+         */
+        stopFrameAnimation(cpm) {
+            if (!cpm._layer) {
+                return;
+            }
+            for (const part in cpm._layer) {
+                for (const state in cpm._layer[part]) {
+                    clearTimeout(cpm._layer[part][state].frame_timer_id);
+                }
+            }
+        },
+
+        /**
+         * すべてのキャラクターのフレームアニメーションを停止する
+         * ロード時に呼び出す
+         * @returns
+         */
+        stopAllFrameAnimation() {
+            // キャラが存在しない場合なにもしない
+            const charas = this.kag.stat.charas;
+            if (!charas) {
+                return;
+            }
+
+            // すべてのキャラについて瞬きのsetTimeoutを停止
+            for (const name in this.kag.stat.charas) {
+                const cpm = charas[name];
+                this.stopFrameAnimation(cpm);
+            }
+        },
+
+        /**
+         * ゲーム画面に出ているすべてのキャラクターの瞬きを復元する
+         * ロード時に呼び出す
+         */
+        restoreAllFrameAnimation() {
+            const that = this;
+
+            // フレームアニメーションの復元作業
+            $(".chara-layer-frame.base").each(function () {
+                try {
+                    // ベース画像
+                    const j_frame_base = $(this);
+                    // 保存しておいた設定値
+                    const setting = JSON.parse(j_frame_base.attr("data-restore"));
+                    // キャラ定義
+                    const cpm = that.kag.stat.charas[setting.chara_name];
+                    // キャラパーツ状態定義
+                    const state_obj = cpm._layer[setting.part_name][setting.state_name];
+
+                    // このパーツのフレームアニメーションの
+                    // すべてのフレーム画像を含むようなコレクション
+                    let j_frames = $(j_frame_base);
+                    const j_siblings = j_frame_base.siblings(`.chara-layer-frame[data-event-pm=${setting.part_name}]`);
+                    j_frames = j_frames.add(j_siblings);
+
+                    // いったんベース画像を表示する
+                    const i = j_frames.index(j_frame_base);
+                    j_frames.showAtIndexWithVisibility(i);
+
+                    // フレームアニメーションを開始
+                    that.startFrameAnimation(state_obj, j_frames);
+                } catch (e) {
+                    console.error(e);
+                }
+            });
+
+            // リップシンクが有効な口パーツをベース画像に戻す
+            // 口パク中にセーブされる可能性があるためその対策
+            $(".lipsync-frame.base").each(function () {
+                try {
+                    const j_frame_base = $(this);
+                    const data_effect = j_frame_base.attr("data-effect");
+                    j_frame_base.siblings(`.sub[data-effect=${data_effect}]`).css("visibility", "hidden");
+                    j_frame_base.css("visibility", "visible");
+                } catch (e) {
+                    console.error(e);
+                }
+            });
+        },
+
+        /**
+         * リップシンクを更新するメソッド。
+         * 入力値に基づいて、指定されたパーツの表示状態を変更する。
+         * @param {number} value - 現在の振幅の値。
+         * @param {Array<Object>} target_parts - 更新対象のパーツの配列。
+         * @param {number} elapsed_time - 前回のリップシンクからの経過時間。
+         * @param {Object} target_parts[].j_frames - jQueryオブジェクト。フレームのコレクション。
+         * @param {Array<number>} target_parts[].thresholds - 各フレームを表示するための閾値の配列。
+         * @param {number} target_parts[].current_index - 前回表示したフレームのインデックス。
+         */
+        updateLipSyncWithVoice(value, target_parts, elapsed_time) {
+            target_parts.forEach((part) => {
+                // 閾値から現在形成すべきリップフレーム番号を特定する
+                let target_i = 0;
+                for (; target_i < part.thresholds.length; target_i++) {
+                    if (value < part.thresholds[target_i]) {
+                        break;
+                    }
+                }
+
+                // 前回のリップフレーム番号と同じであれば何も処理しなくてよい
+                if (target_i === part.current_index) {
+                    return;
+                }
+
+                // ここに到達したならば前回のリップフレーム番号とは異なるということ
+
+                // 先ほどまで口を最大まで開けていた場合
+                if (part.current_index === part.thresholds.length) {
+                    // 経過時間を数える
+                    part.max_open_mouth_time += elapsed_time;
+                    // 一度口を開けたら200ミリ秒間はそのまま固定する
+                    if (part.max_open_mouth_time < 200) {
+                        return;
+                    } else {
+                        part.max_open_mouth_time = 0;
+                    }
+                }
+
+                // より口を大きく開こうとしている
+                if (target_i > part.current_index) {
+                    // 1ずつ大きくしよう
+                    target_i = part.current_index + 1;
+                } else {
+                    // 1ずつ小さくしよう
+                    target_i = part.current_index - 1;
+                }
+
+                part.j_frames.showAtIndexWithVisibility(target_i);
+                part.current_index = target_i;
+            });
         },
     },
 

--- a/tyrano/plugins/kag/kag.js
+++ b/tyrano/plugins/kag/kag.js
@@ -411,6 +411,8 @@ tyrano.plugin.kag = {
         message_config: {},
         word_nobreak_list: [],
 
+        lipsync_buf_chara: {},
+
         title: "", //ゲームのタイトル
     }, //ゲームの現在の状態を保持する所 状況によって、いろいろ変わってくる
 
@@ -2912,8 +2914,16 @@ tyrano.plugin.kag = {
          * 発言者がいない場合は空の文字列を返す
          * @returns {string}
          */
-        getCharaName() {
+        getCharaName(convert_to_id) {
             let chara_name = "";
+
+            // stat.current_speakerが未定義でないならそれを返す
+            if (this.kag.stat.current_speaker !== undefined) {
+                return this.kag.stat.current_speaker;
+            }
+
+            // stat.current_speakerが未定義の場合は
+            // 泥臭いがchara_ptext_areaから抽出する必要がある
             if (this.kag.stat.chara_ptext != "") {
                 // 発言者エリアを取得
                 const j_chara_name = this.getCharaNameArea();
@@ -2936,6 +2946,14 @@ tyrano.plugin.kag = {
                     chara_name = j_chara_name.find(".fill").text();
                 }
             }
+
+            // IDへの変換をする場合
+            if (convert_to_id) {
+                if (this.kag.stat.jcharas[chara_name]) {
+                    chara_name = this.kag.stat.jcharas[chara_name];
+                }
+            }
+
             return chara_name;
         },
 
@@ -3293,6 +3311,13 @@ tyrano.plugin.kag = {
                 // すべてのフレーム画像を非表示にしてから
                 // 現在のフレーム画像だけを表示する
                 j_frames.showAtIndexWithVisibility(frame_index);
+
+                // 最後のフレームでループしない設定なら終了する
+                if (frame_index === frame_count - 1) {
+                    if (state_obj.frame_loop === "false") {
+                        return;
+                    }
+                }
 
                 // 次のフレームまでの時間
                 const duration = calc_duration(frame_index);

--- a/tyrano/plugins/kag/kag.menu.js
+++ b/tyrano/plugins/kag/kag.menu.js
@@ -771,6 +771,9 @@ tyrano.plugin.kag.menu = {
         // ティラノイベント"load-start"を発火
         this.kag.trigger("load-start");
 
+        // 瞬きを停止
+        this.kag.ftag.master_tag.chara_show.stopAllFrameAnimation();
+
         // 一時リスナをすべて消去
         this.kag.offTempListeners();
 
@@ -1118,6 +1121,9 @@ tyrano.plugin.kag.menu = {
                 });
             }
         });
+
+        // 瞬きを復元
+        this.kag.ftag.master_tag.chara_show.restoreAllFrameAnimation();
 
         //
         // プロパティの初期化

--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -2311,7 +2311,7 @@ tyrano.plugin.kag.tag.text = {
         }
 
         // リップシンク対象のパーツを取得する（取得できなければこのリップシンクは無効）
-        const target_parts = this.kag.tag.playbgm.getLipSyncParts.call(this, chara_name, "text");
+        const target_parts = this.kag.chara.getLipSyncParts.call(this, chara_name, "text");
         if (!target_parts) return null;
 
         // 別のメソッドからtarget_partsにアクセスできるようにするために

--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -2314,19 +2314,21 @@ tyrano.plugin.kag.tag.text = {
         const target_parts = this.kag.tag.playbgm.getLipSyncParts.call(this, chara_name, "text");
         if (!target_parts) return null;
 
-        // 別のメソッドからtarget_partsにアクセスできるようにしておく
+        // 別のメソッドからtarget_partsにアクセスできるようにするために
+        // tmp領域にtarget_partsの参照を格納しておく
         this.kag.tmp.text_lipsync_target_parts = target_parts;
 
-        // アップデート関数と初回呼び出し
-        const updateLipSync = () => {
-            target_parts.forEach((part) => {
+        // パーツごとに
+        target_parts.forEach((part) => {
+            // アップデート関数と初回呼び出し
+            const updateLipSync = () => {
                 const i = Math.floor(Math.random() * part.j_frames.length);
-                part.j_frames.css("opacity", "0");
-                part.j_frames.eq(i).css("opacity", "1");
-            });
-            this.kag.tmp.text_lipsync_timer_id = setTimeout(updateLipSync, 50);
-        };
-        updateLipSync();
+                part.j_frames.showAtIndexWithVisibility(i);
+                const duration = parseInt(part.def.lip_time) || 50;
+                part.text_lipsync_timer_id = setTimeout(updateLipSync, duration);
+            };
+            updateLipSync();
+        });
     },
 
     /**
@@ -2338,12 +2340,13 @@ tyrano.plugin.kag.tag.text = {
         if (!target_parts) return null;
 
         // タイマーを停止
-        clearTimeout(this.kag.tmp.text_lipsync_timer_id);
+        target_parts.forEach((part) => {
+            clearTimeout(part.text_lipsync_timer_id);
+        });
 
         // ベースとなる口を表示し中間点を非表示にする
         target_parts.forEach((target_part) => {
-            target_part.j_frames.css("opacity", "0");
-            target_part.j_frames.eq(0).css("opacity", "1");
+            target_part.j_frames.showAtIndexWithVisibility(0);
         });
 
         // 不要になったプロパティを削除

--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -2304,11 +2304,8 @@ tyrano.plugin.kag.tag.text = {
      */
     startLipSyncWithText() {
         // 現在の発言者名（誰のセリフでもない場合は無効）
-        let chara_name = this.kag.chara.getCharaName();
+        let chara_name = this.kag.chara.getCharaName(true);
         if (!chara_name) return null;
-        if (this.kag.stat.jcharas[chara_name]) {
-            chara_name = this.kag.stat.jcharas[chara_name];
-        }
 
         // リップシンク対象のパーツを取得する（取得できなければこのリップシンクは無効）
         const target_parts = this.kag.chara.getLipSyncParts.call(this, chara_name, "text");

--- a/tyrano/plugins/kag/kag.tag.js
+++ b/tyrano/plugins/kag/kag.tag.js
@@ -2006,6 +2006,9 @@ tyrano.plugin.kag.tag.text = {
         // もう追加しおわった
         this.kag.stat.is_adding_text = false;
 
+        // リップシンク開始
+        this.stopLipSyncWithText();
+
         // いまメッセージウィンドウがユーザー操作によって非表示にされているかどうか
         if (this.kag.stat.is_hide_message) {
             // メッセージの表示途中でユーザーが右クリックしてメッセージウィンドウを消しおった！
@@ -2086,6 +2089,9 @@ tyrano.plugin.kag.tag.text = {
 
         // テキスト追加中だよ
         this.kag.stat.is_adding_text = true;
+
+        // リップシンク開始
+        this.startLipSyncWithText();
 
         // クリックの割り込みを処理したかどうか
         this.kag.tmp.processed_click_interrupt = false;
@@ -2291,6 +2297,57 @@ tyrano.plugin.kag.tag.text = {
         if (typeof chara_fuki["font_size"] != "undefined") {
             j_outer_message.parent().find(".message_inner").find(".current_span").css("font-size", parseInt(chara_fuki["font_size"]));
         }
+    },
+
+    /**
+     * テキストによるリップシンクを開始する。
+     */
+    startLipSyncWithText() {
+        // 現在の発言者名（誰のセリフでもない場合は無効）
+        let chara_name = this.kag.chara.getCharaName();
+        if (!chara_name) return null;
+        if (this.kag.stat.jcharas[chara_name]) {
+            chara_name = this.kag.stat.jcharas[chara_name];
+        }
+
+        // リップシンク対象のパーツを取得する（取得できなければこのリップシンクは無効）
+        const target_parts = this.kag.tag.playbgm.getLipSyncParts.call(this, chara_name, "text");
+        if (!target_parts) return null;
+
+        // 別のメソッドからtarget_partsにアクセスできるようにしておく
+        this.kag.tmp.text_lipsync_target_parts = target_parts;
+
+        // アップデート関数と初回呼び出し
+        const updateLipSync = () => {
+            target_parts.forEach((part) => {
+                const i = Math.floor(Math.random() * part.j_frames.length);
+                part.j_frames.css("opacity", "0");
+                part.j_frames.eq(i).css("opacity", "1");
+            });
+            this.kag.tmp.text_lipsync_timer_id = setTimeout(updateLipSync, 50);
+        };
+        updateLipSync();
+    },
+
+    /**
+     * テキストによるリップシンクを終了する。
+     */
+    stopLipSyncWithText() {
+        // ターゲットパーツがなければなにもしない
+        const target_parts = this.kag.tmp.text_lipsync_target_parts;
+        if (!target_parts) return null;
+
+        // タイマーを停止
+        clearTimeout(this.kag.tmp.text_lipsync_timer_id);
+
+        // ベースとなる口を表示し中間点を非表示にする
+        target_parts.forEach((target_part) => {
+            target_part.j_frames.css("opacity", "0");
+            target_part.j_frames.eq(0).css("opacity", "1");
+        });
+
+        // 不要になったプロパティを削除
+        delete this.kag.tmp.text_lipsync_target_parts;
     },
 };
 
@@ -3073,9 +3130,8 @@ tyrano.plugin.kag.tag.position = {
         // [position]タグ実行時には必ず上のインナーリフレッシュによって width, height が破壊されてしまうため、
         // 『marginr, marginb が指定されていない[position]タグ』を通過するときにそれまでの marginr, marginb が破棄される問題があった
         // (タグリファレンスの『いずれの属性も、指定しなければ変更は行われません。』という説明と矛盾していた)
-        const new_style_inner = {
-        };
-        
+        const new_style_inner = {};
+
         if (this.kag.stat.fuki.active == true) {
             new_style_inner["box-sizing"] = "content-box";
         } else {
@@ -3196,8 +3252,7 @@ tyrano.plugin.kag.tag.fuki_start = {
         j_msg_inner.css("width", "");
         j_msg_inner.css("height", "");
         j_msg_inner.css("box-sizing", "content-box");
-        
-        
+
         this.kag.ftag.nextOrder();
     },
 };
@@ -3245,9 +3300,9 @@ tyrano.plugin.kag.tag.fuki_stop = {
 
         j_inner_layer.css("left", parseInt(j_outer_layer.css("left")) + 10).css("top", parseInt(j_outer_layer.css("top")) + 10);
         j_inner_layer.css("box-sizing", "border-box");
-        
+
         this.kag.setStyles(j_inner_layer, def_style_inner);
-        
+
         //名前表示エリアを復元する。
         $(".tyrano_base").find(".chara_name_area").show();
 
@@ -6379,7 +6434,6 @@ tyrano.plugin.kag.tag.button = {
     //イメージ表示レイヤ。メッセージレイヤのように扱われますね。。
     //cmで抹消しよう
     start: function (pm) {
-        
         var that = this;
 
         var target_layer = null;
@@ -6553,9 +6607,8 @@ tyrano.plugin.kag.tag.button = {
         //
 
         j_button.on("mousedown touchstart", (e) => {
-            
             e.stopPropagation();
-                
+
             if (!this.kag.stat.is_strong_stop) return true;
             if (button_clicked) return true;
             if (!j_button.hasClass("src-change-disabled")) {
@@ -6570,7 +6623,6 @@ tyrano.plugin.kag.tag.button = {
         //
 
         j_button.on("click", (e) => {
-            
             // ブラウザの音声の再生制限を解除
             if (!that.kag.tmp.ready_audio) that.kag.readyAudio();
 

--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -487,6 +487,22 @@ tyrano.plugin.kag.tag.playbgm = {
             // ボイスなら波形分析する
             if (is_voice) {
                 this.analyzeAudioForLipSync(audio_obj, pm.chara_name);
+            } else if (pm.chara) {
+                this.analyzeAudioForLipSync(audio_obj, pm.chara);
+            } else if (is_se) {
+                const _buf = parseInt(buf);
+                if (this.kag.stat.lipsync_buf_chara[buf]) {
+                    pm.chara_name = this.kag.stat.lipsync_buf_chara[buf];
+                    this.analyzeAudioForLipSync(audio_obj, pm.chara_name);
+                } else {
+                    pm.chara_name = this.kag.chara.getCharaName();
+                    if (pm.chara_name) {
+                        const cpm = this.kag.stat.charas[pm.chara_name];
+                        if (cpm && cpm.lipsync_bufs && cpm.lipsync_bufs.includes(_buf)) {
+                            this.analyzeAudioForLipSync(audio_obj, pm.chara_name);
+                        }
+                    }
+                }
             }
             // nextOrder
             next();

--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -690,16 +690,15 @@ tyrano.plugin.kag.tag.playbgm = {
         const target_parts = this.getLipSyncParts(name);
         if (!target_parts) return null;
 
-        // const requestAnimationFrame = (callback) => {
-        //     return setTimeout(callback, 1000 / 30);
-        // };
-        // const cancelAnimationFrame = clearTimeout;
+        const requestAnimationFrame = (callback) => {
+            return setTimeout(callback, 1000 / 30);
+        };
+        const cancelAnimationFrame = clearTimeout;
 
         // ベースのリップ画像（閉じている口の画像）だけを表示する関数
         const resetFrameOpacity = () => {
             target_parts.forEach((target_part) => {
-                target_part.j_frames.css("opacity", "0");
-                target_part.j_frames.eq(0).css("opacity", "1");
+                target_part.j_frames.showAtIndexWithVisibility(0);
             });
         };
 
@@ -719,8 +718,9 @@ tyrano.plugin.kag.tag.playbgm = {
         analyser.fftSize = 32;
         const buffer_length = analyser.frequencyBinCount;
         const data_array = new Uint8Array(buffer_length);
-        const analyze = (timestamp) => {
+        const analyze = () => {
             // 経過時間
+            const timestamp = performance.now();
             const elapsed_time = timestamp - last_timestamp;
             // 振幅のサンプリングデータをdata_arrayに格納する
             analyser.getByteTimeDomainData(data_array);
@@ -801,8 +801,8 @@ tyrano.plugin.kag.tag.playbgm = {
             if (part.current_index === part.thresholds.length) {
                 // 経過時間を数える
                 part.max_open_mouth_time += elapsed_time;
-                // 一度口を開けたら500ミリ秒間はそのまま固定する
-                if (part.max_open_mouth_time < 100) {
+                // 一度口を開けたら200ミリ秒間はそのまま固定する
+                if (part.max_open_mouth_time < 200) {
                     return;
                 } else {
                     part.max_open_mouth_time = 0;

--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -614,72 +614,6 @@ tyrano.plugin.kag.tag.playbgm = {
     },
 
     /**
-     * リップシンクの対象となるパーツを取得する。
-     * 取得できなかった場合はnullが返る。
-     * @param {string} name - キャラクターの名前。
-     * @param {string} type - リップシンクタイプ。"voice"または"text"。
-     * @returns {Array<Object>} target_parts - 更新対象のパーツの配列。
-     * @returns {Object} target_parts[].j_frames - jQueryオブジェクト。フレームのコレクション。
-     * @returns {Array<number>} target_parts[].thresholds - 各フレームを表示するための閾値の配列。
-     */
-    getLipSyncParts(name, type = "voice") {
-        // キャラ定義
-        const cpm = this.kag.stat.charas[name];
-
-        // キャラ定義が存在しない→無効
-        if (!cpm) return null;
-        // キャラが表示されていない→無効
-        if (!cpm.is_show === "false") return null;
-        // キャラ定義は存在するがリップシンクタイプが一致しない→無効
-        if (cpm.lipsync_type !== type) return null;
-
-        // キャラのjQueryオブジェクト
-        const j_chara = this.kag.chara.getCharaContainer(name);
-
-        // キャラのjQueryオブジェクトが取得できない→無効
-        if (j_chara.length === 0) return null;
-
-        //
-        // 現在のキャラクターのパーツの状況をチェック
-        //
-
-        // リップシンクのパーツを格納する配列
-        // 口が複数あるようなキャラクターを一応想定している
-        const target_parts = [];
-
-        // すべてのパーツを走査してリップシンク対象のパーツを特定する
-        const part_map = cpm._layer;
-        if (!part_map) return;
-        for (const part in part_map) {
-            const part_obj = part_map[part];
-            const state = part_obj.current_part_id;
-            const part_state_obj = part_obj[state];
-            if (!part_state_obj || !part_state_obj.is_lipsync_enabled) {
-                continue;
-            }
-            // ここに到達したならばこのパーツはリップシンク対象である
-
-            // このパーツのすべてのフレームの<img>要素の集合を取得
-            const j_frames = j_chara.find(`.lipsync-frame[data-effect=${part}-${state}]`);
-            const thresholds = part_state_obj.lip_volume;
-            if (j_frames.length > 0 && thresholds) {
-                target_parts.push({
-                    j_frames,
-                    thresholds,
-                    current_index: 0,
-                    max_open_mouth_time: 0,
-                    text_lipsync_timer_id: 0,
-                    def: part_state_obj,
-                });
-            }
-        }
-        // 対象のパーツがない→無効
-        if (target_parts.length === 0) return null;
-
-        return target_parts;
-    },
-
-    /**
      * Howlオブジェクトによって再生される音声を解析してリップシンクに利用するメソッド。
      * 音声信号の振幅を計算し、それに基づいてリップシンクを更新する。
      * @param {Howl} howl - 解析対象のHowlオブジェクト。
@@ -687,7 +621,7 @@ tyrano.plugin.kag.tag.playbgm = {
      */
     analyzeAudioForLipSync(howl, name) {
         // リップシンク対象のパーツを取得する（取得できなければこのリップシンクは無効）
-        const target_parts = this.getLipSyncParts(name);
+        const target_parts = this.kag.chara.getLipSyncParts(name);
         if (!target_parts) return null;
 
         const requestAnimationFrame = (callback) => {
@@ -737,7 +671,7 @@ tyrano.plugin.kag.tag.playbgm = {
             // 振幅を0～100に補正してリップシンクメソッドに渡す
             max = Math.max(128, max);
             const volume = (((max - 128) / (255 - 128)) * 100) | 0;
-            this.updateLipSyncWithVoice(volume, target_parts, elapsed_time);
+            this.kag.chara.updateLipSyncWithVoice(volume, target_parts, elapsed_time);
             // 無音の経過時間を計算
             // 既定時間無音だった場合は波形分析を中断する
             if (max <= 128) {
@@ -768,59 +702,6 @@ tyrano.plugin.kag.tag.playbgm = {
 
         // 解析開始
         analyze();
-    },
-
-    /**
-     * リップシンクを更新するメソッド。
-     * 入力値に基づいて、指定されたパーツの表示状態を変更する。
-     * @param {number} value - 現在の振幅の値。
-     * @param {Array<Object>} target_parts - 更新対象のパーツの配列。
-     * @param {number} elapsed_time - 前回のリップシンクからの経過時間。
-     * @param {Object} target_parts[].j_frames - jQueryオブジェクト。フレームのコレクション。
-     * @param {Array<number>} target_parts[].thresholds - 各フレームを表示するための閾値の配列。
-     * @param {number} target_parts[].current_index - 前回表示したフレームのインデックス。
-     */
-    updateLipSyncWithVoice(value, target_parts, elapsed_time) {
-        target_parts.forEach((part) => {
-            // 閾値から現在形成すべきリップフレーム番号を特定する
-            let target_i = 0;
-            for (; target_i < part.thresholds.length; target_i++) {
-                if (value < part.thresholds[target_i]) {
-                    break;
-                }
-            }
-
-            // 前回のリップフレーム番号と同じであれば何も処理しなくてよい
-            if (target_i === part.current_index) {
-                return;
-            }
-
-            // ここに到達したならば前回のリップフレーム番号とは異なるということ
-
-            // 先ほどまで口を最大まで開けていた場合
-            if (part.current_index === part.thresholds.length) {
-                // 経過時間を数える
-                part.max_open_mouth_time += elapsed_time;
-                // 一度口を開けたら200ミリ秒間はそのまま固定する
-                if (part.max_open_mouth_time < 200) {
-                    return;
-                } else {
-                    part.max_open_mouth_time = 0;
-                }
-            }
-
-            // より口を大きく開こうとしている
-            if (target_i > part.current_index) {
-                // 1ずつ大きくしよう
-                target_i = part.current_index + 1;
-            } else {
-                // 1ずつ小さくしよう
-                target_i = part.current_index - 1;
-            }
-
-            part.j_frames.showAtIndexWithVisibility(target_i);
-            part.current_index = target_i;
-        });
     },
 
     /*

--- a/tyrano/plugins/kag/kag.tag_audio.js
+++ b/tyrano/plugins/kag/kag.tag_audio.js
@@ -668,6 +668,8 @@ tyrano.plugin.kag.tag.playbgm = {
                     thresholds,
                     current_index: 0,
                     max_open_mouth_time: 0,
+                    text_lipsync_timer_id: 0,
+                    def: part_state_obj,
                 });
             }
         }
@@ -735,7 +737,7 @@ tyrano.plugin.kag.tag.playbgm = {
             // 振幅を0～100に補正してリップシンクメソッドに渡す
             max = Math.max(128, max);
             const volume = (((max - 128) / (255 - 128)) * 100) | 0;
-            this.updateLipSync(volume, target_parts, elapsed_time);
+            this.updateLipSyncWithVoice(volume, target_parts, elapsed_time);
             // 無音の経過時間を計算
             // 既定時間無音だった場合は波形分析を中断する
             if (max <= 128) {
@@ -778,7 +780,7 @@ tyrano.plugin.kag.tag.playbgm = {
      * @param {Array<number>} target_parts[].thresholds - 各フレームを表示するための閾値の配列。
      * @param {number} target_parts[].current_index - 前回表示したフレームのインデックス。
      */
-    updateLipSync(value, target_parts, elapsed_time) {
+    updateLipSyncWithVoice(value, target_parts, elapsed_time) {
         target_parts.forEach((part) => {
             // 閾値から現在形成すべきリップフレーム番号を特定する
             let target_i = 0;
@@ -816,8 +818,7 @@ tyrano.plugin.kag.tag.playbgm = {
                 target_i = part.current_index - 1;
             }
 
-            part.j_frames.css("opacity", "0");
-            part.j_frames.eq(target_i).css("opacity", "1");
+            part.j_frames.showAtIndexWithVisibility(target_i);
             part.current_index = target_i;
         });
     },

--- a/tyrano/plugins/kag/kag.tag_ext.js
+++ b/tyrano/plugins/kag/kag.tag_ext.js
@@ -2819,13 +2819,60 @@ tyrano.plugin.kag.tag.chara_show = {
     },
 
     /**
-     * キーフレームアニメーションを構成する
-     * キャラ表示時に呼び出す
-     * @param {*} cpm - キャラ定義。例）TYRANO.kag.stat.charas.akane
-     * @param {*} part - パーツ部位名。例）eye
-     * @param {*} state - パーツ状態名。例）smile
-     * @param {*} j_frame_base - ベースとなるパーツの<img>要素。
-     * @param {*} preload_srcs - この配列に画像ソースを入れておくと関数の呼び出し元でプリロードに使われる。
+     * フレームアニメーションの各フレームの画像ソースの配列を取得する
+     * @param {Object} cpm - キャラ定義。例）TYRANO.kag.stat.charas.akane
+     * @param {string} part - パーツ部位名。例）eye
+     * @param {string} state - パーツ状態名。例）smile
+     * @returns {Array<string>}
+     */
+    getFrameAnimationSrcs(cpm, part, state) {
+        // パーツ状態がstorage直接指定の場合は無視
+        if (state === "allow_storage") {
+            return [];
+        }
+
+        // パーツ状態定義を取得
+        const state_obj = cpm["_layer"][part][state];
+
+        // frame_image属性が未指定なら無視
+        if (!state_obj.frame_image) {
+            return [];
+        }
+
+        const srcs = [];
+
+        // すべてのフレームについて<img>要素を作成
+        state_obj.frame_image.forEach((frame_src) => {
+            // 画像ソースを決定する
+            const origin_src = $.parseStorage(state_obj.storage, "fgimage");
+            const src = ((path, filename) => {
+                const hash_slash = path.split("/");
+                const hash_dot = hash_slash.pop().split(".");
+                let new_filename;
+                if (hash_dot.length > 1) {
+                    const extension = hash_dot.pop();
+                    new_filename = `${filename}.${extension}`;
+                } else {
+                    new_filename = filename;
+                }
+                hash_slash.push(new_filename);
+                return hash_slash.join("/");
+            })(origin_src, frame_src);
+
+            srcs.push(src);
+        });
+
+        return srcs;
+    },
+
+    /**
+     * フレームアニメーションを設定する
+     * @param {Object} cpm - キャラ定義。例）TYRANO.kag.stat.charas.akane
+     * @param {string} part - パーツ部位名。例）eye
+     * @param {string} state - パーツ状態名。例）smile
+     * @param {jQuery} j_frame_base - ベースとなるパーツの<img>要素。
+     * @param {Array<string>} preload_srcs - この配列に画像ソースを入れておくと関数の呼び出し元でプリロードに使われる。
+     * @returns {jQuery|null}
      */
     setFrameAnimation(cpm, part, state, j_frame_base, preload_srcs) {
         // パーツ状態がstorage直接指定の場合は無視
@@ -2867,7 +2914,7 @@ tyrano.plugin.kag.tag.chara_show = {
             // 属性、クラス、CSSの調整
             j_clone.attr("src", src);
             j_clone.addClass("sub");
-            j_clone.removeClass("chara-layer-frame-base");
+            j_clone.removeClass("base");
             j_clone.css("visibility", "hidden");
 
             // プリロードに追加
@@ -2886,6 +2933,7 @@ tyrano.plugin.kag.tag.chara_show = {
         if (state_obj.lip_image) {
             cpm.lipsync_type = state_obj.lip_type;
             state_obj.is_lipsync_enabled = true;
+            j_frame_base.addClass("base");
             j_frames.addClass("lipsync-frame");
             j_frames.attr("data-effect", `${part}-${state}`);
             return j_frames;
@@ -2893,7 +2941,7 @@ tyrano.plugin.kag.tag.chara_show = {
 
         // オリジナルの<img>要素にクラスと属性付与
         // キャラの名前、パーツ部位の名前、パーツ状態の名前を記憶
-        j_frame_base.addClass("chara-layer-frame-base");
+        j_frame_base.addClass("base");
         j_frame_base.attr(
             "data-restore",
             JSON.stringify({
@@ -2911,17 +2959,16 @@ tyrano.plugin.kag.tag.chara_show = {
             j_img.attr("data-event-pm", part);
         });
 
-        this.startFrameAnimation(cpm, state_obj, j_frames);
+        this.startFrameAnimation(state_obj, j_frames);
         return j_frames;
     },
 
     /**
      * フレームアニメーションを開始する
-     * @param {Object} cpm - キャラ定義。例）TYRANO.kag.stat.charas.akane
      * @param {string} state_obj - パーツ状態定義。例）cpm._layer.eye.smile
      * @param {jQuery} j_frames - フレームアニメーションを構成するすべての<img>要素のjQueryコレクション
      */
-    startFrameAnimation(cpm, state_obj, j_frames) {
+    startFrameAnimation(state_obj, j_frames) {
         // フレーム番号
         let frame_index = 0;
 
@@ -2986,7 +3033,7 @@ tyrano.plugin.kag.tag.chara_show = {
         };
 
         // 最初の瞬き
-        setTimeout(anim, calc_duration(0));
+        state_obj.frame_timer_id = setTimeout(anim, calc_duration(0));
     },
 
     /**
@@ -3033,16 +3080,20 @@ tyrano.plugin.kag.tag.chara_show = {
     restoreAllFrameAnimation() {
         const that = this;
 
-        // フレームアニメーションのベース画像すべてについて復元
-        $(".chara-layer-frame-base").each(function () {
+        // フレームアニメーションの復元作業
+        $(".chara-layer-frame.base").each(function () {
             try {
+                // ベース画像
                 const j_frame_base = $(this);
+                // 保存しておいた設定値
                 const setting = JSON.parse(j_frame_base.attr("data-restore"));
+                // キャラ定義
                 const cpm = that.kag.stat.charas[setting.chara_name];
+                // キャラパーツ状態定義
                 const state_obj = cpm._layer[setting.part_name][setting.state_name];
 
                 // このパーツのフレームアニメーションの
-                // すべてのフレーム画像を含むような集合
+                // すべてのフレーム画像を含むようなコレクション
                 let j_frames = $(j_frame_base);
                 const j_siblings = j_frame_base.siblings(`.chara-layer-frame[data-event-pm=${setting.part_name}]`);
                 j_frames = j_frames.add(j_siblings);
@@ -3052,7 +3103,20 @@ tyrano.plugin.kag.tag.chara_show = {
                 j_frames.showAtIndexWithVisibility(i);
 
                 // フレームアニメーションを開始
-                that.startFrameAnimation(cpm, state_obj, j_frames);
+                that.startFrameAnimation(state_obj, j_frames);
+            } catch (e) {
+                console.error(e);
+            }
+        });
+
+        // リップシンクが有効な口パーツをベース画像に戻す
+        // 口パク中にセーブされる可能性があるためその対策
+        $(".lipsync-frame.base").each(function () {
+            try {
+                const j_frame_base = $(this);
+                const data_effect = j_frame_base.attr("data-effect");
+                j_frame_base.siblings(`.sub[data-effect=${data_effect}]`).css("visibility", "hidden");
+                j_frame_base.css("visibility", "visible");
             } catch (e) {
                 console.error(e);
             }
@@ -3764,7 +3828,7 @@ zindex  = このパーツが他のパーツと重なった時にどちらが前�
 */
 
 tyrano.plugin.kag.tag.chara_layer = {
-    vital: ["name", "part", "id", "storage"],
+    vital: ["name", "part", "id"],
 
     pm: {
         name: "",
@@ -3817,6 +3881,17 @@ tyrano.plugin.kag.tag.chara_layer = {
                 lip_image: "",
                 lip_volume: "",
             };
+        } else {
+            for (const key in part_obj[pm.id]) {
+                if (!pm[key]) {
+                    pm[key] = part_obj[pm.id][key];
+                }
+                if (part_obj["current_part_id"] === pm.id) {
+                    if (pm.lip_type) {
+                        cpm.lipsync_type = pm.lip_type;
+                    }
+                }
+            }
         }
 
         // リップシンク画像が設定されている場合
@@ -3916,6 +3991,17 @@ tyrano.plugin.kag.tag.chara_layer = {
 
         // パーツ差分領域にpmの内容を上書きする
         $.extendParam(pm, part_obj[pm.id]);
+
+        // いま表示されているキャラクターのパーツの設定を変更した場合
+        // [chara_part]を呼んで強制的にパーツを更新する
+        if (cpm.is_show === "true" && cpm._layer[pm.part].current_part_id === pm.id) {
+            this.kag.ftag.startTag("chara_part", {
+                name: pm.name,
+                [pm.part]: pm.id,
+                force: "true",
+            });
+            return;
+        }
 
         this.kag.ftag.nextOrder();
     },
@@ -4019,6 +4105,7 @@ tyrano.plugin.kag.tag.chara_part = {
         allow_storage: "false",
         time: "",
         wait: "true",
+        force: "false",
     },
 
     start: function (pm) {
@@ -4042,11 +4129,14 @@ tyrano.plugin.kag.tag.chara_part = {
         // 切替先のパーツ状態定義のマップを取得する
         //
 
-        // 切替対象のパーツ状態定義を格納する配列
+        // 切替対象のパーツ状態定義を格納するマップ
         const target_map = {};
 
+        // 切替前のパーツ状態IDを格納しておくマップ
+        const prev_map = {};
+
         // プリロード対象の画像ソースを格納する配列
-        const preload_srcs = [];
+        let preload_srcs = [];
 
         // タグに指定されたすべての属性（＝パーツ名）について走査する
         for (const part_id in pm) {
@@ -4061,17 +4151,24 @@ tyrano.plugin.kag.tag.chara_part = {
             // この状態IDがパーツ定義に存在する場合
             if (part_map[part_id][state_id]) {
                 // この状態IDが現在のパーツの状態IDとは異なる場合に限り切替作業を行う
-                if (part_map[part_id]["current_part_id"] !== state_id) {
+                // ただしforce=trueが指定されている場合は同じパーツ状態IDでも強制的に切替作業を行う
+                if (part_map[part_id]["current_part_id"] !== state_id || pm.force === "true") {
                     // 状態定義を取得
                     const state_obj = part_map[part_id][state_id];
                     state_obj.id = state_id;
 
                     // プリロード対象に追加
                     if (state_obj["storage"] !== "none") {
-                        preload_srcs.push($.parseStorage(state_obj["storage"], "fgimage"));
+                        const src = $.parseStorage(state_obj["storage"], "fgimage");
+                        preload_srcs.push(src);
+                        const frame_srcs = this.kag.tag.chara_show.getFrameAnimationSrcs(cpm, part_id, state_id);
+                        if (frame_srcs.length) {
+                            preload_srcs = preload_srcs.concat(frame_srcs);
+                        }
                     }
 
                     // 現在のパーツ状態を書き換える
+                    prev_map[part_id] = part_map[part_id]["current_part_id"];
                     part_map[part_id]["current_part_id"] = state_id;
 
                     // 切替対象マップに追加
@@ -4105,6 +4202,9 @@ tyrano.plugin.kag.tag.chara_part = {
 
         // キャラクターを構成するDOM要素のラッパーのjQueryオブジェクトを取得
         const j_chara = this.kag.chara.getCharaContainer(pm.name);
+
+        // 重複を除く
+        preload_srcs = [...new Set(preload_srcs)];
 
         // プリロード完了を待つ
         this.kag.preloadAll(preload_srcs, () => {
@@ -4154,7 +4254,7 @@ tyrano.plugin.kag.tag.chara_part = {
                     j_img_last.after(j_new_img);
 
                     // クローンについて目パチ口パクなどのフレームアニメーションを設定する（設定があれば）
-                    const ret = this.kag.tag.chara_show.setFrameAnimation(cpm, part_id, part.id, j_new_img, preload_srcs);
+                    const ret = this.kag.tag.chara_show.setFrameAnimation(cpm, part_id, part.id, j_new_img);
 
                     // フレームアニメーションの設定があった場合、すべてのフレームのコレクションをj_new_imgに代入する
                     j_new_img = ret || j_new_img;
@@ -4205,7 +4305,20 @@ tyrano.plugin.kag.tag.chara_part = {
                     const part = target_map[part_id];
 
                     // このパーツの<img>要素を取得
-                    const j_img = j_chara.find(`.part.${part_id}`);
+                    let j_img = j_chara.find(`.part.${part_id}`);
+
+                    // フレームアニメーションなどの設定がある場合はベースの1枚を残してあとは削除する
+                    if (j_img.length > 1) {
+                        j_img.filter(".lipsync-frame.sub").remove();
+                        j_img.filter(".chara-layer-frame.sub").remove();
+                        j_img = j_img.filter(".base");
+                        j_img.css("visibility", "visible");
+                        j_img.removeClass("chara-layer-frame lipsync-frame　base sub");
+                        j_img.removeAttr("data-restore");
+                        j_img.removeAttr("data-effect");
+                        j_img.removeAttr("data-event-pm");
+                        clearTimeout(cpm._layer[part_id][prev_map[part_id]].frame_timer_id);
+                    }
 
                     // src属性を書き換える
                     if (part.storage !== "none") {
@@ -4213,6 +4326,9 @@ tyrano.plugin.kag.tag.chara_part = {
                     } else {
                         j_img.attr("src", "./tyrano/images/system/transparent.png");
                     }
+
+                    // クローンについて目パチ口パクなどのフレームアニメーションを設定する（設定があれば）
+                    this.kag.tag.chara_show.setFrameAnimation(cpm, part_id, part.id, j_img);
 
                     // [chara_layer]にeye_zindex="10"のような指定があった場合
                     // CSSのz-indexプロパティの変更を行う

--- a/tyrano/plugins/kag/kag.tag_ext.js
+++ b/tyrano/plugins/kag/kag.tag_ext.js
@@ -2001,8 +2001,8 @@ tyrano.plugin.kag.tag.chara_ptext = {
         // 発言者名
         //
 
+        // 誰も話していない場合
         if (pm.name == "") {
-            // 誰も話していない
             j_chara_name.updatePText("");
 
             // キャラフォーカス機能が有効の場合、全員に非発言者用のスタイルを当てる。誰も話していないから
@@ -2014,9 +2014,9 @@ tyrano.plugin.kag.tag.chara_ptext = {
             if (this.kag.stat.chara_talk_anim == "zoom") {
                 this.zoomChara("", this.kag.stat.chara_talk_anim_zoom_rate);
             }
-        } else {
-            // 誰かが話している
-
+        }
+        // 誰かが話している場合
+        else {
             // 日本語で指定されていた場合はIDに直す
             // 例) "あかね" → "akane"
             if (this.kag.stat.jcharas[pm.name]) {
@@ -2025,9 +2025,9 @@ tyrano.plugin.kag.tag.chara_ptext = {
 
             // キャラクター定義を取得
             const cpm = this.kag.stat.charas[pm.name];
-            if (cpm) {
-                // キャラクターが取得できた場合
 
+            // キャラクターが取得できた場合
+            if (cpm) {
                 // キャラクター名出力
                 j_chara_name.updatePText(cpm.jname);
 
@@ -2069,8 +2069,10 @@ tyrano.plugin.kag.tag.chara_ptext = {
                         }
                     }, timeout);
                 }
-            } else {
-                // キャラクター定義が存在しない場合は指定ワードをそのまま表示
+            }
+            // キャラクター定義が存在しない場合
+            else {
+                // 指定ワードをそのまま表示
                 j_chara_name.updatePText(pm.name);
 
                 // キャラフォーカス機能が有効の場合、全員に非発言者用のスタイルを当てる。誰も話していないから
@@ -2084,6 +2086,9 @@ tyrano.plugin.kag.tag.chara_ptext = {
                 }
             }
         }
+
+        // 現在の発言者
+        this.kag.stat.current_speaker = pm.name || "";
 
         //
         // ボイス設定
@@ -3572,9 +3577,13 @@ tyrano.plugin.kag.tag.chara_layer = {
                 frame_image: "",
                 frame_time: "",
                 frame_direction: "",
-                lip_type: "text",
+                frame_loop: "true",
                 lip_image: "",
+                lip_time: 50,
+                lip_type: "text",
                 lip_volume: "",
+                lip_se_buf: "",
+                lip_se_buf_all: "",
             };
         } else {
             for (const key in part_obj[pm.id]) {
@@ -3624,9 +3633,9 @@ tyrano.plugin.kag.tag.chara_layer = {
             for (let i = 0; i < pm.frame_image.length; i++) {
                 if (!pm.lip_volume[i]) {
                     if (!prev_value) {
-                        pm.lip_volume[i] = 5;
+                        pm.lip_volume[i] = 1;
                     } else {
-                        pm.lip_volume[i] = prev_value + 5;
+                        pm.lip_volume[i] = prev_value + 4;
                     }
                 }
                 prev_value = pm.lip_volume[i];
@@ -3686,6 +3695,19 @@ tyrano.plugin.kag.tag.chara_layer = {
                     prev_val = pm.frame_time[i];
                 }
             });
+        }
+
+        // 口パクの対象に取る[playse]のスロット
+        if (pm.lip_se_buf) {
+            pm.lip_se_buf = parseInt(pm.lip_se_buf);
+            if (!cpm.lipsync_bufs) {
+                cpm.lipsync_bufs = [];
+            }
+            cpm.lipsync_bufs.push(pm.lip_se_buf);
+        }
+        if (pm.lip_se_buf_all) {
+            pm.lip_se_buf_all = parseInt(pm.lip_se_buf_all);
+            this.kag.stat.lipsync_buf_chara[pm.lip_se_buf_all] = pm.name;
         }
 
         // パーツ差分領域にpmの内容を上書きする


### PR DESCRIPTION
ティラノスクリプトのキャラパーツ定義タグ[chara_layer]を改変し、目パチ口パクのアニメーションが設定できるようにした。目パチに限らず、汎用的なキャラパーツアニメーションの設定が可能である。口パクについては、テキストベースのものだけでなく、ボイスに紐付いたリップシンクも可能である。ドキュメントは[こちら](https://harmless-drawer-b69.notion.site/cf86426a04304d81894edfbe2f24a681)。