### PR TITLE
カメラ制御の見直し

### DIFF
--- a/tyrano/plugins/kag/kag.tag_camera.js
+++ b/tyrano/plugins/kag/kag.tag_camera.js
@@ -150,22 +150,20 @@ tyrano.plugin.kag.tag.camera = {
             },
 
             complete: function () {
-                //アニメーションが完了しないと次へはいかない
-                if (pm.wait == "true" && flag_complete == false) {
-                    flag_complete = true; //最初の一回だけwait有効
-
-                    setTimeout(function () {
+                if (flag_complete) return;
+                flag_complete = true;
+                setTimeout(function () {
+                    that.kag.stat.is_move_camera = false;
+                    if (pm.wait == "true") {
                         that.kag.ftag.nextOrder();
-                    }, 300);
-                } else {
-                    //カメラを待ってる状態なら
-                    if (that.kag.stat.is_wait_camera == true) {
-                        that.kag.stat.is_wait_camera = false;
-                        that.kag.ftag.nextOrder();
+                    } else {
+                        //カメラを待ってる状態なら
+                        if (that.kag.stat.is_wait_camera == true) {
+                            that.kag.stat.is_wait_camera = false;
+                            that.kag.ftag.nextOrder();
+                        }
                     }
-                }
-
-                that.kag.stat.is_move_camera = false;
+                }, 20);
             },
         };
 
@@ -277,32 +275,33 @@ tyrano.plugin.kag.tag.reset_camera = {
             },
 
             complete: function () {
-                //リセットした時は、本当に消す
-                $("." + pm.layer).css({
-                    "-animation-name": "",
-                    "-animation-duration": "",
-                    "-animation-play-state": "",
-                    "-animation-delay": "",
-                    "-animation-iteration-count": "",
-                    "-animation-direction": "",
-                    "-animation-fill-mode": "",
-                    "-animation-timing-function": "",
-                    "transform": "",
-                });
-
-                //アニメーションが完了しないと次へはいかない
-                if (pm.wait == "true" && flag_complete == false) {
-                    flag_complete = true; //最初の一回だけwait有効
-                    that.kag.ftag.nextOrder();
-                } else {
-                    //カメラを待ってる状態なら
-                    if (that.kag.stat.is_wait_camera == true) {
-                        that.kag.stat.is_wait_camera = false;
+                if (flag_complete) return;
+                flag_complete = true;
+                setTimeout(function() {
+                    //リセットした時は、本当に消す
+                    $("." + pm.layer).css({
+                        "-animation-name": "",
+                        "-animation-duration": "",
+                        "-animation-play-state": "",
+                        "-animation-delay": "",
+                        "-animation-iteration-count": "",
+                        "-animation-direction": "",
+                        "-animation-fill-mode": "",
+                        "-animation-timing-function": "",
+                        "transform": "",
+                    });
+                    that.kag.stat.is_move_camera = false;
+                    if (pm.wait == "true") {
                         that.kag.ftag.nextOrder();
+                    } else {
+                        //カメラを待ってる状態なら
+                        if (that.kag.stat.is_wait_camera == true) {
+                            that.kag.stat.is_wait_camera = false;
+                            that.kag.ftag.nextOrder();
+                        }
                     }
-                }
+                }, 20);
 
-                that.kag.stat.is_move_camera = false;
             },
         };
 


### PR DESCRIPTION
以下の説明並びにコードに対するコメントをご参照ください。

## 前提

cameraをwait=falseで利用した場合、連続で利用するとwait_cameraをかけても上手く動作しないことがある。

また、cameraをwait=trueで利用すると、動きが少しもっさりする。

## 解決する問題

1. cameraをwait=trueで利用した場合、300msを待つのではなく、20ms待つ形に変更し、もっさり感を軽減する
2. wait=falseで利用した場合に、wait_cameraが正しく動作するようにする
3. reset_cameraでcompleteイベントが複数回飛んでくる挙動に対する耐性が弱かったので少し耐性を強化

## 副作用

reset_cameraに20ミリ秒waitを入れたため、reset_cameraでは逆に少しもっさりするようになる。

## 解決しない問題

cameraをwait="false"で起動し、その演出が終わらない内に違うcameraを起動する。

この場合、前のcameraのcompleteイベントで次のcameraが終了扱いされてしまう問題が残る。

このため、cameraの利用はwait=trueで利用するか、wait=falseで利用した後次のcamera演出の前に必ずwait_cameraを挟む、という制約をつける。
