### PR TITLE
commit タグにおけるシングルクォートのエスケープ

### DIFF
--- a/tyrano/plugins/kag/kag.tag_system.js
+++ b/tyrano/plugins/kag/kag.tag_system.js
@@ -1821,7 +1821,7 @@ tyrano.plugin.kag.tag.commit = {
             .find(".form")
             .each(function () {
                 var name = $(this).attr("name");
-                var val = $(this).val();
+                var val = $(this).val().replace("'", "\\'");
 
                 var str = name + " = '" + val + "'";
 


### PR DESCRIPTION
`commit` タグにおいて `'` が含まれる文字列が入力された場合、エラーでソフトロックとなります。
エスケープすることで解消されました。