### PR TITLE
fix: $.isBase64(str)の関数で audio, video の形式も受け入れるように変更

### DIFF
--- a/tyrano/libs.js
+++ b/tyrano/libs.js
@@ -1299,14 +1299,16 @@
         });
     };
 
+    /**
+     * 文字列がdata-URLであるかを判定する
+     * @param {string} str - 判定する文字列
+     * @returns {boolean} data-URLの場合はtrue、そうでない場合はfalse
+     */
     $.isBase64 = function (str) {
-        if (!str) return false;
-
-        if (str.substr(0, 10) == "data:image") {
-            return true;
-        } else {
-            return false;
-        }
+        if (!str || typeof str !== "string" ) return false;
+        
+        // 画像, 音声, 動画ファイルを受け入れる
+        return str.startsWith("data:image") || str.startsWith("data:audio") || str.startsWith("data:video")
     };
 
     //オブジェクトの個数をもってきます。1


### PR DESCRIPTION
playseのstorageにdata-urlのバイナリデータを渡しても音が鳴るようになります。

## 備考

- isBase64 という関数名ですが、isDataUrlという関数名にしたほうが良いかもしれません。
- imageを受け入れたいとき、audioを受け入れたいとき、videoを受け入れたいときと区別するべきかもしれません。
- 判定方法が甘くdata-urlの一部しかtrueになりません。また厳密にdata-urlの要件を満たしていないものでも`true`になりえます。