### PR TITLE
cameraを全体的に見直し

### DIFF
--- a/tyrano/plugins/kag/kag.tag_camera.js
+++ b/tyrano/plugins/kag/kag.tag_camera.js
@@ -86,13 +86,6 @@ tyrano.plugin.kag.tag.camera = {
             return false;
         }
         */
-        
-        if (parseInt(pm.time) < 10) {
-            pm.time = 10;
-        }
-
-        //duration を確認する
-        var duration = pm.time + "ms";
 
         if (typeof this.kag.stat.current_camera[pm.layer] == "undefined") {
             this.kag.stat.current_camera[pm.layer] = {
@@ -130,7 +123,31 @@ tyrano.plugin.kag.tag.camera = {
             };
         }
 
-        var flag_complete = false;
+        var target_layers = pm.layer == "layer_camera" ? $(".layer_camera:visible") : $("." + pm.layer + "_fore:visible");
+        var complete_count = 0;
+        var time = parseInt(pm.time, 10);
+        if (time === 0) {
+            target_layers.css({
+                "-animation-name": "",
+                "-animation-duration": "",
+                "-animation-play-state": "",
+                "-animation-delay": "",
+                "-animation-iteration-count": "",
+                "-animation-direction": "",
+                "-animation-fill-mode": "",
+                "-animation-timing-function": "",
+                "transform": `scale(${to_camera.scale}) translate(${to_camera.x}, ${to_camera.y}) rotate(${to_camera.rotate})`
+            });
+            this.kag.stat.current_camera[pm.layer] = to_camera;
+            that.kag.ftag.nextOrder();
+            return;
+        }
+        if (time < 10) {
+            pm.time = 10;
+        }
+
+        //duration を確認する
+        var duration = pm.time + "ms";
         that.kag.stat.is_move_camera = true;
 
         var a3d_define = {
@@ -151,21 +168,18 @@ tyrano.plugin.kag.tag.camera = {
 
             complete: function () {
                 //アニメーションが完了しないと次へはいかない
-                if (pm.wait == "true" && flag_complete == false) {
-                    flag_complete = true; //最初の一回だけwait有効
-
-                    setTimeout(function () {
-                        that.kag.ftag.nextOrder();
-                    }, 300);
-                } else {
-                    //カメラを待ってる状態なら
-                    if (that.kag.stat.is_wait_camera == true) {
-                        that.kag.stat.is_wait_camera = false;
-                        that.kag.ftag.nextOrder();
+                if (++complete_count === target_layers.length) {
+                    that.kag.stat.is_move_camera = false;
+                    if (pm.wait == "true") {
+                            that.kag.ftag.nextOrder();
+                    } else {
+                        //カメラを待ってる状態なら
+                        if (that.kag.stat.is_wait_camera == true) {
+                            that.kag.stat.is_wait_camera = false;
+                            that.kag.ftag.nextOrder();
+                        }
                     }
                 }
-
-                that.kag.stat.is_move_camera = false;
             },
         };
 
@@ -176,13 +190,11 @@ tyrano.plugin.kag.tag.camera = {
         }
 
         //アニメーションの実行
+        target_layers.css("-webkit-transform-origin", "center center");
+        target_layers.a3d(a3d_define);
         if (pm.layer == "layer_camera") {
-            $(".layer_camera").css("-webkit-transform-origin", "center center");
-            $(".layer_camera").a3d(a3d_define);
             this.kag.stat.current_camera_layer = "";
         } else {
-            $("." + pm.layer + "_fore").css("-webkit-transform-origin", "center center");
-            $("." + pm.layer + "_fore").a3d(a3d_define);
             this.kag.stat.current_camera_layer = pm.layer;
         }
     },
@@ -241,7 +253,30 @@ tyrano.plugin.kag.tag.reset_camera = {
         var that = this;
         //duration を確認する
 
-        if (parseInt(pm.time) < 10) {
+        var target_layers = pm.layer == "layer_camera" ? $(".layer_camera:visible") : $("." + pm.layer + "_fore:visible");
+        var time = parseInt(pm.time, 10);
+        if (time === 0) {
+            target_layers.css({
+                "-animation-name": "",
+                "-animation-duration": "",
+                "-animation-play-state": "",
+                "-animation-delay": "",
+                "-animation-iteration-count": "",
+                "-animation-direction": "",
+                "-animation-fill-mode": "",
+                "-animation-timing-function": "",
+                "transform": "",
+            });
+            if (pm.layer !== "layer_camera") {
+                delete this.kag.stat.current_camera[pm.layer];
+            } else {
+                //全クリア
+                this.kag.stat.current_camera = {};
+            }
+            that.kag.ftag.nextOrder();
+            return;
+        }
+        if (time < 10) {
             pm.time = 10;
         }
 
@@ -256,7 +291,7 @@ tyrano.plugin.kag.tag.reset_camera = {
             rotate: "0deg",
         };
 
-        var flag_complete = false;
+        var complete_count = 0;
 
         that.kag.stat.is_move_camera = true;
 
@@ -278,7 +313,7 @@ tyrano.plugin.kag.tag.reset_camera = {
 
             complete: function () {
                 //リセットした時は、本当に消す
-                $("." + pm.layer).css({
+                target_layers.css({
                     "-animation-name": "",
                     "-animation-duration": "",
                     "-animation-play-state": "",
@@ -291,18 +326,18 @@ tyrano.plugin.kag.tag.reset_camera = {
                 });
 
                 //アニメーションが完了しないと次へはいかない
-                if (pm.wait == "true" && flag_complete == false) {
-                    flag_complete = true; //最初の一回だけwait有効
-                    that.kag.ftag.nextOrder();
-                } else {
-                    //カメラを待ってる状態なら
-                    if (that.kag.stat.is_wait_camera == true) {
-                        that.kag.stat.is_wait_camera = false;
+                if (++complete_count === target_layers.length) {
+                    that.kag.stat.is_move_camera = false;
+                    if (pm.wait == "true") {
                         that.kag.ftag.nextOrder();
+                    } else {
+                        //カメラを待ってる状態なら
+                        if (that.kag.stat.is_wait_camera == true) {
+                            that.kag.stat.is_wait_camera = false;
+                            that.kag.ftag.nextOrder();
+                        }
                     }
                 }
-
-                that.kag.stat.is_move_camera = false;
             },
         };
 
@@ -318,15 +353,9 @@ tyrano.plugin.kag.tag.reset_camera = {
         }
 
         //アニメーションの実行
-        if (pm.layer == "layer_camera") {
-            $(".layer_camera").css("-webkit-transform-origin", "center center");
-            $(".layer_camera").a3d(a3d_define);
-            this.kag.stat.current_camera_layer = "";
-        } else {
-            $("." + pm.layer + "_fore").css("-webkit-transform-origin", "center center");
-            $("." + pm.layer + "_fore").a3d(a3d_define);
-            this.kag.stat.current_camera_layer = "";
-        }
+        target_layers.css("-webkit-transform-origin", "center center");
+        target_layers.a3d(a3d_define);
+        this.kag.stat.current_camera_layer = "";
     },
 
     play: function (obj, cb) {},


### PR DESCRIPTION
以下の説明並びにコードに対するコメントをご参照ください。

## 前提

https://github.com/ShikemokuMK/tyranoscript/pull/132 同様、cameraをwait=falseで利用した場合、連続で利用するとwait_cameraをかけても上手く動作しないことがある。

また、cameraをwait=trueで利用すると、動きが少しもっさりする。

132では対応していなかったが、アニメーションを設定するレイヤーが必要以上に多い、並びに time = 0でカメラをかけても10ms + 20ms待たされるという問題がある。

## 解決する問題

1. cameraをwait=trueで利用した場合、300ms待つのをやめる
2. wait=falseで利用した場合に、wait_cameraが正しく動作するようにする
3. reset_cameraでも、camera同様の対応を入れる
4. time = 0で利用した場合に処理を即終了するようにする
5. 制御対象のレイヤーをアニメーションが発動するレイヤーのみに限定する

## 副作用

これまで a3dの「最初のcompleteイベント」で判断していたのを、「最後のcopmleteイベント」で判断する形に変更したため、completeイベントが飛んでこないケースでは固まることがありえる。

## 解決しない問題

（132同様）

cameraをwait="false"で起動し、その演出が終わらない内に違うcameraを起動する。

この場合、前のcameraのcompleteイベントで次のcameraが終了扱いされてしまう問題が残る。

このため、cameraの利用はwait=trueで利用するか、wait=falseで利用した後次のcamera演出の前に必ずwait_cameraを挟む、という制約をつける必要がある。本制約は本PRで解決せず、また文書にもない。

※本PR前の状態だとそもそもwait_cameraで待ちきれないので、この制約を守っても複数回のcamera演出の連続仕様をwait=falseで利用する事は難しい状態だったのが、本制約をつければ利用する事ができるようになった、ともいえる