### PR TITLE
wait_preloadタグ

### DIFF
--- a/tyrano/plugins/kag/kag.js
+++ b/tyrano/plugins/kag/kag.js
@@ -1952,29 +1952,29 @@ tyrano.plugin.kag = {
     },
 
     registerPreloadCompleteCallback(callback) {
-        if (this.preload_objects.length === 0) {
+        if (this.tmp.preload_objects.length === 0) {
             callback();
             return;
         }
-        this.preload_complete_callbacks.push(callback);
+        this.tmp.preload_complete_callbacks.push(callback);
     },
 
     //画像のプリロード オンの場合は、ロードが完了するまで次へ行かない
     preload: function (src, callbk, options = {}) {
         var symbol = Symbol();
-        this.preload_objects.push(symbol);
+        this.tmp.preload_objects.push(symbol);
         this.kag.showLoadingLog("preload");
 
         const removeByPreloadObjects = () => {
-            var index = this.preload_objects.indexOf(symbol);
+            var index = this.tmp.preload_objects.indexOf(symbol);
             if (index !== -1) {
-                this.preload_objects.splice(index, 1);
+                this.tmp.preload_objects.splice(index, 1);
             }
-            if (this.preload_objects.length == 0 && this.preload_complete_callbacks.length > 0) {
-                this.preload_complete_callbacks.forEach((callback) => {
+            if (this.tmp.preload_objects.length == 0 && this.tmp.preload_complete_callbacks.length > 0) {
+                this.tmp.preload_complete_callbacks.forEach((callback) => {
                     callback();
                 });
-                this.preload_complete_callbacks.splice(0, this.preload_complete_callbacks.length);
+                this.tmp.preload_complete_callbacks.splice(0, this.tmp.preload_complete_callbacks.length);
             }
         }
 

--- a/tyrano/plugins/kag/kag.js
+++ b/tyrano/plugins/kag/kag.js
@@ -164,6 +164,8 @@ tyrano.plugin.kag = {
         },
 
         preload_audio_map: {},
+        preload_objects: [],
+        preload_complete_callbacks: [],
 
         mode_effect: {
             pc: {
@@ -1949,11 +1951,35 @@ tyrano.plugin.kag = {
         jtext.find("p").find(".current_span").html(str);
     },
 
+    registerPreloadCompleteCallback(callback) {
+        if (this.preload_objects.length === 0) {
+            callback();
+            return;
+        }
+        this.preload_complete_callbacks.push(callback);
+    },
+
     //画像のプリロード オンの場合は、ロードが完了するまで次へ行かない
     preload: function (src, callbk, options = {}) {
+        var symbol = Symbol();
+        this.preload_objects.push(symbol);
         this.kag.showLoadingLog("preload");
 
+        const removeByPreloadObjects = () => {
+            var index = this.preload_objects.indexOf(symbol);
+            if (index !== -1) {
+                this.preload_objects.splice(index, 1);
+            }
+            if (this.preload_objects.length == 0 && this.preload_complete_callbacks.length > 0) {
+                this.preload_complete_callbacks.forEach((callback) => {
+                    callback();
+                });
+                this.preload_complete_callbacks.splice(0, this.preload_complete_callbacks.length);
+            }
+        }
+
         const onend = (elm) => {
+            removeByPreloadObjects();
             this.kag.hideLoadingLog();
             if (callbk) callbk(elm);
         };
@@ -1988,6 +2014,7 @@ tyrano.plugin.kag = {
                 switch (preloaded_audio.state()) {
                     case "unload":
                         // アンロードで残っていることは基本的にはないが…
+                        removeByPreloadObjects();
                         delete this.kag.tmp.preload_audio_map[src];
                         break;
                     case "loading":

--- a/tyrano/plugins/kag/kag.tag_system.js
+++ b/tyrano/plugins/kag/kag.tag_system.js
@@ -1705,7 +1705,7 @@ tyrano.plugin.kag.tag.wait_preload = {
     start: function (pm) {
         var that = this;
         that.kag.weaklyStop();
-        that.tag.registerPreloadCompleteCallback(function () {
+        that.kag.registerPreloadCompleteCallback(function () {
             that.kag.cancelWeakStop();
             that.kag.ftag.nextOrder();
         });

--- a/tyrano/plugins/kag/kag.tag_system.js
+++ b/tyrano/plugins/kag/kag.tag_system.js
@@ -1678,6 +1678,41 @@ tyrano.plugin.kag.tag.preload = {
 };
 
 /*
+#[wait_preload]
+
+:group
+変数・JS操作・ファイル読込
+
+:title
+素材ファイルの事前読み込みの完了待機
+
+:exp
+`[preload]`タグをwait=falseで利用した後、何かの演出を挟んだ後、全てのpreloadが終わるのを待機します。
+
+:sample
+
+;preloadで複数の画像をwait=falseで読み込みます
+[preload storage="data/fgimage/girl.jpg" wait="false"]
+[preload storage="data/fgimage/haruko.jpg" wait="false"]
+;読み込んでいる間に別のアニメーションをします
+[quake2 time="1000" wait="true"]
+;まだ終わっていない場合は終わるまで待機します
+[wait_preload]
+
+#[end]
+*/
+tyrano.plugin.kag.tag.wait_preload = {
+    start: function (pm) {
+        var that = this;
+        that.kag.weaklyStop();
+        that.tag.registerPreloadCompleteCallback(function () {
+            that.kag.cancelWeakStop();
+            that.kag.ftag.nextOrder();
+        });
+    },
+}
+
+/*
 #[unload]
 
 :group


### PR DESCRIPTION
preloadをwait = falseで実行してからなんらかの演出を挟み、その後で改めてpreloadの完了を待つ、という、よくある処理記述できるようにしたいです。

現状、kag.jsのpreloadは、特にロード中のvideoとimgのオブジェクトを外部から掴む事ができない構造になっているため、preload処理自体に待機中のオブジェクト管理機能を設け、改めてそのロードを待つ、という機能を付ける形にしました。

コード中のコメントでも補足します。

ご検討の程よろしくお願いします。